### PR TITLE
Make password expiration notice translatable

### DIFF
--- a/UI/lib/ui-header.html
+++ b/UI/lib/ui-header.html
@@ -35,9 +35,21 @@
     [% FOREACH s = include_stylesheet %]
     <link href="js/css/[% s %]" rel="stylesheet">
     [% END %]
-    [% IF warn_expire %]
+    [% IF warn_expire ;
+       IF pw_expires.years ;
+          ALERT = text("Warning: Your password will expire in [_1] years", pw_expires.years);
+       ELSIF pw_expires.months ;
+          ALERT = text("Warning: Your password will expire in [_1] months", pw_expires.months);
+       ELSIF pw_expires.weeks ;
+          ALERT = text("Warning: Your password will expire in [_1] weeks", pw_expires.weeks);
+       ELSIF pw_expires.days ;
+          ALERT = text("Warning: Your password will expire in [_1] days", pw_expires.days);
+       ELSE ;
+          ALERT = text("Warning: Your password will expire today");
+       END;
+    %]
     <script>
-        window.alert("[% text('Warning:  Your password will expire in [_1]', pw_expires)%]");
+        window.alert("[% ALERT %]");
     </script>
     [% END %]
     <script>

--- a/UI/users/preferences.html
+++ b/UI/users/preferences.html
@@ -47,9 +47,22 @@
               </tr>
             [% END # if action %]
             <tr><th class="info">
+                [%
+                IF user.password_expires.years ;
+                ALERT = text("Warning: Your password will expire in [_1] years", user.password_expires.years);
+                ELSIF user.password_expires.months ;
+                ALERT = text("Warning: Your password will expire in [_1] months", user.password_expires.months);
+                ELSIF user.password_expires.weeks ;
+                ALERT = text("Warning: Your password will expire in [_1] weeks", user.password_expires.weeks);
+                ELSIF user.password_expires.days ;
+                ALERT = text("Warning: Your password will expire in [_1] days", user.password_expires.days);
+                ELSE ;
+                ALERT = text("Warning: Your password will expire today");
+                END;
+                %]
                 <!-- don't translate password_expires as it's essentially a generated string with numbers and untranslatable -->
                 <!-- tracked in issue #1699 -->
-                [% text('Your password will expire in [_1]',user.password_expires) %]
+                [% ALERT %]
               </th>
             </tr>
             <tr>

--- a/cpanfile
+++ b/cpanfile
@@ -12,6 +12,7 @@ requires 'DBD::Pg', '3.3.0';
 requires 'DBI', '1.635';
 requires 'Data::UUID';
 requires 'DateTime';
+requires 'DateTime::Format::Duration::ISO8601', '0.008';
 requires 'DateTime::Format::Strptime';
 requires 'Email::Sender::Simple';
 requires 'Email::Sender::Transport::SMTP';

--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -190,6 +190,7 @@ use strict;
 use warnings;
 
 use Carp;
+use DateTime::Format::Duration::ISO8601;
 use Encode qw(perlio_ok);
 use HTTP::Headers::Fast;
 use HTTP::Status qw( HTTP_OK ) ;
@@ -210,7 +211,7 @@ use LedgerSMB::Template::UI;
 our $VERSION = '1.9.0-dev';
 
 my $logger = Log::Log4perl->get_logger('LedgerSMB');
-
+my $expiration_parser = DateTime::Format::Duration::ISO8601->new;
 
 sub new {
     my ($class, $request) = @_;
@@ -275,7 +276,8 @@ sub initialize_with_db {
         $sth = $self->{dbh}->prepare('SELECT user__check_my_expiration()')
             or die $self->{dbh}->errstr;
         $sth->execute or die $sth->errstr;
-        ($self->{pw_expires})  = $sth->fetchrow_array;
+        my ($pw_expires) = $sth->fetchrow_array;
+        $self->{pw_expires} = $expiration_parser->parse_duration($pw_expires);
     }
 
     $self->{_company_config} =

--- a/lib/LedgerSMB/Middleware/Authenticate/Company.pm
+++ b/lib/LedgerSMB/Middleware/Authenticate/Company.pm
@@ -116,6 +116,7 @@ sub _connect {
         @{$session}{qw/ login username password company /} =
             ($login, $login, $password, $company);
     }
+    $dbh->do(q{SET intervalstyle = 'iso_8601'});
     return $dbh;
 }
 

--- a/locale/LedgerSMB.pot
+++ b/locale/LedgerSMB.pot
@@ -2,32 +2,27 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.9.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -40,12 +35,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -91,7 +82,6 @@ msgstr ""
 msgid "AP Aging"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -100,7 +90,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -115,7 +104,6 @@ msgstr ""
 msgid "AP Transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr ""
@@ -128,9 +116,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -148,7 +134,6 @@ msgstr ""
 msgid "AR Aging"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -157,7 +142,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -172,7 +156,6 @@ msgstr ""
 msgid "AR Transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr ""
@@ -185,9 +168,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -195,8 +176,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -206,16 +185,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -241,38 +215,20 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -293,23 +249,18 @@ msgstr ""
 msgid "Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -349,17 +300,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -371,7 +320,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -399,12 +348,10 @@ msgstr ""
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -427,11 +374,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -556,7 +503,6 @@ msgstr ""
 msgid "Add Service"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -622,7 +568,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -647,7 +592,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -657,12 +601,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -682,8 +625,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -735,7 +677,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -744,11 +685,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -782,14 +718,10 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -798,27 +730,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -836,14 +762,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -862,17 +788,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -881,13 +804,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -896,7 +812,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -905,14 +820,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -924,19 +837,16 @@ msgstr ""
 msgid "Apr"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -952,7 +862,6 @@ msgstr ""
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -970,19 +879,17 @@ msgstr ""
 msgid "Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -995,29 +902,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1033,7 +937,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1131,8 +1034,7 @@ msgstr ""
 msgid "Aug"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr ""
 
@@ -1144,7 +1046,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1158,7 +1059,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1171,7 +1071,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1205,8 +1104,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1221,7 +1118,6 @@ msgstr ""
 msgid "Balance Sheet"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1242,7 +1138,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1253,7 +1148,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 msgid "Base Currency"
 msgstr ""
@@ -1262,18 +1156,15 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1286,12 +1177,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1308,13 +1197,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1355,8 +1242,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1402,17 +1287,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1425,12 +1307,10 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1440,12 +1320,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1467,7 +1345,6 @@ msgstr ""
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1499,18 +1376,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1636,12 +1511,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr ""
 
@@ -1661,7 +1535,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1690,7 +1563,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1702,9 +1575,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr ""
 
@@ -1732,15 +1605,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 msgid "Closing Balance"
 msgstr ""
@@ -1753,8 +1624,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1769,22 +1638,18 @@ msgstr ""
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1796,39 +1661,31 @@ msgstr ""
 msgid "Company"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1849,7 +1706,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1867,7 +1724,6 @@ msgstr ""
 msgid "Contact"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1883,7 +1739,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1901,9 +1756,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1933,7 +1785,6 @@ msgstr ""
 msgid "Contra"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1941,10 +1792,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1975,20 +1822,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2004,26 +1847,20 @@ msgstr ""
 msgid "Could not transfer Inventory!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2035,7 +1872,6 @@ msgstr ""
 msgid "Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2048,7 +1884,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2056,11 +1892,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2088,8 +1924,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2097,17 +1931,14 @@ msgstr ""
 msgid "Credit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2132,29 +1963,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2177,18 +1998,14 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2198,11 +2015,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2217,7 +2030,6 @@ msgstr ""
 msgid "Customer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2235,9 +2047,6 @@ msgstr ""
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2257,9 +2066,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2271,7 +2078,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2295,12 +2102,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2333,28 +2139,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2401,19 +2195,14 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2435,7 +2224,6 @@ msgstr ""
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2499,8 +2287,6 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2516,10 +2302,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2529,17 +2313,14 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2549,7 +2330,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2562,47 +2342,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2615,21 +2386,14 @@ msgstr ""
 msgid "Defaults"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2647,7 +2411,6 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2660,7 +2423,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2674,37 +2436,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2726,20 +2484,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2750,46 +2505,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2900,12 +2616,10 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2918,7 +2632,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2927,7 +2640,6 @@ msgstr ""
 msgid "Discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2936,28 +2648,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2965,7 +2677,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2974,7 +2685,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -2982,12 +2693,10 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3000,12 +2709,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3014,19 +2721,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3042,10 +2746,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3064,7 +2764,7 @@ msgstr ""
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3090,7 +2790,7 @@ msgstr ""
 msgid "E-mailed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3120,7 +2820,7 @@ msgstr ""
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3264,8 +2964,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3279,7 +2977,6 @@ msgstr ""
 msgid "Employee"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3289,12 +2986,11 @@ msgstr ""
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 msgid "Employee wage screen"
 msgstr ""
@@ -3303,37 +2999,26 @@ msgstr ""
 msgid "Employees"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3357,7 +3042,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3382,12 +3066,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3397,7 +3079,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3405,7 +3087,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3430,7 +3111,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3442,14 +3123,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3463,16 +3141,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3480,7 +3157,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3493,8 +3170,6 @@ msgstr ""
 msgid "Exch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3509,7 +3184,6 @@ msgstr ""
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3518,7 +3192,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3536,13 +3209,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3620,8 +3290,7 @@ msgstr ""
 msgid "Feb"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr ""
 
@@ -3637,14 +3306,10 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3655,11 +3320,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3670,7 +3335,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3728,12 +3392,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr ""
@@ -3742,12 +3404,10 @@ msgstr ""
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3764,7 +3424,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3783,18 +3442,10 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3815,7 +3466,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3826,15 +3476,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3848,10 +3493,8 @@ msgstr ""
 msgid "GIFI"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3872,7 +3515,6 @@ msgstr ""
 msgid "GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3881,7 +3523,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3889,11 +3531,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3902,7 +3543,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3910,9 +3551,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3928,7 +3568,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3936,7 +3576,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3952,12 +3592,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3966,7 +3604,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4040,21 +3677,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4085,7 +3707,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4095,13 +3716,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4144,7 +3763,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4178,14 +3796,10 @@ msgstr ""
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4193,12 +3807,10 @@ msgstr ""
 msgid "Income"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4209,7 +3821,6 @@ msgstr ""
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4218,7 +3829,6 @@ msgstr ""
 msgid "Income statement"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4238,11 +3848,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4252,30 +3861,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4285,17 +3890,14 @@ msgstr ""
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4321,11 +3923,7 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4367,8 +3965,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4384,11 +3980,6 @@ msgstr ""
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4407,7 +3998,6 @@ msgstr ""
 msgid "Invoice Number missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4437,12 +4027,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4500,8 +4088,7 @@ msgstr ""
 msgid "Jan"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr ""
 
@@ -4530,8 +4117,7 @@ msgstr ""
 msgid "Jul"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr ""
 
@@ -4539,8 +4125,8 @@ msgstr ""
 msgid "Jun"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr ""
 
@@ -4553,10 +4139,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4578,15 +4160,12 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr ""
@@ -4607,7 +4186,6 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4618,7 +4196,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4640,40 +4217,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4685,9 +4261,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4709,9 +4283,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4725,8 +4297,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4743,7 +4313,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4780,7 +4349,6 @@ msgstr ""
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4806,7 +4374,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4824,7 +4391,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4845,7 +4411,7 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4873,45 +4439,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4933,40 +4492,34 @@ msgstr ""
 msgid "Mar"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr ""
@@ -4983,7 +4536,6 @@ msgstr ""
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr ""
@@ -4992,7 +4544,6 @@ msgstr ""
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5011,14 +4562,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5032,7 +4580,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5045,14 +4592,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5070,7 +4615,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5094,14 +4639,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5110,15 +4653,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5137,7 +4671,6 @@ msgstr ""
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5188,8 +4721,6 @@ msgstr ""
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5211,12 +4742,10 @@ msgstr ""
 msgid "Ninety"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5225,7 +4754,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5233,11 +4762,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5245,7 +4774,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5254,11 +4782,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5266,21 +4794,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5299,12 +4824,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5313,12 +4836,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5356,11 +4877,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5406,23 +4922,18 @@ msgstr ""
 msgid "Nov"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5453,7 +4964,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr ""
 
@@ -5474,13 +4985,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5489,8 +4998,7 @@ msgstr ""
 msgid "Oct"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr ""
 
@@ -5502,9 +5010,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5554,7 +5059,6 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 msgid "Opening Balance"
 msgstr ""
@@ -5575,9 +5079,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5623,7 +5124,6 @@ msgstr ""
 msgid "Order Entry"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5645,7 +5145,6 @@ msgstr ""
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5667,7 +5166,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5712,7 +5211,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5731,10 +5229,6 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5777,11 +5271,6 @@ msgstr ""
 msgid "Packing list"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5799,12 +5288,10 @@ msgstr ""
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5814,14 +5301,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5851,14 +5330,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5873,15 +5348,12 @@ msgstr ""
 msgid "Parts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5891,7 +5363,6 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5904,7 +5375,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5918,7 +5388,6 @@ msgstr ""
 msgid "Payables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5927,7 +5396,6 @@ msgstr ""
 msgid "Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5940,7 +5408,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5957,7 +5424,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 msgid "Payment batch"
 msgstr ""
@@ -5992,15 +5458,15 @@ msgstr ""
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6019,7 +5485,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6049,108 +5514,88 @@ msgstr ""
 msgid "Pick list"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6166,7 +5611,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6175,24 +5619,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6201,13 +5643,11 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6248,7 +5688,6 @@ msgstr ""
 msgid "Postscript"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6285,20 +5724,16 @@ msgstr ""
 msgid "Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6334,8 +5769,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6345,7 +5778,6 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6362,7 +5794,7 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr ""
 
@@ -6406,17 +5838,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6445,7 +5875,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6464,7 +5893,6 @@ msgstr ""
 msgid "Project Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6473,9 +5901,6 @@ msgstr ""
 msgid "Projects"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6485,7 +5910,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6503,22 +5927,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6532,14 +5950,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6570,7 +5984,6 @@ msgstr ""
 msgid "Qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6584,8 +5997,6 @@ msgstr ""
 msgid "Quarter"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6622,9 +6033,7 @@ msgstr ""
 msgid "Quotation deleted!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6645,25 +6054,20 @@ msgstr ""
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6675,7 +6079,6 @@ msgstr ""
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 msgid "Rate Type"
 msgstr ""
@@ -6696,13 +6099,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6720,7 +6119,6 @@ msgstr ""
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6734,8 +6132,7 @@ msgstr ""
 msgid "Receivables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr ""
 
@@ -6743,7 +6140,6 @@ msgstr ""
 msgid "Receive Merchandise"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6764,7 +6160,6 @@ msgstr ""
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6785,13 +6180,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6830,12 +6218,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6873,7 +6259,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6885,7 +6271,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6898,7 +6284,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6947,7 +6332,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -6967,13 +6352,10 @@ msgstr ""
 msgid "Required by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7003,7 +6385,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7012,7 +6393,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7029,7 +6409,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7079,11 +6458,11 @@ msgstr ""
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7109,7 +6488,6 @@ msgstr ""
 msgid "Sales Invoice"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7125,20 +6503,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr ""
@@ -7159,9 +6534,6 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7185,13 +6557,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7211,7 +6580,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7221,7 +6590,6 @@ msgstr ""
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7280,11 +6648,10 @@ msgstr ""
 msgid "Save as new"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7307,10 +6674,8 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr ""
 
@@ -7330,7 +6695,6 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7339,7 +6703,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7392,11 +6755,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7408,11 +6771,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7424,7 +6787,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7432,7 +6795,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7488,7 +6850,6 @@ msgstr ""
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7497,9 +6858,6 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7553,13 +6911,11 @@ msgstr ""
 msgid "Sep"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr ""
 
@@ -7580,9 +6936,6 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7611,7 +6964,6 @@ msgstr ""
 msgid "Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 msgid "Session Timeout (e.g. \"90 minutes\")"
 msgstr ""
@@ -7624,7 +6976,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7644,10 +6996,10 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr ""
 
@@ -7674,10 +7026,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7738,10 +7086,6 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7782,7 +7126,6 @@ msgstr ""
 msgid "Short"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7823,7 +7166,6 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7836,12 +7178,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7868,7 +7204,6 @@ msgstr ""
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7890,21 +7225,10 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7935,8 +7259,6 @@ msgstr ""
 msgid "Startdate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -7973,13 +7295,11 @@ msgstr ""
 msgid "Statement"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8009,7 +7329,7 @@ msgstr ""
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr ""
 
@@ -8034,7 +7354,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8077,7 +7396,6 @@ msgstr ""
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8110,12 +7428,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8127,9 +7439,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8148,8 +7457,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8160,17 +7467,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8313,7 +7617,6 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8322,7 +7625,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8375,7 +7677,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8387,7 +7689,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8438,24 +7740,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8478,14 +7777,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8529,7 +7824,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8559,19 +7853,10 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8608,7 +7893,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8633,16 +7917,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8685,7 +7960,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8693,7 +7968,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8714,7 +7988,6 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8730,14 +8003,12 @@ msgstr ""
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8776,7 +8047,6 @@ msgstr ""
 msgid "Translations saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr ""
@@ -8785,7 +8055,6 @@ msgstr ""
 msgid "Trillion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8842,10 +8111,6 @@ msgstr ""
 msgid "Two"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8880,39 +8145,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8931,43 +8190,37 @@ msgstr ""
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -8975,23 +8228,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9008,7 +8256,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9036,21 +8283,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9059,7 +8301,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9077,24 +8318,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9104,7 +8340,6 @@ msgstr ""
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9125,7 +8360,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9151,8 +8385,6 @@ msgstr ""
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9162,11 +8394,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9182,7 +8410,6 @@ msgstr ""
 msgid "Vendor"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9196,7 +8423,6 @@ msgstr ""
 msgid "Vendor Invoice"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9206,9 +8432,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9238,9 +8461,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9248,8 +8469,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 msgid "Vendor/Customer"
@@ -9263,7 +8482,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9276,7 +8494,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9299,7 +8516,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr ""
@@ -9308,11 +8524,26 @@ msgstr ""
 msgid "Warning!"
 msgstr ""
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9322,7 +8553,6 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9339,13 +8569,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr ""
@@ -9362,7 +8590,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9379,11 +8606,11 @@ msgstr ""
 msgid "Work order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9426,14 +8653,9 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
-msgstr ""
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
 msgstr ""
 
 #: t/data/04-complex_template.html:388
@@ -9461,7 +8683,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9525,17 +8747,12 @@ msgstr ""
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9552,7 +8769,7 @@ msgstr ""
 msgid "done"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9580,8 +8797,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9590,22 +8805,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9630,7 +8841,6 @@ msgstr ""
 msgid "sent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9655,8 +8865,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/ar_EG.po
+++ b/locale/po/ar_EG.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Arabic (Egypt) (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -16,27 +16,22 @@ msgstr ""
 "Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && "
 "n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -49,12 +44,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -100,7 +91,6 @@ msgstr "موردين"
 msgid "AP Aging"
 msgstr "كشف حساب موردين"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -109,7 +99,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -124,7 +113,6 @@ msgstr "ارصدة موردين متبقية"
 msgid "AP Transaction"
 msgstr "حركة حساب مورد"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "حركات حساب الموردين"
@@ -137,9 +125,7 @@ msgstr ""
 msgid "AP account"
 msgstr "حساب مورد"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -158,7 +144,6 @@ msgstr "عملاء"
 msgid "AR Aging"
 msgstr "كشوفات حسابات العملاء"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr "فاتورة مورد"
@@ -167,7 +152,6 @@ msgstr "فاتورة مورد"
 msgid "AR Invoices"
 msgstr "فواتير الموردين"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -182,7 +166,6 @@ msgstr "ارصدة عملاء "
 msgid "AR Transaction"
 msgstr "حركة حساب عميل"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "حركات حساب العملاء"
@@ -195,9 +178,7 @@ msgstr ""
 msgid "AR account"
 msgstr "حساب مورد"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -206,8 +187,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "حركة حساب عميل"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -217,16 +196,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr "الوصول ممنوع"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -252,38 +226,20 @@ msgstr "الوصول ممنوع"
 msgid "Account"
 msgstr "حساب"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr "وصف الحساب"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr "اسم الحساب"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -304,23 +260,18 @@ msgstr "اسم الحساب"
 msgid "Account Number"
 msgstr "رقم حساب"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -360,17 +311,15 @@ msgstr "الحسابات من"
 msgid "Accounts To"
 msgstr "الحسابات إلى"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr "الحسابات بدون ترويسة"
 
@@ -382,7 +331,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -410,12 +359,10 @@ msgstr "فعال"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -438,11 +385,11 @@ msgstr "إضافة حسابات"
 msgid "Add Assembly"
 msgstr "اضافة تجميع"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr "إضافة ملكية"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -567,7 +514,6 @@ msgstr "اضافة طلب بيع"
 msgid "Add Service"
 msgstr "اضافة خدمة"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -634,7 +580,6 @@ msgstr "إضافة\\تعديل الأجرة"
 msgid "Add/Update"
 msgstr "تعديل"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -659,7 +604,6 @@ msgstr "العنوان:"
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -669,12 +613,11 @@ msgstr "العناوين"
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -694,8 +637,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -748,7 +690,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -757,11 +698,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -795,14 +731,10 @@ msgstr ""
 msgid "Amount"
 msgstr "الكمية"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -811,27 +743,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "الرصيد "
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -849,14 +775,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -875,17 +801,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr "خصومات مطبقة"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr "تطبيق الخصم"
@@ -894,13 +817,6 @@ msgstr "تطبيق الخصم"
 msgid "Approval Status"
 msgstr "حالة القبول"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -909,7 +825,6 @@ msgstr "حالة القبول"
 msgid "Approve"
 msgstr "موافقة"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -918,14 +833,12 @@ msgstr "موافقة"
 msgid "Approved"
 msgstr "تمت الموافقة"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr "تمت الموافقة بواسطة"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr "تمت الموافقة في"
 
@@ -937,19 +850,16 @@ msgstr "توقيع الموافقة"
 msgid "Apr"
 msgstr "ابريل"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "ابريل"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -965,7 +875,6 @@ msgstr ""
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -984,19 +893,17 @@ msgstr ""
 msgid "Asset"
 msgstr "أصول"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr "حساب أصول"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1009,29 +916,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1047,7 +951,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1145,8 +1048,7 @@ msgstr ""
 msgid "Aug"
 msgstr "اغسطس"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "اغسطس"
 
@@ -1158,7 +1060,6 @@ msgstr ""
 msgid "Automatic"
 msgstr "أوتوماتيكي"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1172,7 +1073,6 @@ msgstr "قواعد البيانات المتوفرة"
 msgid "Available Users"
 msgstr "المستخدمين المتوفرين"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1185,7 +1085,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr "الكلفة الوسطية"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr "الكلفة الوسطية"
@@ -1219,8 +1118,6 @@ msgstr "قاعدة بيانات احتياطية"
 msgid "Backup Roles"
 msgstr "أدوار النسخ الاحتياطي"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1235,7 +1132,6 @@ msgstr "رصيد"
 msgid "Balance Sheet"
 msgstr "الميزانية"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr "الميزانية"
@@ -1256,7 +1152,6 @@ msgstr "حساب بنكي"
 msgid "Bank Account:"
 msgstr "حساب بنكي:"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1267,7 +1162,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr "باركود"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1277,18 +1171,15 @@ msgstr "عملة"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1301,12 +1192,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1323,13 +1212,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1370,8 +1257,6 @@ msgstr ""
 msgid "Billion"
 msgstr "مليار"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1417,17 +1302,14 @@ msgstr ""
 msgid "Budget"
 msgstr "ميزانية"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1440,12 +1322,10 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "الرقم الضريبى"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1455,12 +1335,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1482,7 +1360,6 @@ msgstr ""
 msgid "CC"
 msgstr "نسخة كربونية"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1514,18 +1391,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr "إلغاء الأمر"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr "إلغاء الأمر؟"
 
@@ -1651,12 +1526,11 @@ msgstr "تغيير كلمة المرور"
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "قائمة الحسابات"
 
@@ -1676,7 +1550,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "مراجعة مخزون"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1705,7 +1578,7 @@ msgstr "مدينة:"
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1717,9 +1590,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "مغلق"
 
@@ -1747,15 +1620,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "مغلق"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1770,8 +1641,6 @@ msgstr "رصيد"
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1786,22 +1655,18 @@ msgstr "كود غير موجود!"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1813,39 +1678,31 @@ msgstr ""
 msgid "Company"
 msgstr "شركة"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr "عنوان الشركة"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr "فاكس الشركة"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr "معلومات الشركة"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr "رقم ترخيص الشركة"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "اسم  الشركة"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr "تلفون الشركة"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1866,7 +1723,7 @@ msgstr "تأكيد العملية"
 msgid "Confirm!"
 msgstr "تاكيد"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr "تعارض مع بيانات موجودة، ربما أدخلت هذا من قبل؟"
 
@@ -1884,7 +1741,6 @@ msgstr "تعارض مع بيانات موجودة، ربما أدخلت هذا �
 msgid "Contact"
 msgstr "شخص الاتصال"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1900,7 +1756,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1918,9 +1773,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1950,7 +1802,6 @@ msgstr ""
 msgid "Contra"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1958,10 +1809,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1992,20 +1839,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "تكلفة"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr "تكلفة البضائع المباعة"
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr "لم نتمكن من تحميل القالب من قاعدة البيانات"
 
@@ -2021,26 +1864,20 @@ msgstr "لم نتمكن من الحفظ!"
 msgid "Could not transfer Inventory!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2052,7 +1889,6 @@ msgstr ""
 msgid "Country"
 msgstr "دولة"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr "اسم الدولة"
@@ -2065,7 +1901,7 @@ msgstr "الدولة:"
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2073,11 +1909,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr "إنشاء قاعدة البيانات؟"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2105,8 +1941,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2114,17 +1948,14 @@ msgstr ""
 msgid "Credit"
 msgstr "دائن"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2149,29 +1980,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "عملة"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2194,18 +2015,14 @@ msgstr "عملة"
 msgid "Currency"
 msgstr "عملة"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "الحالي"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2215,11 +2032,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2234,7 +2047,6 @@ msgstr ""
 msgid "Customer"
 msgstr "العميل"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2253,9 +2065,6 @@ msgstr " عميل غير موجود في الملف"
 msgid "Customer Name"
 msgstr "اسم العميل"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2275,9 +2084,7 @@ msgstr "البحث عن عميل"
 msgid "Customer missing!"
 msgstr "عميل غير موجود"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2289,7 +2096,7 @@ msgstr " عميل غير موجود في الملف"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2313,12 +2120,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2351,28 +2157,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr "قاعدة البيانات غير موجودة"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2419,19 +2213,14 @@ msgstr ""
 msgid "Date"
 msgstr "التاريخ"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr "تنسيق التاريخ"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2453,7 +2242,6 @@ msgstr ""
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2517,8 +2305,6 @@ msgstr "يوم(أيام)"
 msgid "Days"
 msgstr "أيام"
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2534,10 +2320,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2547,17 +2331,14 @@ msgstr ""
 msgid "Dec"
 msgstr "ديسمبر"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "ديسمبر"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr "المنازل العشرية للعملة"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2567,7 +2348,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2580,47 +2360,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2633,21 +2404,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "معطيات النظام"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2665,7 +2429,6 @@ msgstr ""
 msgid "Delete"
 msgstr "الغاء"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2678,7 +2441,6 @@ msgstr "حذف اللغة"
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2692,37 +2454,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "تاريخ الوصول"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2744,20 +2502,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2768,46 +2523,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2918,12 +2634,10 @@ msgstr "تفصيلى"
 msgid "Details"
 msgstr "تفاصيل"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2936,7 +2650,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2945,7 +2658,6 @@ msgstr ""
 msgid "Discount"
 msgstr "خصم"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2954,28 +2666,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2983,7 +2695,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr "مستند"
@@ -2992,7 +2703,7 @@ msgstr "مستند"
 msgid "Document Type"
 msgstr "نوع المستند"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -3000,12 +2711,10 @@ msgstr ""
 msgid "Done"
 msgstr "نفذ"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3018,12 +2727,10 @@ msgstr "د."
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3032,19 +2739,16 @@ msgstr ""
 msgid "Drafts"
 msgstr "مسودات"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "رسم"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3060,10 +2764,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3082,7 +2782,7 @@ msgstr "تاريخ الاستحقاق غير موجود"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3108,7 +2808,7 @@ msgstr "رسالة البريد الالكتروني"
 msgid "E-mailed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3138,7 +2838,7 @@ msgstr ""
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3282,8 +2982,6 @@ msgstr ""
 msgid "Email"
 msgstr "بريد الكتروني"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3297,7 +2995,6 @@ msgstr "بريد الكتروني"
 msgid "Employee"
 msgstr "الموظف"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3307,12 +3004,11 @@ msgstr ""
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3322,37 +3018,26 @@ msgstr "العاملين"
 msgid "Employees"
 msgstr "العاملين"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3376,7 +3061,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3401,12 +3085,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3416,7 +3098,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3424,7 +3106,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3450,7 +3131,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "اسم الدولة"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3462,14 +3143,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "رأس المال"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3483,16 +3161,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3500,7 +3177,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3513,8 +3190,6 @@ msgstr ""
 msgid "Exch"
 msgstr "سعر  الصرف"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3529,7 +3204,6 @@ msgstr "سعر الصرف"
 msgid "Exchange rate for payment missing!"
 msgstr "سعر الصرف للمدفوعات غير موجود"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3538,7 +3212,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "سعر الصرف غير موجود"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3556,13 +3229,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "الخصوم/الأصول"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3640,8 +3310,7 @@ msgstr ""
 msgid "Feb"
 msgstr "فبراير"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "فبراير"
 
@@ -3657,14 +3326,10 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3675,11 +3340,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3690,7 +3355,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3748,12 +3412,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "ارباح التحويل الاجنبي"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "خسائر التحويل الاجنبي"
@@ -3762,12 +3424,10 @@ msgstr "خسائر التحويل الاجنبي"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3784,7 +3444,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3803,18 +3462,10 @@ msgstr ""
 msgid "From"
 msgstr "من"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3835,7 +3486,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3846,15 +3496,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3868,10 +3513,8 @@ msgstr ""
 msgid "GIFI"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3892,7 +3535,6 @@ msgstr ""
 msgid "GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3901,7 +3543,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3909,11 +3551,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3922,7 +3563,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3930,9 +3571,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3948,7 +3588,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3956,7 +3596,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3972,12 +3612,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3986,7 +3624,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4060,21 +3697,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4105,7 +3727,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4115,13 +3736,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "صورة"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4164,7 +3783,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4198,14 +3816,10 @@ msgstr "ضع الحساب فى قائمة الخيارات ---"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4213,12 +3827,10 @@ msgstr ""
 msgid "Income"
 msgstr "الربح"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4229,7 +3841,6 @@ msgstr "قائمة الدخل"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4239,7 +3850,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "قائمة الدخل"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4259,11 +3869,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4273,30 +3882,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "ملاحظات داخلية"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4306,17 +3911,14 @@ msgstr "مخزون"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4342,11 +3944,7 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4388,8 +3986,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4405,11 +4001,6 @@ msgstr "تاريخ الفاتورة غير موجود"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4428,7 +4019,6 @@ msgstr "رقم الفاتورة"
 msgid "Invoice Number missing!"
 msgstr "رقم الفاتورة غير موجود"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4458,12 +4048,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4521,8 +4109,7 @@ msgstr ""
 msgid "Jan"
 msgstr "يناير"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "يناير"
 
@@ -4551,8 +4138,7 @@ msgstr ""
 msgid "Jul"
 msgstr "يولية"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "يولية"
 
@@ -4560,8 +4146,8 @@ msgstr "يولية"
 msgid "Jun"
 msgstr "يونية"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "يونية"
 
@@ -4574,10 +4160,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4599,15 +4181,12 @@ msgstr "تكلفة عمالة"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "اللغة"
@@ -4628,7 +4207,6 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4639,7 +4217,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4661,40 +4238,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr "مدة التسليم"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4706,9 +4282,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4730,9 +4304,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4746,8 +4318,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4764,7 +4334,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4801,7 +4370,6 @@ msgstr "قائمة اللغات"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4827,7 +4395,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4845,7 +4412,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4866,7 +4432,7 @@ msgstr ""
 msgid "Login"
 msgstr "دخول"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4894,45 +4460,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "افعل"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4954,40 +4513,34 @@ msgstr ""
 msgid "Mar"
 msgstr "مارس"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "مارس"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "نسبة الربح"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "مايو"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "ملاحظات"
@@ -5004,7 +4557,6 @@ msgstr "رسالة"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "طريقة"
@@ -5013,7 +4565,6 @@ msgstr "طريقة"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5032,14 +4583,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5053,7 +4601,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5066,14 +4613,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "موديل"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5091,7 +4636,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5115,14 +4660,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5131,15 +4674,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5158,7 +4692,6 @@ msgstr "الاسم"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5209,8 +4742,6 @@ msgstr ""
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5232,12 +4763,10 @@ msgstr ""
 msgid "Ninety"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "لا"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5246,7 +4775,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5254,11 +4783,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5266,7 +4795,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5275,11 +4803,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5287,21 +4815,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5320,12 +4845,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5334,12 +4857,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5377,11 +4898,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5427,23 +4943,18 @@ msgstr ""
 msgid "Nov"
 msgstr "نوفمبر"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "نوفمبر"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5474,7 +4985,7 @@ msgstr ""
 msgid "Number"
 msgstr "الرقم"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr ""
 
@@ -5495,13 +5006,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5510,8 +5019,7 @@ msgstr ""
 msgid "Oct"
 msgstr "اكتوبر"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "اكتوبر"
 
@@ -5523,9 +5031,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5575,7 +5080,6 @@ msgstr ""
 msgid "Open"
 msgstr "فتح"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5598,9 +5102,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5646,7 +5147,6 @@ msgstr "تاريخ الامر غير موجود"
 msgid "Order Entry"
 msgstr "ادخال الامر"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5668,7 +5168,6 @@ msgstr "الغي الامر"
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5690,7 +5189,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5736,7 +5235,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5755,10 +5253,6 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5802,11 +5296,6 @@ msgstr "رقم بوليصة الشحن غير موجود"
 msgid "Packing list"
 msgstr "قائمة تعبئة"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5824,12 +5313,10 @@ msgstr "المدفوع"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "جزء"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5839,14 +5326,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5877,14 +5356,10 @@ msgstr "تفاصيل"
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5900,15 +5375,12 @@ msgstr ""
 msgid "Parts"
 msgstr "جزء"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5918,7 +5390,6 @@ msgstr ""
 msgid "Password"
 msgstr "كلمة السر"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5931,7 +5402,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5945,7 +5415,6 @@ msgstr ""
 msgid "Payables"
 msgstr "المدفوعات"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5954,7 +5423,6 @@ msgstr "المدفوعات"
 msgid "Payment"
 msgstr "الدفع النقدى"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5967,7 +5435,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5984,7 +5451,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6020,15 +5486,15 @@ msgstr "المدفوعات"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6047,7 +5513,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6077,108 +5542,88 @@ msgstr ""
 msgid "Pick list"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6194,7 +5639,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6203,24 +5647,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6229,13 +5671,11 @@ msgstr ""
 msgid "Post"
 msgstr "تسجيل"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6276,7 +5716,6 @@ msgstr ""
 msgid "Postscript"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6313,20 +5752,16 @@ msgstr ""
 msgid "Price"
 msgstr "سعر"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6362,8 +5797,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6373,7 +5806,6 @@ msgstr ""
 msgid "Print"
 msgstr "طباعة"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6390,7 +5822,7 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "طابعة"
 
@@ -6434,17 +5866,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6473,7 +5903,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6492,7 +5921,6 @@ msgstr "ترجمة وصف المشروع"
 msgid "Project Number"
 msgstr "رقم المشروع"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6501,9 +5929,6 @@ msgstr ""
 msgid "Projects"
 msgstr "مشروعات"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6513,7 +5938,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6531,22 +5955,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "امر شراء"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "رقم أمر الشراء"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "اوامر شراء"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6561,14 +5979,10 @@ msgstr "قيمة أمر الشراء:"
 msgid "Purchase order"
 msgstr "امر شراء"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr "تم الشراء"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6599,7 +6013,6 @@ msgstr "تم الشراء"
 msgid "Qty"
 msgstr "الكمية"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr "الكمية"
@@ -6613,8 +6026,6 @@ msgstr "الكمية تتجاوز عدد الوحدات المتوفرة في ا
 msgid "Quarter"
 msgstr "ربع"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6651,9 +6062,7 @@ msgstr "رقم عرض السعر غير موجود!"
 msgid "Quotation deleted!"
 msgstr "تم حذف عرض السعر!"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6674,25 +6083,20 @@ msgstr "عرض أسعار مورد"
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "رقم  عرض السعر"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "عروض اسعار موردين"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6704,7 +6108,6 @@ msgstr "النسبة"
 msgid "Rate (%)"
 msgstr "النسبة (%)"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6727,13 +6130,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6751,7 +6150,6 @@ msgstr "الوارد"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6765,8 +6163,7 @@ msgstr "الواردات"
 msgid "Receivables"
 msgstr "المقبوضات"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "شحن وارد"
 
@@ -6774,7 +6171,6 @@ msgstr "شحن وارد"
 msgid "Receive Merchandise"
 msgstr "استلام بضاعة"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6795,7 +6191,6 @@ msgstr "تسويات"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6816,13 +6211,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6861,12 +6249,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6904,7 +6290,7 @@ msgstr ""
 msgid "Report Name"
 msgstr "اسم التقرير"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr "نتائج التقرير"
 
@@ -6916,7 +6302,7 @@ msgstr ""
 msgid "Report Type"
 msgstr "نوع التقرير"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6929,7 +6315,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6979,7 +6364,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -6999,13 +6384,10 @@ msgstr ""
 msgid "Required by"
 msgstr "مطلوب من قبل"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7035,7 +6417,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7044,7 +6425,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7061,7 +6441,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7111,11 +6490,11 @@ msgstr ""
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7141,7 +6520,6 @@ msgstr "مبيعات"
 msgid "Sales Invoice"
 msgstr "فاتورة المبيعات"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7157,20 +6535,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr "امر بيع"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "رقم أمر البيع"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "اوامر بيع"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr ""
@@ -7193,9 +6568,6 @@ msgstr "عروض اسعار للعملاء"
 msgid "Sales:"
 msgstr "المبيعات:"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7219,13 +6591,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr "السبت"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7245,7 +6614,7 @@ msgstr "السبت"
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7255,7 +6624,6 @@ msgstr "تخزين"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7314,11 +6682,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "خزن كجديد"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7341,10 +6708,8 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "الشاشة"
 
@@ -7364,7 +6729,6 @@ msgstr "الشاشة"
 msgid "Search"
 msgstr "بحث"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr "البحث عن مورد"
@@ -7373,7 +6737,6 @@ msgstr "البحث عن مورد"
 msgid "Search AP Invoices"
 msgstr "البحث عن فواتير مورد"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7426,11 +6789,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7442,11 +6805,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7458,7 +6821,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr "البحث في التقارير"
 
@@ -7466,7 +6829,6 @@ msgstr "البحث في التقارير"
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7522,7 +6884,6 @@ msgstr ""
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7531,9 +6892,6 @@ msgstr ""
 msgid "Sell"
 msgstr "بيع"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7587,13 +6945,11 @@ msgstr ""
 msgid "Sep"
 msgstr "سبتمبر"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "سبتمبر"
 
@@ -7614,9 +6970,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "رقم تسلسلي"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7646,7 +6999,6 @@ msgstr "كود الخدمة"
 msgid "Services"
 msgstr "خدمة"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 msgid "Session Timeout (e.g. \"90 minutes\")"
 msgstr ""
@@ -7659,7 +7011,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr "الإعدادات"
 
@@ -7679,10 +7031,10 @@ msgstr "سبعة عشر"
 msgid "Seventy"
 msgstr "سبعون"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "شحن صادر"
 
@@ -7709,10 +7061,6 @@ msgstr "شحن إلى"
 msgid "Ship To:"
 msgstr "شحن إلى:"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7773,10 +7121,6 @@ msgstr "تاريخ الشحن غير موجود!"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7818,7 +7162,6 @@ msgstr "تاريخ الشحن"
 msgid "Short"
 msgstr "قصير"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7859,7 +7202,6 @@ msgstr "ستون"
 msgid "Skip"
 msgstr "تجاوز"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7872,12 +7214,6 @@ msgstr "بعض"
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7904,7 +7240,6 @@ msgstr "مصدر"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7926,21 +7261,10 @@ msgstr ""
 msgid "Standard"
 msgstr "اساس"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "الاكواد الصناعية القياسية"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7971,8 +7295,6 @@ msgstr ""
 msgid "Startdate"
 msgstr "تاريخ يدء العمل"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8009,13 +7331,11 @@ msgstr ""
 msgid "Statement"
 msgstr "كشف حساب"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "رصيد كشف حساب"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8046,7 +7366,7 @@ msgstr "تجميع مخزون"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr ""
 
@@ -8071,7 +7391,6 @@ msgstr ""
 msgid "Submit"
 msgstr "تسليم"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8114,7 +7433,6 @@ msgstr "ملخص"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr "الأحد"
@@ -8147,12 +7465,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr "الإجمالي"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8164,9 +7476,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8185,8 +7494,6 @@ msgstr "حساب الضريبة"
 msgid "Tax Code"
 msgstr "كود الضريبة"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8197,17 +7504,14 @@ msgstr "ضريبة من"
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8351,7 +7655,6 @@ msgstr ""
 msgid "Template"
 msgstr "قالب الحفظ"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8360,7 +7663,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8413,7 +7715,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8425,7 +7727,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8476,24 +7778,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8516,14 +7815,10 @@ msgstr "عتبة"
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr "الخميس"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8567,7 +7862,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8597,19 +7891,10 @@ msgstr ""
 msgid "To"
 msgstr "إلى"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8646,7 +7931,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8671,16 +7955,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8723,7 +7998,7 @@ msgstr ""
 msgid "Total"
 msgstr "مجموع"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8731,7 +8006,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr "إجمالي المدفوعات"
@@ -8752,7 +8026,6 @@ msgstr "حركة"
 msgid "Transaction Approval"
 msgstr "الموافقة على الحركة"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8768,14 +8041,12 @@ msgstr "تاريخ الحركة غير موجود"
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr "نوع الحركة"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8814,7 +8085,6 @@ msgstr "ترجمات"
 msgid "Translations saved!"
 msgstr "تم حفظ الترجمات!"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "ميزان المراجعة"
@@ -8823,7 +8093,6 @@ msgstr "ميزان المراجعة"
 msgid "Trillion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr "الثلاثاء"
@@ -8880,10 +8149,6 @@ msgstr "اثنان وعشرون"
 msgid "Two"
 msgstr "اثنان"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8918,39 +8183,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8969,43 +8228,37 @@ msgstr "وحدة"
 msgid "Unit Price"
 msgstr "سعر الوحدة"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr "فك القفل"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9013,23 +8266,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9046,7 +8294,6 @@ msgstr "غير مستخدم"
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9074,21 +8321,16 @@ msgstr ""
 msgid "Upload"
 msgstr "رفع ملفات"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr "تم الرفع بواسطة"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9097,7 +8339,6 @@ msgstr ""
 msgid "Url"
 msgstr "رابط"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9115,24 +8356,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9142,7 +8378,6 @@ msgstr "مستخدم"
 msgid "User Name"
 msgstr "اسم المستخدم"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr "المستخدم موجود، هل تريد استيراده؟"
@@ -9163,7 +8398,6 @@ msgstr "اسم المستخدم"
 msgid "Users"
 msgstr "مستخدمين"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9189,8 +8423,6 @@ msgstr "سارى حتى"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9200,11 +8432,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9220,7 +8448,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "المورد"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9234,7 +8461,6 @@ msgstr "بيانات تاريخية عن مورد"
 msgid "Vendor Invoice"
 msgstr "فاتورة المورد "
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9244,9 +8470,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9276,9 +8499,7 @@ msgstr "البحث عن مورد"
 msgid "Vendor missing!"
 msgstr "مورد غير موجود"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9286,8 +8507,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "مورد غير موجود في الملف"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9302,7 +8521,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9315,7 +8533,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9338,7 +8555,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "مخازن"
@@ -9347,11 +8563,26 @@ msgstr "مخازن"
 msgid "Warning!"
 msgstr ""
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr "الأربعاء"
@@ -9361,7 +8592,6 @@ msgstr "الأربعاء"
 msgid "Week"
 msgstr "أسبوع"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr "الأسبوع يبدأ في"
@@ -9378,13 +8608,11 @@ msgstr ""
 msgid "Weeks"
 msgstr "أسابيع"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "وزن"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "وزن الوحدة"
@@ -9401,7 +8629,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9419,11 +8646,11 @@ msgstr "امر شغل"
 msgid "Work order"
 msgstr "امر شغل"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9466,15 +8693,10 @@ msgstr ""
 msgid "Years"
 msgstr "سنوات"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "نعم"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9501,7 +8723,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9565,17 +8787,12 @@ msgstr "ايام"
 msgid "debits"
 msgstr "مدين"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr "الغاء"
 
@@ -9592,7 +8809,7 @@ msgstr ""
 msgid "done"
 msgstr "نفذ"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9620,8 +8837,6 @@ msgstr "استيراد"
 msgid "in months"
 msgstr "في شهور"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9630,22 +8845,18 @@ msgstr ""
 msgid "in years"
 msgstr "في سنوات"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr "أصغر من الصفر"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr "أصغر من الكمية الواجب دفعها"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9670,7 +8881,6 @@ msgstr ""
 msgid "sent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9695,8 +8905,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr "خطأ غير متوقع!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/bg.po
+++ b/locale/po/bg.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Bulgarian (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,27 +15,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -48,12 +43,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -99,7 +90,6 @@ msgstr "Покупки"
 msgid "AP Aging"
 msgstr "Разчети с доставчици"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -108,7 +98,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -123,7 +112,6 @@ msgstr "Задължения към доставчици"
 msgid "AP Transaction"
 msgstr "Превод покупка"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Преводи покупки"
@@ -136,9 +124,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -157,7 +143,6 @@ msgstr "Продажби"
 msgid "AR Aging"
 msgstr "Разчети с клиенти"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -166,7 +151,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -181,7 +165,6 @@ msgstr "Вземания от клиенти"
 msgid "AR Transaction"
 msgstr "Превод продажба"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Преводи продажби"
@@ -194,9 +177,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -205,8 +186,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Превод продажба"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -216,16 +195,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -251,38 +225,20 @@ msgstr ""
 msgid "Account"
 msgstr "Сметка"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -303,23 +259,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Номер на сметка"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -359,17 +310,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -381,7 +330,7 @@ msgstr "Натрупване"
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -409,12 +358,10 @@ msgstr "Актив"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -437,11 +384,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr "Добави комплект"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -566,7 +513,6 @@ msgstr "Добави поръчка продажби"
 msgid "Add Service"
 msgstr "Добави услуга"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -633,7 +579,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Обнови"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -658,7 +603,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -668,12 +612,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -693,8 +636,7 @@ msgstr ""
 msgid "Aged"
 msgstr "Остарял"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -747,7 +689,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -756,11 +697,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -794,14 +730,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Сума"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -810,27 +742,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Сума за получаване"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -848,14 +774,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -874,17 +800,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -893,13 +816,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -908,7 +824,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -917,14 +832,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -936,19 +849,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Апр"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "Април"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -964,7 +874,6 @@ msgstr "Сигурен ли сте, че ще изтриете номера на
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -983,19 +892,17 @@ msgstr "Завършен комплект!"
 msgid "Asset"
 msgstr "Актив"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1008,29 +915,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1046,7 +950,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1144,8 +1047,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Авг"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Август"
 
@@ -1157,7 +1059,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1171,7 +1072,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1184,7 +1084,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr "Средно-претеглена цена"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1218,8 +1117,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1234,7 +1131,6 @@ msgstr "Баланс"
 msgid "Balance Sheet"
 msgstr "Баланс"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1255,7 +1151,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1266,7 +1161,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1276,18 +1170,15 @@ msgstr "Валута"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1300,12 +1191,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1322,13 +1211,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1369,8 +1256,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1417,17 +1302,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1440,12 +1322,10 @@ msgstr ""
 msgid "Business"
 msgstr "Направления"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Номер на направление"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1455,12 +1335,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1482,7 +1360,6 @@ msgstr "Направлението е запазено!"
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1514,18 +1391,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1653,12 +1528,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Сметкоплан"
 
@@ -1678,7 +1552,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "Провери инвентара"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1707,7 +1580,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1719,9 +1592,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "Изчистено"
 
@@ -1749,15 +1622,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Затворено"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1771,8 +1642,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1787,22 +1656,18 @@ msgstr "Липсва код!"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1814,39 +1679,31 @@ msgstr ""
 msgid "Company"
 msgstr "Фирма"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Име на фирма"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1867,7 +1724,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Съгласие!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1885,7 +1742,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Лице за контакт"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1901,7 +1757,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1919,9 +1774,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1951,7 +1803,6 @@ msgstr ""
 msgid "Contra"
 msgstr "Коректив"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1959,10 +1810,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1993,20 +1840,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Цена"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2022,26 +1865,20 @@ msgstr "Невъзможно е да се запази!"
 msgid "Could not transfer Inventory!"
 msgstr "Невъзможно е да се премести инвентара!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2053,7 +1890,6 @@ msgstr ""
 msgid "Country"
 msgstr "Държава"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2066,7 +1902,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2074,11 +1910,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2106,8 +1942,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2115,17 +1949,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Кредит"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2150,29 +1981,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Валута"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2195,18 +2016,14 @@ msgstr "Валута"
 msgid "Currency"
 msgstr "Валута"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Текущ"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2216,11 +2033,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2235,7 +2048,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Клиент"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2254,9 +2066,6 @@ msgstr "Липсва клиента в базите!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2276,9 +2085,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "Пропуснат клиент!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2290,7 +2097,7 @@ msgstr "Липсва клиента в базите!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2314,12 +2121,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2352,28 +2158,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2420,19 +2214,14 @@ msgstr ""
 msgid "Date"
 msgstr "Дата"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2454,7 +2243,6 @@ msgstr "Дата за получаване"
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2518,8 +2306,6 @@ msgstr "Ден(дни)"
 msgid "Days"
 msgstr "Дни"
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2535,10 +2321,8 @@ msgstr "Дебитно известие към фактура"
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2548,17 +2332,14 @@ msgstr ""
 msgid "Dec"
 msgstr "Дек"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Декември"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2568,7 +2349,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2581,47 +2361,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2634,21 +2405,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "По подразбиране"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2666,7 +2430,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Изтрии"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2679,7 +2442,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr "Изтрии задачата"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2693,37 +2455,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Дата на доставка"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2745,20 +2503,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2769,46 +2524,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2919,12 +2635,10 @@ msgstr "Детаилен"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2937,7 +2651,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2946,7 +2659,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Отстъпка"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2955,28 +2667,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2984,7 +2696,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2993,7 +2704,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -3001,12 +2712,10 @@ msgstr ""
 msgid "Done"
 msgstr "Готов"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3019,12 +2728,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3033,19 +2740,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Изрисуване"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3061,10 +2765,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3083,7 +2783,7 @@ msgstr "Пропусната дата за плащане"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3109,7 +2809,7 @@ msgstr "Ел.съобщение"
 msgid "E-mailed"
 msgstr "Изпратено ел.съобщение"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3139,7 +2839,7 @@ msgstr "Редакция на превод към клиент"
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3283,8 +2983,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3298,7 +2996,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Сътрудник"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3308,12 +3005,11 @@ msgstr "Сътрудник номер"
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3323,37 +3019,26 @@ msgstr "Сътрудник номер"
 msgid "Employees"
 msgstr "Сътрудници"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3377,7 +3062,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3402,12 +3086,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3417,7 +3099,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3425,7 +3107,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3451,7 +3132,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Име на фирма"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3463,14 +3144,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Капитал"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3484,16 +3162,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3501,7 +3178,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3514,8 +3191,6 @@ msgstr "Винаги"
 msgid "Exch"
 msgstr "Курс"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3530,7 +3205,6 @@ msgstr "Валутен курс"
 msgid "Exchange rate for payment missing!"
 msgstr "Валутен курс за пропуснато плащане"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3539,7 +3213,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "Пропуснат валутен курс"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3557,13 +3230,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Разход/активи"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3641,8 +3311,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Фев"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Февруари"
 
@@ -3658,14 +3327,10 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3676,11 +3341,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3691,7 +3356,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3749,12 +3413,10 @@ msgstr ""
 msgid "For"
 msgstr "За"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Печалба от курсови разлики"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Загуба от курсови разлики"
@@ -3763,12 +3425,10 @@ msgstr "Загуба от курсови разлики"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3785,7 +3445,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3804,18 +3463,10 @@ msgstr ""
 msgid "From"
 msgstr "От"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3836,7 +3487,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr "От склад"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3847,15 +3497,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3869,10 +3514,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "GIFI"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3893,7 +3536,6 @@ msgstr "GIFI е запазен!"
 msgid "GL"
 msgstr "Главна книга"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr "Номер на главната книга"
@@ -3902,7 +3544,7 @@ msgstr "Номер на главната книга"
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3910,11 +3552,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3923,7 +3564,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3931,9 +3572,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr "Създай"
 
@@ -3949,7 +3589,7 @@ msgstr "Създай поръчка"
 msgid "Generate Purchase Orders"
 msgstr "Създай поръчка за доставка"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3957,7 +3597,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr "Създай поръчките за продажбите"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3973,12 +3613,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3987,7 +3625,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4061,21 +3698,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4106,7 +3728,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4116,13 +3737,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Изображение"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4165,7 +3784,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4199,14 +3817,10 @@ msgstr "Включи в падащо меню"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4214,12 +3828,10 @@ msgstr ""
 msgid "Income"
 msgstr "Приходи"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4230,7 +3842,6 @@ msgstr "Отчет за Приходи и Разходи"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4240,7 +3851,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Отчет за Приходи и Разходи"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4260,11 +3870,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4274,30 +3883,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "Вътрешни бележки"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4307,17 +3912,14 @@ msgstr "Инвентар"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4344,11 +3946,7 @@ msgstr "Ивентара е запазен!"
 msgid "Inventory transferred!"
 msgstr "Инвентара е преместен!"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4390,8 +3988,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4407,11 +4003,6 @@ msgstr "Попусната дата на фактурата"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4430,7 +4021,6 @@ msgstr "Фактура номер"
 msgid "Invoice Number missing!"
 msgstr "Липсва номер на фактура!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4460,12 +4050,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4523,8 +4111,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Яну"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Януари"
 
@@ -4553,8 +4140,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Юли"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Юли"
 
@@ -4562,8 +4148,8 @@ msgstr "Юли"
 msgid "Jun"
 msgstr "Юни"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Юни"
 
@@ -4576,10 +4162,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "LaTeX Шаблони"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4601,15 +4183,12 @@ msgstr "Текущи разходи"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Език"
@@ -4630,7 +4209,6 @@ msgstr "Езикът не е определен!"
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4641,7 +4219,6 @@ msgstr "Последна цена"
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4663,40 +4240,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr "Основно време"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4708,9 +4284,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4732,9 +4306,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4748,8 +4320,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4766,7 +4336,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4803,7 +4372,6 @@ msgstr "Списък-езици"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4829,7 +4397,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4847,7 +4414,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4868,7 +4434,7 @@ msgstr ""
 msgid "Login"
 msgstr "Влизане"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4896,45 +4462,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Изработи"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4956,40 +4515,34 @@ msgstr ""
 msgid "Mar"
 msgstr "Мар"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Март"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Надценка"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "Май"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Бележка"
@@ -5006,7 +4559,6 @@ msgstr "Съобщение"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Метод"
@@ -5015,7 +4567,6 @@ msgstr "Метод"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5034,14 +4585,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5055,7 +4603,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5068,14 +4615,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Модел"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5093,7 +4638,7 @@ msgstr "Месеци"
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5117,14 +4662,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5133,15 +4676,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5160,7 +4694,6 @@ msgstr "Име"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5211,8 +4744,6 @@ msgstr "Следваща дата"
 msgid "Next Number"
 msgstr "Следващ номер"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5234,12 +4765,10 @@ msgstr ""
 msgid "Ninety"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Но."
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5248,7 +4777,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5256,11 +4785,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5268,7 +4797,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5277,11 +4805,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5289,21 +4817,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr "Няма отворен проект!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5322,12 +4847,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5336,12 +4859,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr "Стоки без проследяване"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5379,11 +4900,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5429,23 +4945,18 @@ msgstr "Нищо не е преведено!"
 msgid "Nov"
 msgstr "Ное"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "Ноември"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5476,7 +4987,7 @@ msgstr ""
 msgid "Number"
 msgstr "Номер"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Формат-число"
 
@@ -5497,13 +5008,11 @@ msgstr "OH"
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Остарял"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5512,8 +5021,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Окт"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Октомври"
 
@@ -5525,9 +5033,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5577,7 +5082,6 @@ msgstr ""
 msgid "Open"
 msgstr "Отворен"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5599,9 +5103,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5647,7 +5148,6 @@ msgstr "Липсва дата на поръчката!"
 msgid "Order Entry"
 msgstr "Поръчки"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5669,7 +5169,6 @@ msgstr "Поръчката е изтрита!"
 msgid "Order generation failed!"
 msgstr "Създаването на поръчка е провалено!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5691,7 +5190,7 @@ msgstr "Поръчките са създадени!"
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5737,7 +5236,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5756,10 +5254,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5803,11 +5297,6 @@ msgstr "Липсва номер на опаковъчния лист!"
 msgid "Packing list"
 msgstr "Опъковачен лист"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5825,12 +5314,10 @@ msgstr "Платено"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Позиция"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5840,14 +5327,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5877,14 +5356,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5900,15 +5375,12 @@ msgstr ""
 msgid "Parts"
 msgstr "Позиция"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5918,7 +5390,6 @@ msgstr ""
 msgid "Password"
 msgstr "Парола"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5931,7 +5402,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5945,7 +5415,6 @@ msgstr ""
 msgid "Payables"
 msgstr "Подлежащи на плащане"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5954,7 +5423,6 @@ msgstr "Подлежащи на плащане"
 msgid "Payment"
 msgstr "Разходен ордер"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5967,7 +5435,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5984,7 +5451,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6020,15 +5486,15 @@ msgstr "Плащания"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6047,7 +5513,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6078,108 +5543,88 @@ msgstr "Товарителница"
 msgid "Pick list"
 msgstr "Товарителница"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6195,7 +5640,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6204,24 +5648,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6230,13 +5672,11 @@ msgstr ""
 msgid "Post"
 msgstr "Запази"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6277,7 +5717,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Postscript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6315,20 +5754,16 @@ msgstr ""
 msgid "Price"
 msgstr "Цена"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6364,8 +5799,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6375,7 +5808,6 @@ msgstr ""
 msgid "Print"
 msgstr "Печат"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6392,7 +5824,7 @@ msgstr "Разпечатай и запази като нов"
 msgid "Printed"
 msgstr "Разпечатано"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Принтер"
 
@@ -6436,17 +5868,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6475,7 +5905,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6494,7 +5923,6 @@ msgstr "Описание на преводите към проекта"
 msgid "Project Number"
 msgstr "Номер на проекта"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6503,9 +5931,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Проекти"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6515,7 +5940,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6533,22 +5957,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Поръчка за доставка"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "Номер на Поръчка за доставка"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Поръчки за доставки"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6563,14 +5981,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Поръчка за доставка"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6601,7 +6015,6 @@ msgstr ""
 msgid "Qty"
 msgstr "К-во"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6615,8 +6028,6 @@ msgstr "Превишено е количеството в пакет!"
 msgid "Quarter"
 msgstr "Четиримесечие"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6653,9 +6064,7 @@ msgstr "Липсва номер на заданието!"
 msgid "Quotation deleted!"
 msgstr "Заданието е изтрито!"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6676,25 +6085,20 @@ msgstr "Резервация"
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "Номер на искане за заявка"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "Резервации"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "ROP"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6706,7 +6110,6 @@ msgstr "Курс"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6729,13 +6132,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6753,7 +6152,6 @@ msgstr "Приходен ордер"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6767,8 +6165,7 @@ msgstr "Постъпления"
 msgid "Receivables"
 msgstr "Подлежащи на получване"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Получи"
 
@@ -6776,7 +6173,6 @@ msgstr "Получи"
 msgid "Receive Merchandise"
 msgstr "Получаване на стока"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6797,7 +6193,6 @@ msgstr "Съгласуване"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6818,13 +6213,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Повтарящи се преводи"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6863,12 +6251,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6906,7 +6292,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6918,7 +6304,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6931,7 +6317,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6981,7 +6366,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -7001,13 +6386,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Необходим е за"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7037,7 +6419,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7046,7 +6427,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7063,7 +6443,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7113,11 +6492,11 @@ msgstr "SKU"
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7143,7 +6522,6 @@ msgstr "Продажби"
 msgid "Sales Invoice"
 msgstr "Фактура продажба"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Фактура продажби/Номер на превод от клиент"
@@ -7159,20 +6537,17 @@ msgstr "Фактура продажби/Номер на превод от кли
 msgid "Sales Order"
 msgstr "Поръчка продажба"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "Номер на поръчка продажба"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Поръчки продажби"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "Номер на поръчка продажба със запазване"
@@ -7195,9 +6570,6 @@ msgstr "Номер на поръчка продажба със запазван�
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7221,13 +6593,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7247,7 +6616,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7257,7 +6626,6 @@ msgstr "Запази"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7316,11 +6684,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "Запази като нов"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7343,10 +6710,8 @@ msgstr "Разписание"
 msgid "Scheduled"
 msgstr "Зададено разписание"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Екран"
 
@@ -7366,7 +6731,6 @@ msgstr "Екран"
 msgid "Search"
 msgstr "Търси"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7375,7 +6739,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7428,11 +6791,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7444,11 +6807,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7460,7 +6823,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7468,7 +6831,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7524,7 +6886,6 @@ msgstr "Избери txt, postscrip или PDF!"
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7533,9 +6894,6 @@ msgstr ""
 msgid "Sell"
 msgstr "Продажба"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7589,13 +6947,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Сеп"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "Септември"
 
@@ -7616,9 +6972,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "Сериен номер"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7648,7 +7001,6 @@ msgstr "Код на услуга"
 msgid "Services"
 msgstr "Услуга"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 #, fuzzy
 msgid "Session Timeout (e.g. \"90 minutes\")"
@@ -7662,7 +7014,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7682,10 +7034,10 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Доставка"
 
@@ -7712,10 +7064,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7776,10 +7124,6 @@ msgstr "Липсва дата на доставка!"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7821,7 +7165,6 @@ msgstr "Дата на доставка"
 msgid "Short"
 msgstr "Къс"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7862,7 +7205,6 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7875,12 +7217,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7907,7 +7243,6 @@ msgstr "Оригинал"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7929,21 +7264,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Стандарт"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "БДС"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7974,8 +7298,6 @@ msgstr ""
 msgid "Startdate"
 msgstr "Начална дата"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8012,13 +7334,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Ведомост"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Баланс за потвърждение"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8049,7 +7369,7 @@ msgstr "Изграждане на комплект"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Таблица със стилове"
 
@@ -8074,7 +7394,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8117,7 +7436,6 @@ msgstr "Сумарно"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8150,12 +7468,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8167,9 +7479,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8188,8 +7497,6 @@ msgstr "Сметка за данъци"
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8200,17 +7507,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8354,7 +7658,6 @@ msgstr ""
 msgid "Template"
 msgstr "HTML Шаблони"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8363,7 +7666,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8416,7 +7718,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8428,7 +7730,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8479,24 +7781,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8519,14 +7818,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8570,7 +7865,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8600,19 +7894,10 @@ msgstr ""
 msgid "To"
 msgstr "за"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8649,7 +7934,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8674,16 +7958,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8726,7 +8001,7 @@ msgstr ""
 msgid "Total"
 msgstr "Всичко"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8734,7 +8009,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8755,7 +8029,6 @@ msgstr "Превод"
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8771,14 +8044,12 @@ msgstr "Липсва дата на превода"
 msgid "Transaction Dates"
 msgstr "Дата на превод"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8817,7 +8088,6 @@ msgstr "Преводи"
 msgid "Translations saved!"
 msgstr "Превода е запазен!"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Временен баланс"
@@ -8826,7 +8096,6 @@ msgstr "Временен баланс"
 msgid "Trillion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8883,10 +8152,6 @@ msgstr ""
 msgid "Two"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8921,39 +8186,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8972,43 +8231,37 @@ msgstr "Единица"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9016,23 +8269,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9049,7 +8297,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9077,21 +8324,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9100,7 +8342,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9118,24 +8359,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9145,7 +8381,6 @@ msgstr "потребител"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9166,7 +8401,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9192,8 +8426,6 @@ msgstr "Валидно до"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9203,11 +8435,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9223,7 +8451,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Доставчик"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9237,7 +8464,6 @@ msgstr "История на доставчика"
 msgid "Vendor Invoice"
 msgstr "Фактура за доставка"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr "Фактура за доставка/номер на превода от доставчик"
@@ -9247,9 +8473,6 @@ msgstr "Фактура за доставка/номер на превода от
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9279,9 +8502,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "Липсва доставчик"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9289,8 +8510,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Липсва доствчика в базата"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9305,7 +8524,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9318,7 +8536,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9341,7 +8558,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Складове"
@@ -9350,11 +8566,26 @@ msgstr "Складове"
 msgid "Warning!"
 msgstr "Внимание!"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9364,7 +8595,6 @@ msgstr ""
 msgid "Week"
 msgstr "Седмица"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9381,13 +8611,11 @@ msgstr ""
 msgid "Weeks"
 msgstr "Седмици"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Тегло"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Мерна еденица за тежест"
@@ -9404,7 +8632,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9422,11 +8649,11 @@ msgstr "Работна поръчка"
 msgid "Work order"
 msgstr "Работна поръчка"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9469,15 +8696,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Да"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9504,7 +8726,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9568,17 +8790,12 @@ msgstr "дни"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9595,7 +8812,7 @@ msgstr ""
 msgid "done"
 msgstr "Готов"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9623,8 +8840,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9633,22 +8848,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9673,7 +8884,6 @@ msgstr ""
 msgid "sent"
 msgstr "изпрати"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9698,8 +8908,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr "Необяснима грешка!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/ca.po
+++ b/locale/po/ca.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Catalan (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -15,27 +15,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -48,12 +43,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -99,7 +90,6 @@ msgstr "Despeses"
 msgid "AP Aging"
 msgstr "Diari de Despeses"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -108,7 +98,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -123,7 +112,6 @@ msgstr ""
 msgid "AP Transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Transaccions de Despeses"
@@ -136,9 +124,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -157,7 +143,6 @@ msgstr "Ingressos"
 msgid "AR Aging"
 msgstr "Diari d'Ingressos"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -166,7 +151,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -181,7 +165,6 @@ msgstr ""
 msgid "AR Transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Transaccions d'Ingressos"
@@ -194,9 +177,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -205,8 +186,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Transaccions d'Ingressos"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -216,16 +195,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -251,38 +225,20 @@ msgstr ""
 msgid "Account"
 msgstr "Compta"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -303,23 +259,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Num. Compta"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -359,17 +310,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -381,7 +330,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -409,12 +358,10 @@ msgstr ""
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -437,11 +384,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr "Afegir Compost"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -566,7 +513,6 @@ msgstr "Afegir Pressupost"
 msgid "Add Service"
 msgstr "Afegir Servei"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -632,7 +578,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -657,7 +602,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -667,12 +611,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -692,8 +635,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -746,7 +688,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -755,11 +696,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -793,14 +729,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Total"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -809,27 +741,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -847,14 +773,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -873,17 +799,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -892,13 +815,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -907,7 +823,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -916,14 +831,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -935,19 +848,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Abr"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "Abril"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -963,7 +873,6 @@ msgstr ""
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -982,19 +891,17 @@ msgstr ""
 msgid "Asset"
 msgstr "Activat"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1007,29 +914,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1045,7 +949,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1143,8 +1046,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Ago"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Agost"
 
@@ -1156,7 +1058,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1170,7 +1071,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1183,7 +1083,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1217,8 +1116,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1233,7 +1130,6 @@ msgstr ""
 msgid "Balance Sheet"
 msgstr "Fulla de Balanç"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1254,7 +1150,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1265,7 +1160,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1275,18 +1169,15 @@ msgstr "Moneda"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1299,12 +1190,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1321,13 +1210,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1368,8 +1255,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1415,17 +1300,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1438,12 +1320,10 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Núm. Negoci"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1453,12 +1333,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1480,7 +1358,6 @@ msgstr ""
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1512,18 +1389,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1649,12 +1524,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Taula de Comptes"
 
@@ -1674,7 +1548,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1703,7 +1576,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1715,9 +1588,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr ""
 
@@ -1745,15 +1618,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Tancat"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1767,8 +1638,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1783,22 +1652,18 @@ msgstr ""
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1810,39 +1675,31 @@ msgstr ""
 msgid "Company"
 msgstr "Empresa"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1863,7 +1720,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Confirmar!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1881,7 +1738,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Contacte"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1897,7 +1753,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1915,9 +1770,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1947,7 +1799,6 @@ msgstr ""
 msgid "Contra"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1955,10 +1806,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1989,20 +1836,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2018,26 +1861,20 @@ msgstr ""
 msgid "Could not transfer Inventory!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2049,7 +1886,6 @@ msgstr ""
 msgid "Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2062,7 +1898,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2070,11 +1906,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2102,8 +1938,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2111,17 +1945,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Crèdit"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2146,29 +1977,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2191,18 +2012,14 @@ msgstr ""
 msgid "Currency"
 msgstr "Moneda"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2212,11 +2029,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2231,7 +2044,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Client"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2250,9 +2062,6 @@ msgstr "Client"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2272,9 +2081,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2286,7 +2093,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2310,12 +2117,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2348,28 +2154,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2416,19 +2210,14 @@ msgstr ""
 msgid "Date"
 msgstr "Data"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2450,7 +2239,6 @@ msgstr ""
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2514,8 +2302,6 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2531,10 +2317,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2544,17 +2328,14 @@ msgstr ""
 msgid "Dec"
 msgstr "Des"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Desembre"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2564,7 +2345,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2577,47 +2357,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2630,21 +2401,14 @@ msgstr ""
 msgid "Defaults"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2662,7 +2426,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Esborrar"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2675,7 +2438,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2689,37 +2451,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2741,20 +2499,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2765,46 +2520,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2915,12 +2631,10 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2933,7 +2647,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2942,7 +2655,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Descompte"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2951,28 +2663,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2980,7 +2692,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2989,7 +2700,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -2997,12 +2708,10 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3015,12 +2724,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3029,19 +2736,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3057,10 +2761,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3079,7 +2779,7 @@ msgstr "Falta la Data Venciment!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3105,7 +2805,7 @@ msgstr ""
 msgid "E-mailed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3135,7 +2835,7 @@ msgstr ""
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3279,8 +2979,6 @@ msgstr "once"
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3294,7 +2992,6 @@ msgstr ""
 msgid "Employee"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3304,12 +3001,11 @@ msgstr ""
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 msgid "Employee wage screen"
 msgstr ""
@@ -3318,37 +3014,26 @@ msgstr ""
 msgid "Employees"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3372,7 +3057,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3397,12 +3081,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3412,7 +3094,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3420,7 +3102,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3445,7 +3126,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3457,14 +3138,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Balanç"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3478,16 +3156,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3495,7 +3172,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3508,8 +3185,6 @@ msgstr ""
 msgid "Exch"
 msgstr "Canvi"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3524,7 +3199,6 @@ msgstr "Taxa de Canvi"
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3533,7 +3207,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3551,13 +3224,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Despesa/Activa"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3635,8 +3305,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Febrer"
 
@@ -3652,14 +3321,10 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3670,11 +3335,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3685,7 +3350,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3743,12 +3407,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Guany en Bescanvi Moneda"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Pèrdua en Bescanvi Moneda"
@@ -3757,12 +3419,10 @@ msgstr "Pèrdua en Bescanvi Moneda"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3779,7 +3439,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr "catorce"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3798,18 +3457,10 @@ msgstr ""
 msgid "From"
 msgstr "De"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3830,7 +3481,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3841,15 +3491,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3863,10 +3508,8 @@ msgstr ""
 msgid "GIFI"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3887,7 +3530,6 @@ msgstr ""
 msgid "GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3896,7 +3538,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3904,11 +3546,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3917,7 +3558,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3925,9 +3566,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3943,7 +3583,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3951,7 +3591,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3967,12 +3607,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3981,7 +3619,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4055,21 +3692,6 @@ msgstr ""
 msgid "Hundred"
 msgstr "ciento"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4100,7 +3722,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4110,13 +3731,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4159,7 +3778,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4193,14 +3811,10 @@ msgstr "Incloure en Menús Desplegables"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4208,12 +3822,10 @@ msgstr ""
 msgid "Income"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4224,7 +3836,6 @@ msgstr "Balanç Situació"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4234,7 +3845,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Balanç Situació"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4254,11 +3864,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4268,30 +3877,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4301,17 +3906,14 @@ msgstr "Inventari"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4338,11 +3940,7 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4384,8 +3982,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4401,11 +3997,6 @@ msgstr "Falta Data Fra.!"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4424,7 +4015,6 @@ msgstr "Núm Fra."
 msgid "Invoice Number missing!"
 msgstr "Falta Núm Fra.!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4454,12 +4044,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4517,8 +4105,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Gen"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Gener"
 
@@ -4547,8 +4134,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Juliol"
 
@@ -4556,8 +4142,8 @@ msgstr "Juliol"
 msgid "Jun"
 msgstr "Jun"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Juny"
 
@@ -4570,10 +4156,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "Plantilles LaTeX"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4595,15 +4177,12 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Idioma"
@@ -4624,7 +4203,6 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4635,7 +4213,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4657,40 +4234,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4702,9 +4278,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4726,9 +4300,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4742,8 +4314,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4760,7 +4330,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4797,7 +4366,6 @@ msgstr ""
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4823,7 +4391,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4841,7 +4408,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4862,7 +4428,7 @@ msgstr ""
 msgid "Login"
 msgstr "Entrar"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4890,45 +4456,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Fer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4950,40 +4509,34 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Març"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "Mai"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr ""
@@ -5000,7 +4553,6 @@ msgstr ""
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr ""
@@ -5009,7 +4561,6 @@ msgstr ""
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5028,14 +4579,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5049,7 +4597,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5062,14 +4609,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Model"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5087,7 +4632,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5111,14 +4656,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5127,15 +4670,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5154,7 +4688,6 @@ msgstr "Nom"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5205,8 +4738,6 @@ msgstr ""
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5228,12 +4759,10 @@ msgstr "diecinueve"
 msgid "Ninety"
 msgstr "noventa"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "No"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5242,7 +4771,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5250,11 +4779,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5262,7 +4791,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5271,11 +4799,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5283,21 +4811,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5316,12 +4841,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5330,12 +4853,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5373,11 +4894,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5423,23 +4939,18 @@ msgstr ""
 msgid "Nov"
 msgstr "Nov"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "Novembre"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5470,7 +4981,7 @@ msgstr ""
 msgid "Number"
 msgstr "Número"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Format Número"
 
@@ -5491,13 +5002,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Obsolet"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5506,8 +5015,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Oct"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Octubre"
 
@@ -5519,9 +5027,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5571,7 +5076,6 @@ msgstr ""
 msgid "Open"
 msgstr "Obert"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5593,9 +5097,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5641,7 +5142,6 @@ msgstr "Falta Data Ordre!"
 msgid "Order Entry"
 msgstr "Pressupostos i Comandes"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5663,7 +5163,6 @@ msgstr ""
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5685,7 +5184,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5730,7 +5229,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5749,10 +5247,6 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5796,11 +5290,6 @@ msgstr "Falta Número Albarà!"
 msgid "Packing list"
 msgstr "Albarà"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5818,12 +5307,10 @@ msgstr "Pagat"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Article"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5833,14 +5320,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5870,14 +5349,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5893,15 +5368,12 @@ msgstr ""
 msgid "Parts"
 msgstr "Article"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5911,7 +5383,6 @@ msgstr ""
 msgid "Password"
 msgstr "Contrasenya"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5924,7 +5395,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5938,7 +5408,6 @@ msgstr ""
 msgid "Payables"
 msgstr "Pagables"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5947,7 +5416,6 @@ msgstr "Pagables"
 msgid "Payment"
 msgstr "Pagament"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5960,7 +5428,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5977,7 +5444,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6013,15 +5479,15 @@ msgstr "Pagaments"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6040,7 +5506,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6070,108 +5535,88 @@ msgstr ""
 msgid "Pick list"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6187,7 +5632,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6196,24 +5640,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6222,13 +5664,11 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6269,7 +5709,6 @@ msgstr ""
 msgid "Postscript"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6307,20 +5746,16 @@ msgstr ""
 msgid "Price"
 msgstr "Preu"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6356,8 +5791,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6367,7 +5800,6 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6384,7 +5816,7 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr ""
 
@@ -6428,17 +5860,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6467,7 +5897,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6486,7 +5915,6 @@ msgstr ""
 msgid "Project Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6495,9 +5923,6 @@ msgstr ""
 msgid "Projects"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6507,7 +5932,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6525,22 +5949,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Ordre de Compra"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Ordres de Compra"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6555,14 +5973,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Ordre de Compra"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6593,7 +6007,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Quantitat"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6607,8 +6020,6 @@ msgstr ""
 msgid "Quarter"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6645,9 +6056,7 @@ msgstr ""
 msgid "Quotation deleted!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6668,25 +6077,20 @@ msgstr ""
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "ROP"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6698,7 +6102,6 @@ msgstr "Tarifa"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6721,13 +6124,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6745,7 +6144,6 @@ msgstr ""
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6759,8 +6157,7 @@ msgstr ""
 msgid "Receivables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr ""
 
@@ -6768,7 +6165,6 @@ msgstr ""
 msgid "Receive Merchandise"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6789,7 +6185,6 @@ msgstr ""
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6810,13 +6205,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6855,12 +6243,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6898,7 +6284,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6910,7 +6296,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6923,7 +6309,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6972,7 +6357,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -6992,13 +6377,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Soliciat per"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7028,7 +6410,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7037,7 +6418,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7054,7 +6434,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7104,11 +6483,11 @@ msgstr ""
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7134,7 +6513,6 @@ msgstr "Vendes"
 msgid "Sales Invoice"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7150,20 +6528,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr "Pressupost"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Pressupostos"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr ""
@@ -7185,9 +6560,6 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7211,13 +6583,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7237,7 +6606,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7247,7 +6616,6 @@ msgstr "Guardar"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7306,11 +6674,10 @@ msgstr ""
 msgid "Save as new"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7333,10 +6700,8 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Pantalla"
 
@@ -7356,7 +6721,6 @@ msgstr "Pantalla"
 msgid "Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7365,7 +6729,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7418,11 +6781,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7434,11 +6797,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7450,7 +6813,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7458,7 +6821,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7514,7 +6876,6 @@ msgstr ""
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7523,9 +6884,6 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7579,13 +6937,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Set"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "Setembre"
 
@@ -7606,9 +6962,6 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7638,7 +6991,6 @@ msgstr ""
 msgid "Services"
 msgstr "Servei"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 msgid "Session Timeout (e.g. \"90 minutes\")"
 msgstr ""
@@ -7651,7 +7003,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7671,10 +7023,10 @@ msgstr "diecisiete"
 msgid "Seventy"
 msgstr "setenta"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr ""
 
@@ -7701,10 +7053,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7765,10 +7113,6 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7809,7 +7153,6 @@ msgstr ""
 msgid "Short"
 msgstr "Curt"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7850,7 +7193,6 @@ msgstr "sesenta"
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7863,12 +7205,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7895,7 +7231,6 @@ msgstr "Font"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7917,21 +7252,10 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7962,8 +7286,6 @@ msgstr ""
 msgid "Startdate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8000,13 +7322,11 @@ msgstr ""
 msgid "Statement"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8036,7 +7356,7 @@ msgstr "Inventari Compost"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Fulla Estils"
 
@@ -8061,7 +7381,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8104,7 +7423,6 @@ msgstr ""
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8137,12 +7455,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8154,9 +7466,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8175,8 +7484,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8187,17 +7494,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8341,7 +7645,6 @@ msgstr ""
 msgid "Template"
 msgstr "Plantilles HTML"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8350,7 +7653,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8403,7 +7705,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8415,7 +7717,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8466,24 +7768,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8506,14 +7805,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8557,7 +7852,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8587,19 +7881,10 @@ msgstr ""
 msgid "To"
 msgstr "Fins"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8636,7 +7921,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8661,16 +7945,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8713,7 +7988,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8721,7 +7996,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8742,7 +8016,6 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8758,14 +8031,12 @@ msgstr "Falta Data Transacció!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8804,7 +8075,6 @@ msgstr ""
 msgid "Translations saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Balanç de Comprovació"
@@ -8813,7 +8083,6 @@ msgstr "Balanç de Comprovació"
 msgid "Trillion"
 msgstr "billón"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8870,10 +8139,6 @@ msgstr "veintidós"
 msgid "Two"
 msgstr "dos"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8908,39 +8173,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8959,43 +8218,37 @@ msgstr "Unitat"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9003,23 +8256,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9036,7 +8284,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9064,21 +8311,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9087,7 +8329,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9105,24 +8346,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9132,7 +8368,6 @@ msgstr "Usuari"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9153,7 +8388,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9179,8 +8413,6 @@ msgstr ""
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9190,11 +8422,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9210,7 +8438,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Proveïdor"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9224,7 +8451,6 @@ msgstr ""
 msgid "Vendor Invoice"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9234,9 +8460,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9266,9 +8489,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9276,8 +8497,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9292,7 +8511,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9305,7 +8523,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9328,7 +8545,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr ""
@@ -9337,11 +8553,26 @@ msgstr ""
 msgid "Warning!"
 msgstr ""
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9351,7 +8582,6 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9368,13 +8598,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Pes"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Unitat Pes"
@@ -9391,7 +8619,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9408,11 +8635,11 @@ msgstr ""
 msgid "Work order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9455,15 +8682,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Sí"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9490,7 +8712,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9554,17 +8776,12 @@ msgstr "dies"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9581,7 +8798,7 @@ msgstr ""
 msgid "done"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9609,8 +8826,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9619,22 +8834,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9659,7 +8870,6 @@ msgstr ""
 msgid "sent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9684,8 +8894,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/ckb.po
+++ b/locale/po/ckb.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Central Kurdish (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -16,27 +16,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -49,12 +44,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -100,7 +91,6 @@ msgstr ""
 msgid "AP Aging"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -109,7 +99,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -124,7 +113,6 @@ msgstr ""
 msgid "AP Transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr ""
@@ -137,9 +125,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -157,7 +143,6 @@ msgstr ""
 msgid "AR Aging"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -166,7 +151,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -181,7 +165,6 @@ msgstr ""
 msgid "AR Transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr ""
@@ -194,9 +177,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -204,8 +185,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -215,16 +194,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -250,38 +224,20 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -302,23 +258,18 @@ msgstr ""
 msgid "Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -358,17 +309,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -380,7 +329,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -408,12 +357,10 @@ msgstr ""
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -436,11 +383,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -565,7 +512,6 @@ msgstr ""
 msgid "Add Service"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -631,7 +577,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -656,7 +601,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -666,12 +610,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -691,8 +634,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -744,7 +686,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -753,11 +694,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -791,14 +727,10 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -807,27 +739,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -845,14 +771,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -871,17 +797,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -890,13 +813,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -905,7 +821,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -914,14 +829,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -933,19 +846,16 @@ msgstr ""
 msgid "Apr"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -961,7 +871,6 @@ msgstr ""
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -979,19 +888,17 @@ msgstr ""
 msgid "Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1004,29 +911,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1042,7 +946,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1140,8 +1043,7 @@ msgstr ""
 msgid "Aug"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr ""
 
@@ -1153,7 +1055,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1167,7 +1068,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1180,7 +1080,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1214,8 +1113,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1230,7 +1127,6 @@ msgstr ""
 msgid "Balance Sheet"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1251,7 +1147,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1262,7 +1157,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 msgid "Base Currency"
 msgstr ""
@@ -1271,18 +1165,15 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1295,12 +1186,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1317,13 +1206,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1364,8 +1251,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1411,17 +1296,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1434,12 +1316,10 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1449,12 +1329,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1476,7 +1354,6 @@ msgstr ""
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1508,18 +1385,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1645,12 +1520,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr ""
 
@@ -1670,7 +1544,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1699,7 +1572,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1711,9 +1584,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr ""
 
@@ -1741,15 +1614,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 msgid "Closing Balance"
 msgstr ""
@@ -1762,8 +1633,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1778,22 +1647,18 @@ msgstr ""
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1805,39 +1670,31 @@ msgstr ""
 msgid "Company"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1858,7 +1715,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1876,7 +1733,6 @@ msgstr ""
 msgid "Contact"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1892,7 +1748,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1910,9 +1765,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1942,7 +1794,6 @@ msgstr ""
 msgid "Contra"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1950,10 +1801,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1984,20 +1831,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2013,26 +1856,20 @@ msgstr ""
 msgid "Could not transfer Inventory!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2044,7 +1881,6 @@ msgstr ""
 msgid "Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2057,7 +1893,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2065,11 +1901,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2097,8 +1933,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2106,17 +1940,14 @@ msgstr ""
 msgid "Credit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2141,29 +1972,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2186,18 +2007,14 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2207,11 +2024,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2226,7 +2039,6 @@ msgstr ""
 msgid "Customer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2244,9 +2056,6 @@ msgstr ""
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2266,9 +2075,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2280,7 +2087,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2304,12 +2111,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2342,28 +2148,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2410,19 +2204,14 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2444,7 +2233,6 @@ msgstr ""
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2508,8 +2296,6 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2525,10 +2311,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2538,17 +2322,14 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2558,7 +2339,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2571,47 +2351,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2624,21 +2395,14 @@ msgstr ""
 msgid "Defaults"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2656,7 +2420,6 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2669,7 +2432,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2683,37 +2445,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2735,20 +2493,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2759,46 +2514,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2909,12 +2625,10 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2927,7 +2641,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2936,7 +2649,6 @@ msgstr ""
 msgid "Discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2945,28 +2657,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2974,7 +2686,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2983,7 +2694,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -2991,12 +2702,10 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3009,12 +2718,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3023,19 +2730,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3051,10 +2755,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3073,7 +2773,7 @@ msgstr ""
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3099,7 +2799,7 @@ msgstr ""
 msgid "E-mailed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3129,7 +2829,7 @@ msgstr ""
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3273,8 +2973,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3288,7 +2986,6 @@ msgstr ""
 msgid "Employee"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3298,12 +2995,11 @@ msgstr ""
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 msgid "Employee wage screen"
 msgstr ""
@@ -3312,37 +3008,26 @@ msgstr ""
 msgid "Employees"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3366,7 +3051,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3391,12 +3075,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3406,7 +3088,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3414,7 +3096,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3439,7 +3120,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3451,14 +3132,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3472,16 +3150,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3489,7 +3166,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3502,8 +3179,6 @@ msgstr ""
 msgid "Exch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3518,7 +3193,6 @@ msgstr ""
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3527,7 +3201,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3545,13 +3218,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3629,8 +3299,7 @@ msgstr ""
 msgid "Feb"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr ""
 
@@ -3646,14 +3315,10 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3664,11 +3329,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3679,7 +3344,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3737,12 +3401,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr ""
@@ -3751,12 +3413,10 @@ msgstr ""
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3773,7 +3433,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3792,18 +3451,10 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3824,7 +3475,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3835,15 +3485,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3857,10 +3502,8 @@ msgstr ""
 msgid "GIFI"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3881,7 +3524,6 @@ msgstr ""
 msgid "GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3890,7 +3532,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3898,11 +3540,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3911,7 +3552,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3919,9 +3560,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3937,7 +3577,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3945,7 +3585,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3961,12 +3601,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3975,7 +3613,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4049,21 +3686,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4094,7 +3716,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4104,13 +3725,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4153,7 +3772,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4187,14 +3805,10 @@ msgstr ""
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4202,12 +3816,10 @@ msgstr ""
 msgid "Income"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4218,7 +3830,6 @@ msgstr ""
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4227,7 +3838,6 @@ msgstr ""
 msgid "Income statement"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4247,11 +3857,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4261,30 +3870,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4294,17 +3899,14 @@ msgstr ""
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4330,11 +3932,7 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4376,8 +3974,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4393,11 +3989,6 @@ msgstr ""
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4416,7 +4007,6 @@ msgstr ""
 msgid "Invoice Number missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4446,12 +4036,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4509,8 +4097,7 @@ msgstr ""
 msgid "Jan"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr ""
 
@@ -4539,8 +4126,7 @@ msgstr ""
 msgid "Jul"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr ""
 
@@ -4548,8 +4134,8 @@ msgstr ""
 msgid "Jun"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr ""
 
@@ -4562,10 +4148,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4587,15 +4169,12 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr ""
@@ -4616,7 +4195,6 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4627,7 +4205,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4649,40 +4226,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4694,9 +4270,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4718,9 +4292,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4734,8 +4306,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4752,7 +4322,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4789,7 +4358,6 @@ msgstr ""
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4815,7 +4383,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4833,7 +4400,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4854,7 +4420,7 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4882,45 +4448,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4942,40 +4501,34 @@ msgstr ""
 msgid "Mar"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr ""
@@ -4992,7 +4545,6 @@ msgstr ""
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr ""
@@ -5001,7 +4553,6 @@ msgstr ""
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5020,14 +4571,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5041,7 +4589,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5054,14 +4601,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5079,7 +4624,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5103,14 +4648,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5119,15 +4662,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5146,7 +4680,6 @@ msgstr ""
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5197,8 +4730,6 @@ msgstr ""
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5220,12 +4751,10 @@ msgstr ""
 msgid "Ninety"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5234,7 +4763,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5242,11 +4771,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5254,7 +4783,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5263,11 +4791,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5275,21 +4803,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5308,12 +4833,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5322,12 +4845,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5365,11 +4886,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5415,23 +4931,18 @@ msgstr ""
 msgid "Nov"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5462,7 +4973,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr ""
 
@@ -5483,13 +4994,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5498,8 +5007,7 @@ msgstr ""
 msgid "Oct"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr ""
 
@@ -5511,9 +5019,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5563,7 +5068,6 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 msgid "Opening Balance"
 msgstr ""
@@ -5584,9 +5088,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5632,7 +5133,6 @@ msgstr ""
 msgid "Order Entry"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5654,7 +5154,6 @@ msgstr ""
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5676,7 +5175,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5721,7 +5220,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5740,10 +5238,6 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5786,11 +5280,6 @@ msgstr ""
 msgid "Packing list"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5808,12 +5297,10 @@ msgstr ""
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5823,14 +5310,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5860,14 +5339,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5882,15 +5357,12 @@ msgstr ""
 msgid "Parts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5900,7 +5372,6 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5913,7 +5384,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5927,7 +5397,6 @@ msgstr ""
 msgid "Payables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5936,7 +5405,6 @@ msgstr ""
 msgid "Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5949,7 +5417,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5966,7 +5433,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 msgid "Payment batch"
 msgstr ""
@@ -6001,15 +5467,15 @@ msgstr ""
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6028,7 +5494,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6058,108 +5523,88 @@ msgstr ""
 msgid "Pick list"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6175,7 +5620,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6184,24 +5628,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6210,13 +5652,11 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6257,7 +5697,6 @@ msgstr ""
 msgid "Postscript"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6294,20 +5733,16 @@ msgstr ""
 msgid "Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6343,8 +5778,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6354,7 +5787,6 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6371,7 +5803,7 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr ""
 
@@ -6415,17 +5847,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6454,7 +5884,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6473,7 +5902,6 @@ msgstr ""
 msgid "Project Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6482,9 +5910,6 @@ msgstr ""
 msgid "Projects"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6494,7 +5919,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6512,22 +5936,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6541,14 +5959,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6579,7 +5993,6 @@ msgstr ""
 msgid "Qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6593,8 +6006,6 @@ msgstr ""
 msgid "Quarter"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6631,9 +6042,7 @@ msgstr ""
 msgid "Quotation deleted!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6654,25 +6063,20 @@ msgstr ""
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6684,7 +6088,6 @@ msgstr ""
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 msgid "Rate Type"
 msgstr ""
@@ -6705,13 +6108,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6729,7 +6128,6 @@ msgstr ""
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6743,8 +6141,7 @@ msgstr ""
 msgid "Receivables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr ""
 
@@ -6752,7 +6149,6 @@ msgstr ""
 msgid "Receive Merchandise"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6773,7 +6169,6 @@ msgstr ""
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6794,13 +6189,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6839,12 +6227,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6882,7 +6268,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6894,7 +6280,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6907,7 +6293,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6956,7 +6341,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -6976,13 +6361,10 @@ msgstr ""
 msgid "Required by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7012,7 +6394,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7021,7 +6402,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7038,7 +6418,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7088,11 +6467,11 @@ msgstr ""
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7118,7 +6497,6 @@ msgstr ""
 msgid "Sales Invoice"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7134,20 +6512,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr ""
@@ -7168,9 +6543,6 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7194,13 +6566,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7220,7 +6589,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7230,7 +6599,6 @@ msgstr ""
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7289,11 +6657,10 @@ msgstr ""
 msgid "Save as new"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7316,10 +6683,8 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr ""
 
@@ -7339,7 +6704,6 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7348,7 +6712,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7401,11 +6764,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7417,11 +6780,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7433,7 +6796,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7441,7 +6804,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7497,7 +6859,6 @@ msgstr ""
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7506,9 +6867,6 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7562,13 +6920,11 @@ msgstr ""
 msgid "Sep"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr ""
 
@@ -7589,9 +6945,6 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7620,7 +6973,6 @@ msgstr ""
 msgid "Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 msgid "Session Timeout (e.g. \"90 minutes\")"
 msgstr ""
@@ -7633,7 +6985,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7653,10 +7005,10 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr ""
 
@@ -7683,10 +7035,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7747,10 +7095,6 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7791,7 +7135,6 @@ msgstr ""
 msgid "Short"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7832,7 +7175,6 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7845,12 +7187,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7877,7 +7213,6 @@ msgstr ""
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7899,21 +7234,10 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7944,8 +7268,6 @@ msgstr ""
 msgid "Startdate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -7982,13 +7304,11 @@ msgstr ""
 msgid "Statement"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8018,7 +7338,7 @@ msgstr ""
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr ""
 
@@ -8043,7 +7363,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8086,7 +7405,6 @@ msgstr ""
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8119,12 +7437,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8136,9 +7448,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8157,8 +7466,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8169,17 +7476,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8322,7 +7626,6 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8331,7 +7634,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8384,7 +7686,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8396,7 +7698,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8447,24 +7749,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8487,14 +7786,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8538,7 +7833,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8568,19 +7862,10 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8617,7 +7902,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8642,16 +7926,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8694,7 +7969,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8702,7 +7977,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8723,7 +7997,6 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8739,14 +8012,12 @@ msgstr ""
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8785,7 +8056,6 @@ msgstr ""
 msgid "Translations saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr ""
@@ -8794,7 +8064,6 @@ msgstr ""
 msgid "Trillion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8851,10 +8120,6 @@ msgstr ""
 msgid "Two"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8889,39 +8154,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8940,43 +8199,37 @@ msgstr ""
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -8984,23 +8237,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9017,7 +8265,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9045,21 +8292,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9068,7 +8310,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9086,24 +8327,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9113,7 +8349,6 @@ msgstr ""
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9134,7 +8369,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9160,8 +8394,6 @@ msgstr ""
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9171,11 +8403,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9191,7 +8419,6 @@ msgstr ""
 msgid "Vendor"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9205,7 +8432,6 @@ msgstr ""
 msgid "Vendor Invoice"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9215,9 +8441,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9247,9 +8470,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9257,8 +8478,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 msgid "Vendor/Customer"
@@ -9272,7 +8491,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9285,7 +8503,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9308,7 +8525,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr ""
@@ -9317,11 +8533,26 @@ msgstr ""
 msgid "Warning!"
 msgstr ""
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9331,7 +8562,6 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9348,13 +8578,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr ""
@@ -9371,7 +8599,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9388,11 +8615,11 @@ msgstr ""
 msgid "Work order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9435,14 +8662,9 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
-msgstr ""
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
 msgstr ""
 
 #: t/data/04-complex_template.html:388
@@ -9470,7 +8692,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9534,17 +8756,12 @@ msgstr ""
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9561,7 +8778,7 @@ msgstr ""
 msgid "done"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9589,8 +8806,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9599,22 +8814,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9639,7 +8850,6 @@ msgstr ""
 msgid "sent"
 msgstr "نێردرا"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9664,8 +8874,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/cs.po
+++ b/locale/po/cs.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Czech (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -16,27 +16,22 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n <= "
 "4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -49,12 +44,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -100,7 +91,6 @@ msgstr "Závazky"
 msgid "AP Aging"
 msgstr "Analýza splatnosti"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -109,7 +99,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -124,7 +113,6 @@ msgstr ""
 msgid "AP Transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Faktury přijaté"
@@ -137,9 +125,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -158,7 +144,6 @@ msgstr "Pohledávky"
 msgid "AR Aging"
 msgstr "Analýza splatnosti"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -167,7 +152,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -182,7 +166,6 @@ msgstr ""
 msgid "AR Transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Faktury vydané"
@@ -195,9 +178,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -206,8 +187,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Faktury vydané"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -217,16 +196,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -252,38 +226,20 @@ msgstr ""
 msgid "Account"
 msgstr "Účet"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -304,23 +260,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Číslo účtu"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -360,17 +311,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -382,7 +331,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -410,12 +359,10 @@ msgstr ""
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -438,11 +385,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr "Nový výrobek"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -567,7 +514,6 @@ msgstr "Nová objednávka (příjem)"
 msgid "Add Service"
 msgstr "Nový druh služby"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -633,7 +579,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -658,7 +603,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -668,12 +612,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -693,8 +636,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -747,7 +689,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -756,11 +697,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -794,14 +730,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Částka"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -810,27 +742,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -848,14 +774,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -874,17 +800,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -893,13 +816,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -908,7 +824,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -917,14 +832,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -936,19 +849,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Dub"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "Duben"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -964,7 +874,6 @@ msgstr ""
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -983,19 +892,17 @@ msgstr ""
 msgid "Asset"
 msgstr "Aktiva"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1008,29 +915,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1046,7 +950,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1144,8 +1047,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Srp"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Srpen"
 
@@ -1157,7 +1059,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1171,7 +1072,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1184,7 +1084,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1218,8 +1117,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1234,7 +1131,6 @@ msgstr ""
 msgid "Balance Sheet"
 msgstr "Rozvaha"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1255,7 +1151,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1266,7 +1161,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1276,18 +1170,15 @@ msgstr "Měna"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1300,12 +1191,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1322,13 +1211,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1369,8 +1256,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1416,17 +1301,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1439,12 +1321,10 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "IČO"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1454,12 +1334,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1481,7 +1359,6 @@ msgstr ""
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1513,18 +1390,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1650,12 +1525,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Účtový rozvrh"
 
@@ -1675,7 +1549,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1704,7 +1577,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1716,9 +1589,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr ""
 
@@ -1746,15 +1619,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Zaplaceno"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1768,8 +1639,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1784,22 +1653,18 @@ msgstr ""
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1811,39 +1676,31 @@ msgstr ""
 msgid "Company"
 msgstr "Firma"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1864,7 +1721,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Podtvrďte!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1882,7 +1739,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Kontakt"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1898,7 +1754,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1916,9 +1771,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1948,7 +1800,6 @@ msgstr ""
 msgid "Contra"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1956,10 +1807,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1990,20 +1837,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2019,26 +1862,20 @@ msgstr ""
 msgid "Could not transfer Inventory!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2050,7 +1887,6 @@ msgstr ""
 msgid "Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2063,7 +1899,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2071,11 +1907,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2103,8 +1939,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2112,17 +1946,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Dal"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2147,29 +1978,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Měna"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2192,18 +2013,14 @@ msgstr "Měna"
 msgid "Currency"
 msgstr "Měna"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2213,11 +2030,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2232,7 +2045,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Odběratel"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2251,9 +2063,6 @@ msgstr "Odběratel"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2273,9 +2082,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2287,7 +2094,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2311,12 +2118,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2349,28 +2155,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2417,19 +2211,14 @@ msgstr ""
 msgid "Date"
 msgstr "Datum"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2451,7 +2240,6 @@ msgstr ""
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2515,8 +2303,6 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2532,10 +2318,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2545,17 +2329,14 @@ msgstr ""
 msgid "Dec"
 msgstr "Pro"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Prosinec"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2565,7 +2346,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2578,47 +2358,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2631,21 +2402,14 @@ msgstr ""
 msgid "Defaults"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2663,7 +2427,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Vymazat"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2676,7 +2439,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2690,37 +2452,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2742,20 +2500,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2766,46 +2521,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2916,12 +2632,10 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2934,7 +2648,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2943,7 +2656,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Sleva"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2952,28 +2664,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2981,7 +2693,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2990,7 +2701,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -2998,12 +2709,10 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3016,12 +2725,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3030,19 +2737,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3058,10 +2762,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3080,7 +2780,7 @@ msgstr "Chybí datum splatnosti!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3106,7 +2806,7 @@ msgstr ""
 msgid "E-mailed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3136,7 +2836,7 @@ msgstr ""
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3280,8 +2980,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3295,7 +2993,6 @@ msgstr ""
 msgid "Employee"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3305,12 +3002,11 @@ msgstr ""
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 msgid "Employee wage screen"
 msgstr ""
@@ -3319,37 +3015,26 @@ msgstr ""
 msgid "Employees"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3373,7 +3058,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3398,12 +3082,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3413,7 +3095,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3421,7 +3103,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3446,7 +3127,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3458,14 +3139,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Vlastní jmění"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3479,16 +3157,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3496,7 +3173,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3509,8 +3186,6 @@ msgstr ""
 msgid "Exch"
 msgstr "Kurz"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3525,7 +3200,6 @@ msgstr "Měnový kurz"
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3534,7 +3208,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3552,13 +3225,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Náklad"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3636,8 +3306,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Úno"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Únor"
 
@@ -3653,14 +3322,10 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3671,11 +3336,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3686,7 +3351,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3744,12 +3408,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Kurzový zisk"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Kurzová ztráta"
@@ -3758,12 +3420,10 @@ msgstr "Kurzová ztráta"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3780,7 +3440,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3799,18 +3458,10 @@ msgstr ""
 msgid "From"
 msgstr "z"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3831,7 +3482,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3842,15 +3492,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3864,10 +3509,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "Účtovací řetězec"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3888,7 +3531,6 @@ msgstr ""
 msgid "GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3897,7 +3539,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3905,11 +3547,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3918,7 +3559,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3926,9 +3567,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3944,7 +3584,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3952,7 +3592,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3968,12 +3608,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3982,7 +3620,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4056,21 +3693,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4101,7 +3723,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4111,13 +3732,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4160,7 +3779,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4194,14 +3812,10 @@ msgstr "Ukazovat v drop-down menu"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4209,12 +3823,10 @@ msgstr ""
 msgid "Income"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4225,7 +3837,6 @@ msgstr "Výsledovka"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4235,7 +3846,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Výsledovka"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4255,11 +3865,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4269,30 +3878,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4302,17 +3907,14 @@ msgstr "Zásoby"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4338,11 +3940,7 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4384,8 +3982,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4401,11 +3997,6 @@ msgstr "Chybí datum vystavení!"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4424,7 +4015,6 @@ msgstr "Číslo faktury"
 msgid "Invoice Number missing!"
 msgstr "Chybí číslo faktury!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4454,12 +4044,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4517,8 +4105,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Led"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Leden"
 
@@ -4547,8 +4134,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Čec"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Červenec"
 
@@ -4556,8 +4142,8 @@ msgstr "Červenec"
 msgid "Jun"
 msgstr "Čer"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Červen"
 
@@ -4570,10 +4156,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "LaTeX šablony"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4595,15 +4177,12 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Jazyk"
@@ -4624,7 +4203,6 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4635,7 +4213,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4657,40 +4234,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4702,9 +4278,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4726,9 +4300,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4742,8 +4314,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4760,7 +4330,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4797,7 +4366,6 @@ msgstr ""
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4823,7 +4391,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4841,7 +4408,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4862,7 +4428,7 @@ msgstr ""
 msgid "Login"
 msgstr "Uživatelské jméno"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4890,45 +4456,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Výrobce"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4950,40 +4509,34 @@ msgstr ""
 msgid "Mar"
 msgstr "Bře"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Březen"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "Květen"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr ""
@@ -5000,7 +4553,6 @@ msgstr "Zpráva"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr ""
@@ -5009,7 +4561,6 @@ msgstr ""
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5028,14 +4579,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5049,7 +4597,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5062,14 +4609,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Model"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5087,7 +4632,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5111,14 +4656,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5127,15 +4670,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5154,7 +4688,6 @@ msgstr "Jméno"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5205,8 +4738,6 @@ msgstr ""
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5228,12 +4759,10 @@ msgstr ""
 msgid "Ninety"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Ne"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5242,7 +4771,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5250,11 +4779,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5262,7 +4791,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5271,11 +4799,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5283,21 +4811,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5316,12 +4841,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5330,12 +4853,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5373,11 +4894,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5423,23 +4939,18 @@ msgstr ""
 msgid "Nov"
 msgstr "Lis"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "Listopad"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5470,7 +4981,7 @@ msgstr ""
 msgid "Number"
 msgstr "Číslo"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Číselný formát"
 
@@ -5491,13 +5002,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Vyřazené"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5506,8 +5015,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Říj"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Říjen"
 
@@ -5519,9 +5027,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5571,7 +5076,6 @@ msgstr ""
 msgid "Open"
 msgstr "Otevřené"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5593,9 +5097,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5641,7 +5142,6 @@ msgstr "Chybí datum objednávky!"
 msgid "Order Entry"
 msgstr "Zadání objednávky"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5663,7 +5163,6 @@ msgstr ""
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5685,7 +5184,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5730,7 +5229,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5749,10 +5247,6 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5796,11 +5290,6 @@ msgstr "Chybí číslo dodacího listu"
 msgid "Packing list"
 msgstr "Dodací list"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5818,12 +5307,10 @@ msgstr "Zaplaceno"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Zboží"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5833,14 +5320,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5870,14 +5349,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5893,15 +5368,12 @@ msgstr ""
 msgid "Parts"
 msgstr "Zboží"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5911,7 +5383,6 @@ msgstr ""
 msgid "Password"
 msgstr "Heslo"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5924,7 +5395,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5938,7 +5408,6 @@ msgstr ""
 msgid "Payables"
 msgstr "Závazky"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5947,7 +5416,6 @@ msgstr "Závazky"
 msgid "Payment"
 msgstr "Platba"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5960,7 +5428,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5977,7 +5444,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6013,15 +5479,15 @@ msgstr "Platby"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6040,7 +5506,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6070,108 +5535,88 @@ msgstr ""
 msgid "Pick list"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6187,7 +5632,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6196,24 +5640,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6222,13 +5664,11 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6269,7 +5709,6 @@ msgstr ""
 msgid "Postscript"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6307,20 +5746,16 @@ msgstr ""
 msgid "Price"
 msgstr "Cena"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6356,8 +5791,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6367,7 +5800,6 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6384,7 +5816,7 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr ""
 
@@ -6428,17 +5860,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6467,7 +5897,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6486,7 +5915,6 @@ msgstr ""
 msgid "Project Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6495,9 +5923,6 @@ msgstr ""
 msgid "Projects"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6507,7 +5932,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6525,22 +5949,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Vystavená objednávka"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Vystavené objednávky"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6555,14 +5973,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Vystavená objednávka"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6593,7 +6007,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Množství"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6607,8 +6020,6 @@ msgstr ""
 msgid "Quarter"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6645,9 +6056,7 @@ msgstr ""
 msgid "Quotation deleted!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6668,25 +6077,20 @@ msgstr ""
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "ROP"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6698,7 +6102,6 @@ msgstr "Sazba"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6721,13 +6124,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6745,7 +6144,6 @@ msgstr ""
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6759,8 +6157,7 @@ msgstr ""
 msgid "Receivables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr ""
 
@@ -6768,7 +6165,6 @@ msgstr ""
 msgid "Receive Merchandise"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6789,7 +6185,6 @@ msgstr ""
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6810,13 +6205,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6855,12 +6243,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6898,7 +6284,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6910,7 +6296,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6923,7 +6309,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6972,7 +6357,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -6992,13 +6377,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Požadováno do"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7028,7 +6410,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7037,7 +6418,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7054,7 +6434,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7104,11 +6483,11 @@ msgstr ""
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7134,7 +6513,6 @@ msgstr "Příjmy z prodeje"
 msgid "Sales Invoice"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7150,20 +6528,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr "Přijatá objednávka"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Přijaté objednávky"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr ""
@@ -7185,9 +6560,6 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7211,13 +6583,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7237,7 +6606,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7247,7 +6616,6 @@ msgstr "Uložit"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7306,11 +6674,10 @@ msgstr ""
 msgid "Save as new"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7333,10 +6700,8 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Na obrazovku"
 
@@ -7356,7 +6721,6 @@ msgstr "Na obrazovku"
 msgid "Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7365,7 +6729,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7418,11 +6781,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7434,11 +6797,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7450,7 +6813,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7458,7 +6821,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7514,7 +6876,6 @@ msgstr ""
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7523,9 +6884,6 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7579,13 +6937,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Zář"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "Září"
 
@@ -7606,9 +6962,6 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7638,7 +6991,6 @@ msgstr ""
 msgid "Services"
 msgstr "Služba"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 msgid "Session Timeout (e.g. \"90 minutes\")"
 msgstr ""
@@ -7651,7 +7003,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7671,10 +7023,10 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr ""
 
@@ -7701,10 +7053,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7765,10 +7113,6 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7809,7 +7153,6 @@ msgstr ""
 msgid "Short"
 msgstr "Krátký výpis"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7850,7 +7193,6 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7863,12 +7205,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7895,7 +7231,6 @@ msgstr "Zdroj"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7917,21 +7252,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Standardní"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7962,8 +7286,6 @@ msgstr ""
 msgid "Startdate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8000,13 +7322,11 @@ msgstr ""
 msgid "Statement"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8036,7 +7356,7 @@ msgstr "Výrobky"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Stylesheet"
 
@@ -8061,7 +7381,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8104,7 +7423,6 @@ msgstr ""
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8137,12 +7455,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8154,9 +7466,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8175,8 +7484,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8187,17 +7494,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8341,7 +7645,6 @@ msgstr ""
 msgid "Template"
 msgstr "HTML šablony"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8350,7 +7653,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8403,7 +7705,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8415,7 +7717,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8466,24 +7768,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8506,14 +7805,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8557,7 +7852,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8587,19 +7881,10 @@ msgstr ""
 msgid "To"
 msgstr "do"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8636,7 +7921,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8661,16 +7945,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8713,7 +7988,7 @@ msgstr ""
 msgid "Total"
 msgstr "Celkem"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8721,7 +7996,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8742,7 +8016,6 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8758,14 +8031,12 @@ msgstr "Chybí datum!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8804,7 +8075,6 @@ msgstr ""
 msgid "Translations saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Obratová předvaha"
@@ -8813,7 +8083,6 @@ msgstr "Obratová předvaha"
 msgid "Trillion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8870,10 +8139,6 @@ msgstr ""
 msgid "Two"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8908,39 +8173,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8959,43 +8218,37 @@ msgstr "Jednotka"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9003,23 +8256,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9036,7 +8284,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9064,21 +8311,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9087,7 +8329,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9105,24 +8346,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9132,7 +8368,6 @@ msgstr "Uživatel"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9153,7 +8388,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9179,8 +8413,6 @@ msgstr ""
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9190,11 +8422,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9210,7 +8438,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Dodavatel"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9224,7 +8451,6 @@ msgstr ""
 msgid "Vendor Invoice"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9234,9 +8460,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9266,9 +8489,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9276,8 +8497,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9292,7 +8511,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9305,7 +8523,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9328,7 +8545,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr ""
@@ -9337,11 +8553,26 @@ msgstr ""
 msgid "Warning!"
 msgstr ""
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9351,7 +8582,6 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9368,13 +8598,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Váha"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Jednotka váhy"
@@ -9391,7 +8619,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9408,11 +8635,11 @@ msgstr ""
 msgid "Work order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9455,15 +8682,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Ano"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9490,7 +8712,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9554,17 +8776,12 @@ msgstr "dní"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9581,7 +8798,7 @@ msgstr ""
 msgid "done"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9609,8 +8826,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9619,22 +8834,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9659,7 +8870,6 @@ msgstr ""
 msgid "sent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9684,8 +8894,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/da.po
+++ b/locale/po/da.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Danish (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -16,27 +16,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr "Fakturaer"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -49,12 +44,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -104,7 +95,6 @@ msgstr "Kreditor"
 msgid "AP Aging"
 msgstr "Kreditoropfølgning"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr "Kreditorfaktura"
@@ -113,7 +103,6 @@ msgstr "Kreditorfaktura"
 msgid "AP Invoices"
 msgstr "Kreditorfakturaer"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -128,7 +117,6 @@ msgstr "Udestående (Kreditor)"
 msgid "AP Transaction"
 msgstr "Kreditorpostering"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Kreditorposteringer"
@@ -141,9 +129,7 @@ msgstr "Kreditorbilag"
 msgid "AP account"
 msgstr "Kreditorkonto"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -162,7 +148,6 @@ msgstr "Debitor"
 msgid "AR Aging"
 msgstr "Debitoropfølgning"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr "Debitorfaktura"
@@ -171,7 +156,6 @@ msgstr "Debitorfaktura"
 msgid "AR Invoices"
 msgstr "Debitorfakturaer"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -186,7 +170,6 @@ msgstr "Udestående (Debitor)"
 msgid "AR Transaction"
 msgstr "Debitorpostering"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Debitorposteringer"
@@ -199,9 +182,7 @@ msgstr "Debitorbilag"
 msgid "AR account"
 msgstr "Debitorkonto"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -210,8 +191,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Debitorpostering"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -221,16 +200,11 @@ msgstr "Debitor/Kreditor/Finans beløb"
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr "Ingen adgang"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -256,38 +230,20 @@ msgstr "Ingen adgang"
 msgid "Account"
 msgstr "Konto"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr "Kontobeskrivelse"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr "Kontoetiket"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr "Kontonavn"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -308,23 +264,18 @@ msgstr "Kontonavn"
 msgid "Account Number"
 msgstr "Kontonummer"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr "Kontotitel"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -364,17 +315,15 @@ msgstr "Konti fra"
 msgid "Accounts To"
 msgstr "Konti til"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -386,7 +335,7 @@ msgstr "Periodisering"
 msgid "Accrual Basis:"
 msgstr "Periosdisering Basis"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -414,12 +363,10 @@ msgstr "Aktiv"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr "Aktive Sessioner"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -442,11 +389,11 @@ msgstr "Tilføj konti"
 msgid "Add Assembly"
 msgstr "Nyt produkt"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr "Tilføj Aktiv"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -571,7 +518,6 @@ msgstr "Ny salgsordre"
 msgid "Add Service"
 msgstr "Ny serviceydelse"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -638,7 +584,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Opdatér"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -663,7 +608,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -673,12 +617,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -698,8 +641,7 @@ msgstr ""
 msgid "Aged"
 msgstr "Udgået"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -752,7 +694,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr "Allokeret"
@@ -761,11 +702,6 @@ msgstr "Allokeret"
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -799,14 +735,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Beløb"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -815,27 +747,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Forfaldent"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -853,14 +779,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -879,17 +805,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -898,13 +821,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -913,7 +829,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -922,14 +837,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -941,19 +854,16 @@ msgstr ""
 msgid "Apr"
 msgstr "apr"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "april"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -969,7 +879,6 @@ msgstr "Er du sikker på at du vil slette tilbudsnummer"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -988,19 +897,17 @@ msgstr "Produkter sat på lager igen!"
 msgid "Asset"
 msgstr "Aktiv"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1013,29 +920,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1051,7 +955,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1149,8 +1052,7 @@ msgstr ""
 msgid "Aug"
 msgstr "aug"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "august"
 
@@ -1162,7 +1064,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1176,7 +1077,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1189,7 +1089,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr "Gennemsnitlig kostpris"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1223,8 +1122,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1239,7 +1136,6 @@ msgstr "Balance"
 msgid "Balance Sheet"
 msgstr "Status"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1260,7 +1156,6 @@ msgstr "Bankkonto"
 msgid "Bank Account:"
 msgstr "Bankkonto:"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1271,7 +1166,6 @@ msgstr "Bankkonti"
 msgid "Bar Code"
 msgstr "Stregkode"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1281,18 +1175,15 @@ msgstr "Valuta"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1305,12 +1196,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1327,13 +1216,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1374,8 +1261,6 @@ msgstr "Fakturerings-e-mail"
 msgid "Billion"
 msgstr "Milliard"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1422,17 +1307,14 @@ msgstr ""
 msgid "Budget"
 msgstr "Budget"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr "Budgetnummer"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1445,12 +1327,10 @@ msgstr "Budgetter"
 msgid "Business"
 msgstr "Forretning"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Forretningsnummer"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1460,12 +1340,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1487,7 +1365,6 @@ msgstr "Forretning gemt!"
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1519,18 +1396,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr "Annulér"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr "Annulér?"
 
@@ -1656,12 +1531,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr "Fakturerbar"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Kontoplan"
 
@@ -1681,7 +1555,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "Kontrollér lagerbeholdning"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1710,7 +1583,7 @@ msgstr "By:"
 msgid "Class"
 msgstr "Klasse"
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1722,9 +1595,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "Udlignet"
 
@@ -1752,15 +1625,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Afsluttet"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1774,8 +1645,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1790,22 +1659,18 @@ msgstr "Kode mangler!"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1817,39 +1682,31 @@ msgstr ""
 msgid "Company"
 msgstr "Firma"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Firmanavn"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1870,7 +1727,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Bekræft!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1888,7 +1745,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Kontakt"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1904,7 +1760,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1922,9 +1777,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1954,7 +1806,6 @@ msgstr ""
 msgid "Contra"
 msgstr "Kontra"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1962,10 +1813,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1996,20 +1843,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Udgifter"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2025,26 +1868,20 @@ msgstr "Kunne ikke gemme!"
 msgid "Could not transfer Inventory!"
 msgstr "Kunne ikke overføre lagerbeholdning!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2056,7 +1893,6 @@ msgstr ""
 msgid "Country"
 msgstr "Land"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2069,7 +1905,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2077,11 +1913,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2109,8 +1945,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2118,17 +1952,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Kredit"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr "Kreditkonto"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr "Kreditkontonummer"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr "Kreditkonti"
@@ -2153,29 +1984,19 @@ msgstr "Kreditgrænse"
 msgid "Credit Note"
 msgstr "Kreditnota"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr "Kredit"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Val"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2198,18 +2019,14 @@ msgstr "Val"
 msgid "Currency"
 msgstr "Valuta"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Aktuel"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2219,11 +2036,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2238,7 +2051,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Kunde"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2257,9 +2069,6 @@ msgstr "Kunde ikke i databasen!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2279,9 +2088,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "Kunde mangler!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2293,7 +2100,7 @@ msgstr "Kunde ikke i databasen!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2317,12 +2124,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2355,28 +2161,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2423,19 +2217,14 @@ msgstr ""
 msgid "Date"
 msgstr "Dato"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2457,7 +2246,6 @@ msgstr "Modtagelsesdato"
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2521,8 +2309,6 @@ msgstr "Dag(e)"
 msgid "Days"
 msgstr "Dage"
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2538,10 +2324,8 @@ msgstr "Debitor faktura"
 msgid "Debit Note"
 msgstr "Debitnota"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2551,17 +2335,14 @@ msgstr "Debit"
 msgid "Dec"
 msgstr "dec"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "december"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2571,7 +2352,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2584,47 +2364,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2637,21 +2408,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "Standardopsætning"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2669,7 +2433,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Fjern"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2682,7 +2445,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr "Slet planlægning"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2696,37 +2458,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Leveringsdato"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2748,20 +2506,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2772,46 +2527,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2922,12 +2638,10 @@ msgstr "Detalje"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2940,7 +2654,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2949,7 +2662,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Rabat"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2958,28 +2670,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2987,7 +2699,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2996,7 +2707,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -3004,12 +2715,10 @@ msgstr ""
 msgid "Done"
 msgstr "Færdig"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3022,12 +2731,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3036,19 +2743,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Træk"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3064,10 +2768,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3086,7 +2786,7 @@ msgstr "Forfaldsdato mangler!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3112,7 +2812,7 @@ msgstr "E-post besked"
 msgid "E-mailed"
 msgstr "Sendt som e-post"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3142,7 +2842,7 @@ msgstr "Redigér debitorpostering"
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3286,8 +2986,6 @@ msgstr "Elleve"
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3301,7 +2999,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Medarbejder"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3311,12 +3008,11 @@ msgstr "Medarbejdernummer"
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3326,37 +3022,26 @@ msgstr "Medarbejdernummer"
 msgid "Employees"
 msgstr "Medarbejdere"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3380,7 +3065,6 @@ msgstr "Slutdato:"
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3405,12 +3089,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3420,7 +3102,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3428,7 +3110,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3454,7 +3135,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Firmanavn"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3466,14 +3147,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Egenkapital"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3487,16 +3165,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3504,7 +3181,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3517,8 +3194,6 @@ msgstr "Hver"
 msgid "Exch"
 msgstr "Vxl"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3533,7 +3208,6 @@ msgstr "Vekselkurs"
 msgid "Exchange rate for payment missing!"
 msgstr "Valutakurs for betaling mangler!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3542,7 +3216,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "Vekselkurs mangler!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr "Forventet"
@@ -3560,13 +3233,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Udgift/Aktiv"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3644,8 +3314,7 @@ msgstr ""
 msgid "Feb"
 msgstr "feb"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "februar"
 
@@ -3661,14 +3330,10 @@ msgstr "Halvtreds"
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3679,11 +3344,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3694,7 +3359,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3752,12 +3416,10 @@ msgstr ""
 msgid "For"
 msgstr "Gentag"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Gevinst på valutahandel"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Tab på valutahandel"
@@ -3766,12 +3428,10 @@ msgstr "Tab på valutahandel"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3788,7 +3448,6 @@ msgstr "Fire"
 msgid "Fourteen"
 msgstr "Fjorten"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3807,18 +3466,10 @@ msgstr ""
 msgid "From"
 msgstr "Fra"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3839,7 +3490,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr "Fra lager"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3850,15 +3500,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3872,10 +3517,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "GIFI"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3896,7 +3539,6 @@ msgstr "GIFI gemt!"
 msgid "GL"
 msgstr "Hovedbog"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr "Hovedbog referencenummer"
@@ -3905,7 +3547,7 @@ msgstr "Hovedbog referencenummer"
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3913,11 +3555,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3926,7 +3567,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3934,9 +3575,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr "Generer"
 
@@ -3952,7 +3592,7 @@ msgstr "Generer ordrer"
 msgid "Generate Purchase Orders"
 msgstr "Generer indkøbsordrer"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3960,7 +3600,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr "Generer salgsordrer"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3976,12 +3616,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3990,7 +3628,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4064,21 +3701,6 @@ msgstr ""
 msgid "Hundred"
 msgstr "Hundrede"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4109,7 +3731,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4119,13 +3740,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Billede"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4168,7 +3787,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4202,14 +3820,10 @@ msgstr "Inkludér i rullegardin-menuer"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4217,12 +3831,10 @@ msgstr ""
 msgid "Income"
 msgstr "Indtægt"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4233,7 +3845,6 @@ msgstr "Driftsregnskab"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4243,7 +3854,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Driftsregnskab"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4263,11 +3873,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4277,30 +3886,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "Interne noter"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4310,17 +3915,14 @@ msgstr "Lagerbeholdning"
 msgid "Inventory Activity"
 msgstr "Ændring i lagerbeholdning"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4346,11 +3948,7 @@ msgstr "Lagerbeholdning gemt!"
 msgid "Inventory transferred!"
 msgstr "Lagerbeholdning overført!"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4392,8 +3990,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4409,11 +4005,6 @@ msgstr "Fakturadato mangler!"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4432,7 +4023,6 @@ msgstr "Fakturanummer"
 msgid "Invoice Number missing!"
 msgstr "Fakturanummer mangler!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4462,12 +4052,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4525,8 +4113,7 @@ msgstr ""
 msgid "Jan"
 msgstr "jan"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "januar"
 
@@ -4555,8 +4142,7 @@ msgstr ""
 msgid "Jul"
 msgstr "jul"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "juli"
 
@@ -4564,8 +4150,8 @@ msgstr "juli"
 msgid "Jun"
 msgstr "jun"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "juni"
 
@@ -4578,10 +4164,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "LaTeX-skabeloner"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4603,15 +4185,12 @@ msgstr "Tidsregistrering"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Sprog"
@@ -4632,7 +4211,6 @@ msgstr "Sprog ikke definerede!"
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4643,7 +4221,6 @@ msgstr "Sidste kostpris"
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4665,40 +4242,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr "Leveringstid"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4710,9 +4286,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4734,9 +4308,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4750,8 +4322,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4768,7 +4338,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4805,7 +4374,6 @@ msgstr "Vis sprog"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4831,7 +4399,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4849,7 +4416,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4870,7 +4436,7 @@ msgstr ""
 msgid "Login"
 msgstr "Log på"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4898,45 +4464,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Fabrikat"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4958,40 +4517,34 @@ msgstr ""
 msgid "Mar"
 msgstr "mar"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "marts"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Bruttofortjeneste"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "maj"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Note"
@@ -5008,7 +4561,6 @@ msgstr "Besked"
 msgid "Message: "
 msgstr "Besked: "
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Metode"
@@ -5017,7 +4569,6 @@ msgstr "Metode"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5036,14 +4587,11 @@ msgstr ""
 msgid "Million"
 msgstr "Million"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5057,7 +4605,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5070,14 +4617,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Model"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5095,7 +4640,7 @@ msgstr "Måned(er)"
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5119,14 +4664,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5135,15 +4678,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5162,7 +4696,6 @@ msgstr "Navn"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5213,8 +4746,6 @@ msgstr "Næste dato"
 msgid "Next Number"
 msgstr "Næste nummer"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5236,12 +4767,10 @@ msgstr "Nitten"
 msgid "Ninety"
 msgstr "Halvfems"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Nej"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5250,7 +4779,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5258,11 +4787,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5270,7 +4799,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5279,11 +4807,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5291,21 +4819,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr "Ingen åbne projekter!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5324,12 +4849,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5338,12 +4861,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5381,11 +4902,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5431,23 +4947,18 @@ msgstr "Intet at overføre!"
 msgid "Nov"
 msgstr "nov"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "november"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5478,7 +4989,7 @@ msgstr ""
 msgid "Number"
 msgstr "Nummer"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Numerisk format"
 
@@ -5499,13 +5010,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Forældet"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5514,8 +5023,7 @@ msgstr ""
 msgid "Oct"
 msgstr "okt"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "oktober"
 
@@ -5527,9 +5035,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5579,7 +5084,6 @@ msgstr ""
 msgid "Open"
 msgstr "Åbn"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5601,9 +5105,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5649,7 +5150,6 @@ msgstr "Ordredato mangler"
 msgid "Order Entry"
 msgstr "Ordreindgang"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5671,7 +5171,6 @@ msgstr "Ordre slettet"
 msgid "Order generation failed!"
 msgstr "Ordregenerering fejlet!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5693,7 +5192,7 @@ msgstr "Ordrer genereret!"
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5739,7 +5238,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5758,10 +5256,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5805,11 +5299,6 @@ msgstr "Nummer for pakkeliste mangler!"
 msgid "Packing list"
 msgstr "Følgeseddel"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5827,12 +5316,10 @@ msgstr "Betalt"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Vare"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5842,14 +5329,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5879,14 +5358,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5902,15 +5377,12 @@ msgstr ""
 msgid "Parts"
 msgstr "Vare"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5920,7 +5392,6 @@ msgstr ""
 msgid "Password"
 msgstr "Adgangskode"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5933,7 +5404,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5947,7 +5417,6 @@ msgstr ""
 msgid "Payables"
 msgstr "Udeståender"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5956,7 +5425,6 @@ msgstr "Udeståender"
 msgid "Payment"
 msgstr "Betaling"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5969,7 +5437,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5986,7 +5453,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6022,15 +5488,15 @@ msgstr "Betalinger"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6049,7 +5515,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6080,108 +5545,88 @@ msgstr "Pakkeliste"
 msgid "Pick list"
 msgstr "Pakkeliste"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6197,7 +5642,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6206,24 +5650,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6232,13 +5674,11 @@ msgstr ""
 msgid "Post"
 msgstr "Bogfør"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6279,7 +5719,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Postscript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6317,20 +5756,16 @@ msgstr ""
 msgid "Price"
 msgstr "Pris"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6366,8 +5801,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6377,7 +5810,6 @@ msgstr ""
 msgid "Print"
 msgstr "Udskriv"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6394,7 +5826,7 @@ msgstr "Udskriv og gem som ny"
 msgid "Printed"
 msgstr "Udskrevet"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Printer"
 
@@ -6438,17 +5870,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6477,7 +5907,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6496,7 +5925,6 @@ msgstr "Oversættelser af projektbeskrivelse"
 msgid "Project Number"
 msgstr "Projektnummer"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6505,9 +5933,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Projekter"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6517,7 +5942,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6535,22 +5959,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Indkøbsordre"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "Nummer på indkøbsordre"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Indkøbsordrer"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6565,14 +5983,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Indkøbsordre"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6603,7 +6017,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Mængde"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6617,8 +6030,6 @@ msgstr "Mængde overstiger tilgængeligt antal på lager!"
 msgid "Quarter"
 msgstr "Kvartal"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6655,9 +6066,7 @@ msgstr "Tilbudsnummer mangler!"
 msgid "Quotation deleted!"
 msgstr "Tilbud slettet!"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6678,25 +6087,20 @@ msgstr "Tilbudsønske"
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "Nummer for tilbudsønske"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "Tilbudsønsker"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "Genbestil ved"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6708,7 +6112,6 @@ msgstr "Sats"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6731,13 +6134,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6755,7 +6154,6 @@ msgstr "Kvittering"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6769,8 +6167,7 @@ msgstr "Kvitteringer"
 msgid "Receivables"
 msgstr "Indbetalinger"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Modtagelse"
 
@@ -6778,7 +6175,6 @@ msgstr "Modtagelse"
 msgid "Receive Merchandise"
 msgstr "Modtag varer"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr "Modtaget"
@@ -6799,7 +6195,6 @@ msgstr "Afstemning"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6820,13 +6215,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Gentagne transaktioner"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6865,12 +6253,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6908,7 +6294,7 @@ msgstr ""
 msgid "Report Name"
 msgstr "Rapportnavn"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6920,7 +6306,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6933,7 +6319,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6983,7 +6368,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -7003,13 +6388,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Bestilt af"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7039,7 +6421,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7048,7 +6429,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7065,7 +6445,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7115,11 +6494,11 @@ msgstr "Varenummer"
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7145,7 +6524,6 @@ msgstr "Salg"
 msgid "Sales Invoice"
 msgstr "Salgsfaktura"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Salgsfaktura/debitorposteringnummer"
@@ -7161,20 +6539,17 @@ msgstr "Salgsfaktura/debitorposteringnummer"
 msgid "Sales Order"
 msgstr "Salgsordre"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "Salgsordrenummer"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Salgsordrer"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "Salgstilbudsnummer"
@@ -7197,9 +6572,6 @@ msgstr "Salgstilbudsnummer"
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7223,13 +6595,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7249,7 +6618,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7259,7 +6628,6 @@ msgstr "Gem"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7318,11 +6686,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "Gem som ny"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7345,10 +6712,8 @@ msgstr "Planlæg"
 msgid "Scheduled"
 msgstr "Planlagt"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Skærm"
 
@@ -7368,7 +6733,6 @@ msgstr "Skærm"
 msgid "Search"
 msgstr "Søg"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7377,7 +6741,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7430,11 +6793,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7446,11 +6809,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7462,7 +6825,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7470,7 +6833,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7526,7 +6888,6 @@ msgstr "Vælg txt, postscript eller PDF"
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7535,9 +6896,6 @@ msgstr ""
 msgid "Sell"
 msgstr "Sælg"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7591,13 +6949,11 @@ msgstr ""
 msgid "Sep"
 msgstr "sep"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "september"
 
@@ -7618,9 +6974,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "Serienummer"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7650,7 +7003,6 @@ msgstr "Serviceydelsesnummer"
 msgid "Services"
 msgstr "Serviceydelse"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 #, fuzzy
 msgid "Session Timeout (e.g. \"90 minutes\")"
@@ -7664,7 +7016,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7684,10 +7036,10 @@ msgstr "Sytten"
 msgid "Seventy"
 msgstr "Halvfjerds"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Afsend"
 
@@ -7714,10 +7066,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7778,10 +7126,6 @@ msgstr "Afsendelsesdato mangler!"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7823,7 +7167,6 @@ msgstr "Afsendelsesdato"
 msgid "Short"
 msgstr "Kort"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr "Vis kreditgrænse"
@@ -7864,7 +7207,6 @@ msgstr "Tres"
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr "Solgt"
@@ -7877,12 +7219,6 @@ msgstr ""
 msgid "Sort by"
 msgstr "Sortér efter"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7909,7 +7245,6 @@ msgstr "Bilag"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7931,21 +7266,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Standard"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "Standard industrikoder (SIC)"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7976,8 +7300,6 @@ msgstr ""
 msgid "Startdate"
 msgstr "Startdato"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8014,13 +7336,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Opgørelse"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Balanceopgørelse"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8051,7 +7371,7 @@ msgstr "Sæt produkt på lager"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Stylesheet"
 
@@ -8076,7 +7396,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8119,7 +7438,6 @@ msgstr "Oversigt"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8152,12 +7470,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8169,9 +7481,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8190,8 +7499,6 @@ msgstr "Moms/afgiftkonti"
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8202,17 +7509,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8356,7 +7660,6 @@ msgstr ""
 msgid "Template"
 msgstr "HTML-skabeloner"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8365,7 +7668,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8418,7 +7720,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8430,7 +7732,7 @@ msgstr "Deres kredit"
 msgid "Their Debits"
 msgstr "Deres debit"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8481,24 +7783,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8521,14 +7820,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8572,7 +7867,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8602,19 +7896,10 @@ msgstr ""
 msgid "To"
 msgstr "til"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8651,7 +7936,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8676,16 +7960,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8728,7 +8003,7 @@ msgstr ""
 msgid "Total"
 msgstr "I alt"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8736,7 +8011,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8757,7 +8031,6 @@ msgstr "Postering"
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8773,14 +8046,12 @@ msgstr "Posteringsdato mangler!"
 msgid "Transaction Dates"
 msgstr "Posteringsdato"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8819,7 +8090,6 @@ msgstr "Oversættelser"
 msgid "Translations saved!"
 msgstr "Oversættelser gemt!"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Foreløbig status"
@@ -8828,7 +8098,6 @@ msgstr "Foreløbig status"
 msgid "Trillion"
 msgstr "Billion"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8885,10 +8154,6 @@ msgstr "Toogtyve"
 msgid "Two"
 msgstr "To"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8923,39 +8188,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8974,43 +8233,37 @@ msgstr "Enhed"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9018,23 +8271,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9051,7 +8299,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9079,21 +8326,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9102,7 +8344,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9120,24 +8361,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9147,7 +8383,6 @@ msgstr "Bruger"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9168,7 +8403,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9194,8 +8428,6 @@ msgstr "Gyldig til"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9205,11 +8437,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9225,7 +8453,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Leverandør"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9239,7 +8466,6 @@ msgstr "Leverandørhistorik"
 msgid "Vendor Invoice"
 msgstr "Leverandørfaktura"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr "Leverandørfaktura/kreditorposteringnummer"
@@ -9249,9 +8475,6 @@ msgstr "Leverandørfaktura/kreditorposteringnummer"
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9281,9 +8504,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "Leverandør mangler!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9291,8 +8512,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Leverandør ikke i databasen!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9307,7 +8526,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9320,7 +8538,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9343,7 +8560,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Lagre"
@@ -9352,11 +8568,26 @@ msgstr "Lagre"
 msgid "Warning!"
 msgstr "Advarsel!"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9366,7 +8597,6 @@ msgstr ""
 msgid "Week"
 msgstr "Uge"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9383,13 +8613,11 @@ msgstr ""
 msgid "Weeks"
 msgstr "Uger"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Vægt"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Vægtenhed"
@@ -9406,7 +8634,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9424,11 +8651,11 @@ msgstr "Arbejdsseddel"
 msgid "Work order"
 msgstr "Arbejdsseddel"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9471,15 +8698,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Ja"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9506,7 +8728,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9570,17 +8792,12 @@ msgstr "dage"
 msgid "debits"
 msgstr "debit"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9597,7 +8814,7 @@ msgstr ""
 msgid "done"
 msgstr "færdig"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9625,8 +8842,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9635,22 +8850,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9675,7 +8886,6 @@ msgstr ""
 msgid "sent"
 msgstr "sendt"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9700,8 +8910,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr "uventet fejl!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/de.po
+++ b/locale/po/de.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: German (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -16,27 +16,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr "# Rechnungen"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr "% Verfall"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr "(+) Restwert"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr "(-) Gesamtabschreibung"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr "(=) Buchwert"
@@ -49,12 +44,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -103,7 +94,6 @@ msgstr "Verbindlichkeiten"
 msgid "AP Aging"
 msgstr "Offene Verbindl."
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr "Ausgehende Rechnung"
@@ -112,7 +102,6 @@ msgstr "Ausgehende Rechnung"
 msgid "AP Invoices"
 msgstr "Ausgehende Rechnungen"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -127,7 +116,6 @@ msgstr "Offene Verbindlichkeiten"
 msgid "AP Transaction"
 msgstr "Eingangsbuchung"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Ausgangsbuchungen"
@@ -140,9 +128,7 @@ msgstr "Verbindlichkeitsgutschein"
 msgid "AP account"
 msgstr "Verbindlichkeitskonto"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -161,7 +147,6 @@ msgstr "Forderungen"
 msgid "AR Aging"
 msgstr "Offene Forderungen"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr "Ausstehende Rechnung"
@@ -170,7 +155,6 @@ msgstr "Ausstehende Rechnung"
 msgid "AR Invoices"
 msgstr "Ausstehende Rechnungen"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -185,7 +169,6 @@ msgstr "Offene Forderungen"
 msgid "AR Transaction"
 msgstr "Ausgangsbuchung"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Ausgangsbuchungen"
@@ -198,9 +181,7 @@ msgstr "Forderungsgutschein"
 msgid "AR account"
 msgstr "Forderungskonto"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -209,8 +190,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Ausgangsbuchung"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -220,16 +199,11 @@ msgstr "Forderungen/Verbindlichkeiten/Hauptbuch Betrag"
 msgid "Abandonment"
 msgstr "Verzicht"
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr "Zugriff verweigert"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -255,38 +229,20 @@ msgstr "Zugriff verweigert"
 msgid "Account"
 msgstr "Konto"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr "Kontobezeichnung"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr "Kontobezeichnung"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr "Kontoname"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -307,23 +263,18 @@ msgstr "Kontoname"
 msgid "Account Number"
 msgstr "Kontonummer"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr "Kontennummer Ende"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr "Kontennummer Beginn"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr "Kontobezeichnung"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -363,17 +314,15 @@ msgstr "Konten von"
 msgid "Accounts To"
 msgstr "Konten bis"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr "Konten für Abgleich markiert - einmal"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr "Konten für Abgleich markiert - existiert"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr "Konten ohne Überschrift"
 
@@ -385,7 +334,7 @@ msgstr "Rückstellung"
 msgid "Accrual Basis:"
 msgstr "Periodenabgrenzung:"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr "Summierte Abschreibungen"
 
@@ -413,12 +362,10 @@ msgstr "Aktiv"
 msgid "Active On"
 msgstr "Aktiv auf"
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr "Aktive Sitzungen"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -441,11 +388,11 @@ msgstr "Konten hinzufügen"
 msgid "Add Assembly"
 msgstr "Gruppe hinzufÃ¼gen"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr "Anlage hinzufÃ¼gen"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr "Anlagenklasse hinzufÃ¼gen"
 
@@ -570,7 +517,6 @@ msgstr "Verkaufsbeleg anlegen"
 msgid "Add Service"
 msgstr "Dienstleistung hinzufÃ¼gen"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr "Steuererklärung hinzufügen"
@@ -637,7 +583,6 @@ msgstr "Lohn hinzufügen"
 msgid "Add/Update"
 msgstr "Aktualisieren"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr "id [_1] hinzugefügt"
@@ -662,7 +607,6 @@ msgstr "Adresse:"
 msgid "Address: [_1]"
 msgstr "Adresse: [_1]"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -672,12 +616,11 @@ msgstr "Adressen"
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr "Angepasste Basis"
 
@@ -697,8 +640,7 @@ msgstr "Anpassungsdetails"
 msgid "Aged"
 msgstr "Gealtert"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr "Forderungenspiegel"
 
@@ -751,7 +693,6 @@ msgstr "All prices in [_1]"
 msgid "All prices in [_1]."
 msgstr "Alle Preise in [_1]."
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr "Zugeteilt"
@@ -760,11 +701,6 @@ msgstr "Zugeteilt"
 msgid "Allow Input"
 msgstr "Erlaubte Eingabe"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -798,14 +734,10 @@ msgstr "Erlaubte Eingabe"
 msgid "Amount"
 msgstr "Betrag"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr "Betrag budgettiert"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -814,27 +746,21 @@ msgstr "Betrag budgettiert"
 msgid "Amount Due"
 msgstr "Betrag fÃ¤llig"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr "Betrag von"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr "Betrag grÃ¶sser als"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr "Betrag kleiner als"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -852,14 +778,14 @@ msgstr "Betrag zu bezahlen"
 msgid "Amount/Rate"
 msgstr "Betrag/Rate"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -878,17 +804,14 @@ msgstr "Lineare Abschreibung monatlich"
 msgid "Any"
 msgstr "Jede"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr "Discount angerechnet"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr "Angewandter Nachlass aus Ãœberzahlung"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr "Discount anrechnen"
@@ -897,13 +820,6 @@ msgstr "Discount anrechnen"
 msgid "Approval Status"
 msgstr "Freigabestatus"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -912,7 +828,6 @@ msgstr "Freigabestatus"
 msgid "Approve"
 msgstr "Genehmigen"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -921,14 +836,12 @@ msgstr "Genehmigen"
 msgid "Approved"
 msgstr "Genehmigt"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr "Genehmigt von"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr "Genehmigt am"
 
@@ -940,19 +853,16 @@ msgstr "Genehmigte Unterschrift"
 msgid "Apr"
 msgstr "Apr"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "April"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr "Kaufwert"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr "Verbleibender Kaufwert"
 
@@ -968,7 +878,6 @@ msgstr "Sind Sie sicher dass Sie die Angebotsnummer lÃ¶schen wollen"
 msgid "As per"
 msgstr "Wie per"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -987,19 +896,17 @@ msgstr "Eerzeugnisse eingelagert!"
 msgid "Asset"
 msgstr "VermÃ¶gen"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr "Anlagen Konto"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr "Anlagenklassen"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr "Anlagenklassen Liste"
@@ -1012,29 +919,26 @@ msgstr "Anlagenklasse:"
 msgid "Asset Classes"
 msgstr "Anlageklassen"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr "Anlagenabschreibungsbericht"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr "Bericht zum Anlagenabgang"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr "Anlageklassauflistung"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr "Bericht zum Abgang geteilter Anlagen"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr "Anlagenkennzeichnung"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1050,7 +954,6 @@ msgstr "Anlage zu Eigenkapital"
 msgid "Assets to Liabilities"
 msgstr "Anlage zu Verbindlichkeiten"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1148,8 +1051,7 @@ msgstr "An: [_1]"
 msgid "Aug"
 msgstr "Aug"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "August"
 
@@ -1161,7 +1063,6 @@ msgstr "Autor: [_1]"
 msgid "Automatic"
 msgstr "Automatisch"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1175,7 +1076,6 @@ msgstr "Verfügbare Datenbanken"
 msgid "Available Users"
 msgstr "Verfügbare Benutzer"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1188,7 +1088,6 @@ msgstr "Verfügbare Überzahlungen"
 msgid "Average Cost"
 msgstr "Durchschnittliche Kosten"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr "Durchschnittlicher Kosten"
@@ -1222,8 +1121,6 @@ msgstr "Datenbanksicherungen"
 msgid "Backup Roles"
 msgstr "Datensicherung der Rolle"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1238,7 +1135,6 @@ msgstr "Saldo"
 msgid "Balance Sheet"
 msgstr "Bilanz"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr "Bilanz"
@@ -1259,7 +1155,6 @@ msgstr "Bankkonto"
 msgid "Bank Account:"
 msgstr "Bankkonto:"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1270,7 +1165,6 @@ msgstr "Bankverbindungen"
 msgid "Bar Code"
 msgstr "Barcode"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1280,18 +1174,15 @@ msgstr "WÃ¤hrung"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr "Basis"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr "Posten"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr "Postenklasse"
@@ -1304,12 +1195,10 @@ msgstr "Posten Kontroll Nummer"
 msgid "Batch Date"
 msgstr "Posten Datum"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr "Postenbeschreibung"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr "Posten Nr"
@@ -1326,13 +1215,11 @@ msgstr "Posten Information"
 msgid "Batch Name"
 msgstr "Postenname"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr "Stapelnummer"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr "Postensuche"
@@ -1373,8 +1260,6 @@ msgstr "Abrechnung E-mail"
 msgid "Billion"
 msgstr "Billion"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1421,17 +1306,14 @@ msgstr "Bücher geschlossen bis"
 msgid "Budget"
 msgstr "Budget"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr "Budgetnummer"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr "Budget Suchergebnisse"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr "Bericht zu Budgetabweichungen"
@@ -1444,12 +1326,10 @@ msgstr "Budgets"
 msgid "Business"
 msgstr "Gewerbe"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Gewerbenummer"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1459,12 +1339,10 @@ msgstr "Gewerbe"
 msgid "Business Type:"
 msgstr "Gewerbe:"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr "Geschäftsbereichsliste"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr "Geschäftsbereichsnummer"
@@ -1486,7 +1364,6 @@ msgstr "Gewerbe gespeichert!"
 msgid "CC"
 msgstr "Cc"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1518,18 +1395,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr "Eine stornierte Rechnung kann nicht storniert werden!"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr "Stornieren"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr "Abbrechen?"
 
@@ -1662,12 +1537,11 @@ msgstr "Passwort ändern"
 msgid "Chargeable"
 msgstr "Gebührenpflichtig"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr "Tabellen Nr"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Kontenliste"
 
@@ -1687,7 +1561,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "Inventar prÃ¼fen"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr "Vorzeichen ÃœberprÃ¼fen"
@@ -1716,7 +1589,7 @@ msgstr "Stadt:"
 msgid "Class"
 msgstr "Klasse"
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr "Datum lÃ¶schen"
 
@@ -1728,9 +1601,9 @@ msgstr "Abstimmungsdatum ist [*,_1,day] in der Zukunft nach der Buchung"
 msgid "Clear date over [*,_1,day]"
 msgstr "Gelöschtes Datum über [*,_1,day]"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "Entlastet"
 
@@ -1758,15 +1631,13 @@ msgstr "Jahresabschluss"
 msgid "Close books"
 msgstr "Bücher schließen"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Schliessen"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1781,8 +1652,6 @@ msgstr "Abschlussdaten"
 msgid "Closing data"
 msgstr "Abschlussdaten"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1797,22 +1666,18 @@ msgstr "Code fehlt!"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr "Kombinieren"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr "Einkaufsbestellungen kombinieren"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr "VerkaufsauftrÃ¤ge kombinieren"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1824,39 +1689,31 @@ msgstr "VerkaufsauftrÃ¤ge kombinieren"
 msgid "Company"
 msgstr "Firma"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr "Firmenadresse"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr "Firmenfax"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr "Firmeninformationen"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr "Lizenznummer der Firma"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Firmenname"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr "Firmentelefon"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr "Firmensteuernummer"
@@ -1877,7 +1734,7 @@ msgstr "Vorgang bestätigen"
 msgid "Confirm!"
 msgstr "BestÃ¤tigen!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 "Konflikt mit bestehenden Daten.  MÃ¶glicherweise haben Sie diese Angabe "
@@ -1897,7 +1754,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Kontakt"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1913,7 +1769,6 @@ msgstr "Kontaktinformationen:"
 msgid "Contact Information"
 msgstr "Kontaktinformationen"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1931,9 +1786,6 @@ msgstr "Kontakte"
 msgid "Content"
 msgstr "Inhalt"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1963,7 +1815,6 @@ msgstr "Vorherigen Arbeitsablauf fortsetzen"
 msgid "Contra"
 msgstr "Gegenkonto"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1971,10 +1822,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -2005,20 +1852,16 @@ msgstr "Als Neu kopieren"
 msgid "Copy to New Name"
 msgstr "Zu einem neuen Namen kopieren"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Kosten"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr "Kosten der verkauften GÃ¼ter"
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr "Die Template von der Datenbank konnte nicht geladen werden"
 
@@ -2034,26 +1877,20 @@ msgstr "Konnte nicht gespeichert werden!"
 msgid "Could not transfer Inventory!"
 msgstr "Inventar konnte nicht Ã¼bertragen werden!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr "GezÃ¤hlt"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr "Kontrahent"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr "Kontrahentcode"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2065,7 +1902,6 @@ msgstr "Kontrahentcode"
 msgid "Country"
 msgstr "Land"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr "Landesname"
@@ -2078,7 +1914,7 @@ msgstr "Land:"
 msgid "Create"
 msgstr "Erstellen"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2086,11 +1922,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr "Batch erstellen"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr "Datenbank erstellen?"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2118,8 +1954,6 @@ msgstr "Erstellt von"
 msgid "Created On"
 msgstr "Erstellt am"
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2127,17 +1961,14 @@ msgstr "Erstellt am"
 msgid "Credit"
 msgstr "Haben"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr "Kreditkonto"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr "Kontonummer"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr "Kundenkreditkonto"
@@ -2162,29 +1993,19 @@ msgstr "Kreditlinie"
 msgid "Credit Note"
 msgstr "Gutschrift"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr "Haben"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "WÃ¤hrung"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2207,18 +2028,14 @@ msgstr "WÃ¤hrung"
 msgid "Currency"
 msgstr "WÃ¤hrung"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Aktuell"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2228,11 +2045,7 @@ msgstr "Aktuelles Ergebnis"
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2247,7 +2060,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Kunde"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr "Kundenkonto"
@@ -2266,9 +2078,6 @@ msgstr "Kunde nicht in der Datei!"
 msgid "Customer Name"
 msgstr "Kundenname"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2288,9 +2097,7 @@ msgstr "Kunden suchen"
 msgid "Customer missing!"
 msgstr "Kunde fehlt!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2302,7 +2109,7 @@ msgstr "Kunde nicht in der Datei!"
 msgid "Customer/Vendor Accounts"
 msgstr "Kunden/Lieferant Konto"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr "D M"
 
@@ -2326,12 +2133,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr "Daten nicht gespeichert.  Bitte erneut versuchen."
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr "Daten nicht gespeichert.  Bitte aktualisieren Sie erneut."
 
@@ -2364,28 +2170,16 @@ msgstr "Datenbank Administrator Anmeldedaten"
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr "Datenbank existiert nicht."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr "Datenbank existiert."
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2432,19 +2226,14 @@ msgstr "Datenbank existiert."
 msgid "Date"
 msgstr "Datum"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr "Datumformat"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr "Datum vom"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2466,7 +2255,6 @@ msgstr "Empfangsdatum"
 msgid "Date Reversed"
 msgstr "Datum zurueck"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr "Datum bis"
@@ -2530,8 +2318,6 @@ msgstr "Tag(e)"
 msgid "Days"
 msgstr "Tage"
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2547,10 +2333,8 @@ msgstr "Debit-Rechnung"
 msgid "Debit Note"
 msgstr "Lastschrift"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2560,17 +2344,14 @@ msgstr "Soll"
 msgid "Dec"
 msgstr "Dez"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Dezember"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr "Dezimalstellen fÃ¼r Geld"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2580,7 +2361,6 @@ msgstr "Abzugsart"
 msgid "Deduction Type"
 msgstr "Abzugsart"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr "Abzugsarten"
@@ -2593,47 +2373,38 @@ msgstr "Abbrechnungsverbindlichkeiten"
 msgid "Default AR"
 msgstr "Kreditorenkonto"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr "Standard Konten"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr "Standard Land"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr "Standard Email BCC"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr "Standard Email CC"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr "Default Email Vorlage"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr "Standard Email an"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr "Standardformat"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr "Standard Sprache"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr "Standard Meldepflichtig"
@@ -2646,21 +2417,14 @@ msgstr "Standardsumme"
 msgid "Defaults"
 msgstr "Einstellungen"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2678,7 +2442,6 @@ msgstr ""
 msgid "Delete"
 msgstr "LÃ¶schen"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr "Posten lÃ¶schen"
@@ -2691,7 +2454,6 @@ msgstr "Sprache lÃ¶schen"
 msgid "Delete Schedule"
 msgstr "Plan lÃ¶schen"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr "Gutscheine lÃ¶schen"
@@ -2706,37 +2468,33 @@ msgstr ""
 msgid "Delivery"
 msgstr "Lieferung"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Lieferdatum"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr "Abschreibungsbasis"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr "Abschreibungsmethode"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr "Abschreibungsbeginn"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr "Abschreiben bis"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr "Abschreibungen YTD"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr "Abschreibungen in dieser Periode"
 
@@ -2758,20 +2516,17 @@ msgstr "Abschreibung"
 msgid "Depreciate Through"
 msgstr "Abschreiben bis"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr "Abschreibung"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr "Abschreibungskonto"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2782,46 +2537,7 @@ msgstr "Abschreibungsmethode"
 msgid "Depreciation Starts"
 msgstr "Abschreibungsbeginn"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2932,12 +2648,10 @@ msgstr "Detail"
 msgid "Details"
 msgstr "Details"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr "Deaktivieren Rücktaste"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr "Disc"
@@ -2950,7 +2664,6 @@ msgstr "Disc"
 msgid "Disc %"
 msgstr "Rabatt %"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2959,7 +2672,6 @@ msgstr "Rabatt %"
 msgid "Discount"
 msgstr "Discount"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr "Rabatt (%)"
@@ -2968,28 +2680,28 @@ msgstr "Rabatt (%)"
 msgid "Discount:"
 msgstr "Rabatt:"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr "Durch AbgÃ¤nge erzielte Werte"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr "Abgabe"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr "Zeitpunkt der VerÃ¤usserung"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr "VerÃ¤usserungsmethode"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr "Bericht zu geteilten AbgÃ¤ngen [_1] am Datum [_2]"
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr "Division durch 0 Fehler"
 
@@ -2997,7 +2709,6 @@ msgstr "Division durch 0 Fehler"
 msgid "Do not keep field empty [_1]"
 msgstr "Feld nicht leer lassen [_1]"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr "Dokument"
@@ -3006,7 +2717,7 @@ msgstr "Dokument"
 msgid "Document Type"
 msgstr "Dokumententyp"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr "Unklar was mit Sicherungskopie geschehen soll"
 
@@ -3014,12 +2725,10 @@ msgstr "Unklar was mit Sicherungskopie geschehen soll"
 msgid "Done"
 msgstr "Erledigt"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr "Doppelte Kundennummer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr "Doppelte Lieferantennummer"
@@ -3032,12 +2741,10 @@ msgstr "Dr."
 msgid "Draft Posted"
 msgstr "Entwurf gebucht"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr "Suche in EntwÃ¼rfen"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr "Entwurfsart"
@@ -3046,19 +2753,16 @@ msgstr "Entwurfsart"
 msgid "Drafts"
 msgstr "Entwurf"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Zeichnung"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr "AufklappmenÃ¼s"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3074,10 +2778,6 @@ msgstr "AufklappmenÃ¼s"
 msgid "Due"
 msgstr "FÃ¤llig"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3096,7 +2796,7 @@ msgstr "Verfallsdatum fehlt!"
 msgid "Duplicate User Found: Importing User"
 msgstr "Doppelter Benutzer gefunden: Benutzer wird importiert"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr "Doppelte Mitarbeiternummer"
 
@@ -3122,7 +2822,7 @@ msgstr "E-mail Nachricht"
 msgid "E-mailed"
 msgstr "Gesendet"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr "G&V"
 
@@ -3152,7 +2852,7 @@ msgstr "Debitorerentransaktion bearbeiten"
 msgid "Edit Assembly"
 msgstr "Zusammenbau bearbeiten"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr "Anlagenklasse bearbeiten"
 
@@ -3296,8 +2996,6 @@ msgstr "elf-o"
 msgid "Email"
 msgstr "E-mail"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3311,7 +3009,6 @@ msgstr "E-mail"
 msgid "Employee"
 msgstr "Mitarbeiter"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3321,14 +3018,13 @@ msgstr "Mitarbeiternummer"
 msgid "Employee Search"
 msgstr "Mitarbeiter suchen"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 "Der Name des Mitarbeiters entspricht nicht den Mindestanforderungen (z. B. "
 "nicht leer, alphanumerisch)"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3338,37 +3034,26 @@ msgstr "Mitarbeiternummer"
 msgid "Employees"
 msgstr "Arbeitnehmer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr "Leeres Kreditorenkonto"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr "Leeres Debitorenkonto"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr "Leere Kundennummer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr "Leere Lieferantennummern"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3392,7 +3077,6 @@ msgstr "Datum Ende:"
 msgid "Ending"
 msgstr "Endet"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr "Schlussbilanz"
@@ -3417,12 +3101,10 @@ msgstr "Gebe Inventar ein"
 msgid "Enter User"
 msgstr "Gebe Benutzer ein"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr "Geben Sie die Personalnummern ein, wo sie fehlen"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3432,7 +3114,7 @@ msgstr "Bearbeitet von"
 msgid "Entered For"
 msgstr "Bearbeitet für"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr "Eingegeben am"
 
@@ -3440,7 +3122,6 @@ msgstr "Eingegeben am"
 msgid "Entered at: [_1]"
 msgstr "Eingegeben am: [_1]"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr "EntitÃ¤t"
@@ -3466,7 +3147,7 @@ msgstr "Entitätscode Kreditkonto"
 msgid "Entity Name"
 msgstr "EntitÃ¤t Kode"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr "Eintragungs ID"
 
@@ -3478,14 +3159,11 @@ msgstr "Umschlag"
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Bilanz"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr "Eigenkapital und Verbindlichkeiten"
@@ -3499,16 +3177,15 @@ msgstr "Eigenkapital (temporär)"
 msgid "Equity to Liabilities"
 msgstr "Eigenkapital zu Verbindlichkeiten"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr "Fehler beim erstellen der Sicherungsdatei"
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr "Fehler bei erstellen von Posten.  Bitte versuchen Sie es erneut."
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr "Fehler aus Funktion:"
 
@@ -3517,7 +3194,7 @@ msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 "Fehler: Saldenzusammenfassung konnte nicht ins AufklappmenÃ¼ eingefÃ¼gt werden"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr "GeschÃ¤tzte Lebensdauer"
 
@@ -3530,8 +3207,6 @@ msgstr "Jede"
 msgid "Exch"
 msgstr "Wechselkurs"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3546,7 +3221,6 @@ msgstr "Wechselkurs"
 msgid "Exchange rate for payment missing!"
 msgstr "Wechselkurs fÃ¼r Zahlung fehlt!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr "Wechselkurs wurde nicht definiert!"
@@ -3555,7 +3229,6 @@ msgstr "Wechselkurs wurde nicht definiert!"
 msgid "Exchange rate missing!"
 msgstr "Wechselkurs fehlt!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr "Erwartet"
@@ -3573,13 +3246,10 @@ msgstr "Aufwandskonto"
 msgid "Expense/Asset"
 msgstr "Aufwand/Anlagen"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr "Aufwendungen"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3657,8 +3327,7 @@ msgstr "Fax: [_1]"
 msgid "Feb"
 msgstr "Feb"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Februar"
 
@@ -3674,14 +3343,10 @@ msgstr "fünfzig"
 msgid "File"
 msgstr "Datei"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr "Datei importiert"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3692,11 +3357,11 @@ msgstr "Dateiname"
 msgid "File Type"
 msgstr "Dateityp"
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr "Dateiname"
 
@@ -3707,7 +3372,6 @@ msgstr "Dateiname"
 msgid "File type"
 msgstr "Dateityp"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr "Dateien"
@@ -3765,12 +3429,10 @@ msgstr "Anlagevermögen"
 msgid "For"
 msgstr "FÃ¼r"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Gewinne aus FremdwÃ¤hrungen"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Verluste aus FremdwÃ¤hrungen"
@@ -3779,12 +3441,10 @@ msgstr "Verluste aus FremdwÃ¤hrungen"
 msgid "Form"
 msgstr "Von"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr "Formularname"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr "Format"
@@ -3801,7 +3461,6 @@ msgstr "Vier"
 msgid "Fourteen"
 msgstr "vierzehn"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr "Fre"
@@ -3820,18 +3479,10 @@ msgstr "Fre"
 msgid "From"
 msgstr "Von"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr "Vom Betrag"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3852,7 +3503,6 @@ msgstr "Aus Datei"
 msgid "From Warehouse"
 msgstr "Aus Warenlager"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr "Von Datum"
@@ -3863,15 +3513,10 @@ msgstr "Von Datum"
 msgid "Full"
 msgstr "Voll"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr "Volle Rechte"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3885,10 +3530,8 @@ msgstr "Volle Rechte"
 msgid "GIFI"
 msgstr "GIFI"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3909,7 +3552,6 @@ msgstr "GIFI gespeichert!"
 msgid "GL"
 msgstr "Hauptbuch"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr "Grundbuch Referenznummer"
@@ -3918,7 +3560,7 @@ msgstr "Grundbuch Referenznummer"
 msgid "Gain"
 msgstr "Gewinn"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr "Gewinn (Verlust)"
 
@@ -3926,12 +3568,11 @@ msgstr "Gewinn (Verlust)"
 msgid "Gain Account"
 msgstr "Gewinnkonto"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 #, fuzzy
 msgid "Gain/Loss"
 msgstr "Gewinn (Verlust)"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr "Lückenlose Debitorenbuchhaltung"
@@ -3940,7 +3581,7 @@ msgstr "Lückenlose Debitorenbuchhaltung"
 msgid "General Journal"
 msgstr "Sammeljournal"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr "Hauptbuch Berichte"
 
@@ -3948,9 +3589,8 @@ msgstr "Hauptbuch Berichte"
 msgid "General Ledger Reports"
 msgstr "Hauptbuch Berichte"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr "Generieren"
 
@@ -3966,7 +3606,7 @@ msgstr "Bestellungen erstellen"
 msgid "Generate Purchase Orders"
 msgstr "Einkaufsauftrag erstellen"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr "Verkaufsauftrag aus Kaufauftrag erstellen"
 
@@ -3974,7 +3614,7 @@ msgstr "Verkaufsauftrag aus Kaufauftrag erstellen"
 msgid "Generate Sales Orders"
 msgstr "Verkaufsbeleg erstellen"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr "VerkaufsauftrÃ¤ge aus KaufauftrtÃ¤gen generieren"
 
@@ -3990,12 +3630,10 @@ msgstr "Vorname"
 msgid "Goods & Services"
 msgstr "Waren und Dienstleistungen"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr "Waren und Dienstleistungen"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr "Geschichte der Waren und Dienstleistungen"
@@ -4004,7 +3642,6 @@ msgstr "Geschichte der Waren und Dienstleistungen"
 msgid "Grand Total"
 msgstr "Gesamtsumme"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4078,21 +3715,6 @@ msgstr "Stunden"
 msgid "Hundred"
 msgstr "hundert"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4123,7 +3745,6 @@ msgstr "IRC"
 msgid "Identification"
 msgstr "Identifikation"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4133,13 +3754,11 @@ msgstr "Jahresenden ignorieren"
 msgid "Ignore year-closing"
 msgstr "Jahresabschlüsse ignorieren"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Bild"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr "Bilder in Vorlagen"
@@ -4182,7 +3801,6 @@ msgstr "Existierenden Benutzer importieren"
 msgid "In"
 msgstr "In"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr "In Svc"
@@ -4216,14 +3834,10 @@ msgstr "In Aufklapp-Menü aufnehmen"
 msgid "Includes Part"
 msgstr "Enthält Teil"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr "Einschliesslich Teilnummer"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4231,12 +3845,10 @@ msgstr "Einschliesslich Teilnummer"
 msgid "Income"
 msgstr "Ertrag"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr "Ertragsklasse"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4247,7 +3859,6 @@ msgstr "G&V"
 msgid "Income Type"
 msgstr "Einkommensart"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr "Ertragsarten"
@@ -4257,7 +3868,6 @@ msgstr "Ertragsarten"
 msgid "Income statement"
 msgstr "G&V"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr "Eingehende Dateien"
@@ -4280,11 +3890,10 @@ msgstr ""
 "zur vollständigen Bezahlung fällig. Artikel, die zurückgegeben werden, "
 "unterliegen einer Auffüllgebühr von 10%."
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr "Interner Datenbankenfehler"
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr "Interne Dateien"
@@ -4294,31 +3903,27 @@ msgstr "Interne Dateien"
 msgid "Internal Notes"
 msgstr "Interne Notizen"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr "UngÃ¼ltige Berichtsgrundlage"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr "UngÃ¼ltige Sicherungsanfrage"
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr "UngÃ¼ltiges Datum/Zeit eingegeben"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 "UngÃ¼ltige Saldenaufstellung.  Hinweis: Versuhen Sie eine Zahl einzugeben"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4328,17 +3933,14 @@ msgstr "Inventar"
 msgid "Inventory Activity"
 msgstr "Inventaraktivität"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr "Inventaraktivitätsbericht"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr "Einzelheiten zu Inventaranpassungen"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr "Inventaranpassungen"
@@ -4366,11 +3968,7 @@ msgstr "Inventar gespeichert!"
 msgid "Inventory transferred!"
 msgstr "Inventar Ã¼bertragen!"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4412,8 +4010,6 @@ msgstr "Rechnung erstellt"
 msgid "Invoice Created Date missing!"
 msgstr "Rechnungserstellt"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4429,11 +4025,6 @@ msgstr "Rechnungsdatum fehlt!"
 msgid "Invoice No."
 msgstr "Rechnungsnr."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4452,7 +4043,6 @@ msgstr "Rechnungsnummer"
 msgid "Invoice Number missing!"
 msgstr "Rechnungsnummer fehlt!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr "Rechnungen Gewinn/Verlust"
@@ -4482,12 +4072,10 @@ msgstr "Rechnungsfälligigkeit"
 msgid "Invoice not found"
 msgstr "Rechnung nicht gefunden"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4551,8 +4139,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Jan"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Januar"
 
@@ -4581,8 +4168,7 @@ msgstr "Journallinien"
 msgid "Jul"
 msgstr "Jul"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Juli"
 
@@ -4590,8 +4176,8 @@ msgstr "Juli"
 msgid "Jun"
 msgstr "Jun"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Juni"
 
@@ -4604,10 +4190,6 @@ msgstr "Verhältnisse"
 msgid "LaTeX Templates"
 msgstr "LaTeX Vorlagen"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4629,15 +4211,12 @@ msgstr "Gestehungskosten"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Sprache"
@@ -4658,7 +4237,6 @@ msgstr "Sprachen nicht definiert!"
 msgid "Last"
 msgstr "Letzte"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4669,7 +4247,6 @@ msgstr "Letzte Kosten"
 msgid "Last Name"
 msgstr "Nachname"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr "Letzte Aktualisierung"
@@ -4691,41 +4268,40 @@ msgstr "Vorlaufzeit"
 msgid "Leadtime"
 msgstr "Bestellzeit"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr "LedgerSMB 1.2 db gefunden."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr "LedgerSMB 1.3 db gefunden."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr "LedgerSMB 1.5 db gefunden."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 #, fuzzy
 msgid "LedgerSMB 1.8 db found."
 msgstr "LedgerSMB 1.2 db gefunden."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 #, fuzzy
 msgid "LedgerSMB 1.9 db found."
 msgstr "LedgerSMB 1.2 db gefunden."
@@ -4738,9 +4314,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr "LedgerSMB [_1]"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4762,9 +4336,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4778,8 +4350,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr "Passiven"
@@ -4796,7 +4366,6 @@ msgstr "Lizenznummer"
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4833,7 +4402,6 @@ msgstr "Sprachen aufzeigen"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4859,7 +4427,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4877,7 +4444,6 @@ msgstr "Standort"
 msgid "Locations"
 msgstr "Standorte"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4898,7 +4464,7 @@ msgstr ""
 msgid "Login"
 msgstr "Anmelden"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4926,45 +4492,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Hersteller"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr "Benutzer verwalten"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4986,40 +4545,34 @@ msgstr "Manuell"
 msgid "Mar"
 msgstr "Mrz"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "MÃ¤rz"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Aufschlag"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr "Maximale Rechnungen per Scheckavis"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr "Max per AufklappmenÃ¼"
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "Mai"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Vermerk"
@@ -5036,7 +4589,6 @@ msgstr "Nachricht"
 msgid "Message: "
 msgstr "Nachricht: "
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Methode"
@@ -5045,7 +4597,6 @@ msgstr "Methode"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5064,14 +4615,11 @@ msgstr ""
 msgid "Million"
 msgstr "million"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5085,7 +4633,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr "Sonstige Einstellungen"
@@ -5098,14 +4645,12 @@ msgstr ""
 msgid "Miss."
 msgstr "Fr."
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Modell"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr "Mon"
@@ -5123,7 +4668,7 @@ msgstr "Monat(e)"
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr "Weitere Informationen im Fehlerprotokoll"
 
@@ -5147,14 +4692,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5163,15 +4706,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5190,7 +4724,6 @@ msgstr "Name"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5241,8 +4774,6 @@ msgstr "NÃ¤chstes Datum"
 msgid "Next Number"
 msgstr "NÃ¤chste Nummer"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5264,12 +4795,10 @@ msgstr "neunzehn"
 msgid "Ninety"
 msgstr "neunzig"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Nr"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr "Kein Forderungen oder Verbindlichkeiten Konto gewÃ¤hlt"
@@ -5278,7 +4807,7 @@ msgstr "Kein Forderungen oder Verbindlichkeiten Konto gewÃ¤hlt"
 msgid "No Account id for [_1]"
 msgstr "Keine Konto Nr. fÃ¼r [_1]"
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5286,11 +4815,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr "Kein Id Satz"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr "Keine Null BetrÃ¤ge"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr "Keine Null Mitarbeiternummer"
 
@@ -5298,7 +4827,6 @@ msgstr "Keine Null Mitarbeiternummer"
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5309,11 +4837,11 @@ msgstr ""
 "Keine WÃ¤hrungen definiert.  Bitte richten sie diese unter System/"
 "Einstellungen ein."
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr "Keine Datei hochgeladen"
 
@@ -5321,21 +4849,18 @@ msgstr "Keine Datei hochgeladen"
 msgid "No open Projects!"
 msgstr "Keine offenen Projekte!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr "Kein Ãœberzahlungskonto gewÃ¤hlt.  Wurde ein solches erstellt?"
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr "Kein Bericht festgelegt"
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5354,12 +4879,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5368,12 +4891,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5411,11 +4932,6 @@ msgstr "Notiz Klasse"
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5461,23 +4977,18 @@ msgstr "Nichts zu Ã¼bertragen!"
 msgid "Nov"
 msgstr "Nov"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "November"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5508,7 +5019,7 @@ msgstr ""
 msgid "Number"
 msgstr "Nummer"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Zahlenformat"
 
@@ -5529,13 +5040,11 @@ msgstr "OH"
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Obsolet"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr "HinfÃ¤llig ab"
@@ -5544,8 +5053,7 @@ msgstr "HinfÃ¤llig ab"
 msgid "Oct"
 msgstr "Okt"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Oktober"
 
@@ -5557,9 +5065,6 @@ msgstr "Warten"
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5609,7 +5114,6 @@ msgstr ""
 msgid "Open"
 msgstr "Ã–ffnen"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5632,9 +5136,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5680,7 +5181,6 @@ msgstr "Bestelldatum fehlt!"
 msgid "Order Entry"
 msgstr "Bestellungen"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5702,7 +5202,6 @@ msgstr "Bestellung gelÃ¶scht!"
 msgid "Order generation failed!"
 msgstr "Erstellen der Bestellung fehlgeschlagen!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5724,7 +5223,7 @@ msgstr "Bestellungen generiert!"
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr "Unser Saldo"
 
@@ -5770,7 +5269,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5789,10 +5287,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5836,11 +5330,6 @@ msgstr "Verpackungslistennummer fehlt!"
 msgid "Packing list"
 msgstr "Packliste"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5858,12 +5347,10 @@ msgstr "Bezahlt"
 msgid "Parent"
 msgstr "VorgÃ¤nger"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Teil"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5873,14 +5360,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5912,14 +5391,10 @@ msgstr "Details"
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr "Bericht zu geteilten AbgÃ¤ngen [_1] am Datum [_2]"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5935,15 +5410,12 @@ msgstr "Teilnummer"
 msgid "Parts"
 msgstr "Teil"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5953,7 +5425,6 @@ msgstr ""
 msgid "Password"
 msgstr "Passwort"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5966,7 +5437,6 @@ msgstr "PasswÃ¶rter mÃ¼ssen Ã¼bereinstimmen."
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5980,7 +5450,6 @@ msgstr ""
 msgid "Payables"
 msgstr "Verbindlichkeiten"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5989,7 +5458,6 @@ msgstr "Verbindlichkeiten"
 msgid "Payment"
 msgstr "Zahlung"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr "Zahlungsbetrag"
@@ -6002,7 +5470,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr "Zahlungsergebnisse"
@@ -6019,7 +5486,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6057,15 +5523,15 @@ msgstr ""
 "Zahlungen aus stornierten Rechnungen mÃ¼ssen mÃ¶glicherweise rÃ¼ckÃ¼berwiesen "
 "werden."
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr "Prozent"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr "VerÃ¤usserungen in Prozent"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr "Prozent verbleibend"
 
@@ -6084,7 +5550,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr "Person"
@@ -6115,108 +5580,88 @@ msgstr "Lagerliste"
 msgid "Pick list"
 msgstr "Lagerliste"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6232,7 +5677,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6241,24 +5685,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6267,13 +5709,11 @@ msgstr ""
 msgid "Post"
 msgstr "Buchen"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr "Posten buchen"
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr "Datum einfÃ¼gen"
 
@@ -6314,7 +5754,6 @@ msgstr "Lieferantenrechnung buchen [_1]"
 msgid "Postscript"
 msgstr "Postscript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6352,20 +5791,16 @@ msgstr ""
 msgid "Price"
 msgstr "Preis"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6401,8 +5836,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6412,7 +5845,6 @@ msgstr ""
 msgid "Print"
 msgstr "Drucken"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6429,7 +5861,7 @@ msgstr "Drucken und als Neu speichern"
 msgid "Printed"
 msgstr "Gedruckt"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Drucker"
 
@@ -6473,17 +5905,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr "GetÃ¤tigte Abschreibungen"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr "Bis"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr "ErtrÃ¤ge"
 
@@ -6513,7 +5943,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr "Gewinn/Verlust"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr "Gewinn/Verlust aus InventarverkÃ¤ufen"
@@ -6532,7 +5961,6 @@ msgstr "Ãœbersetzungen der Projektbeschreibungen"
 msgid "Project Number"
 msgstr "Projektnummer"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr "Projekt/Abteilungsnummer"
@@ -6541,9 +5969,6 @@ msgstr "Projekt/Abteilungsnummer"
 msgid "Projects"
 msgstr "Projekte"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6553,7 +5978,6 @@ msgstr "Kaufdatum"
 msgid "Purchase Date:"
 msgstr "Kaufdatum:"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6571,22 +5995,16 @@ msgstr "Kaufhistorie"
 msgid "Purchase Order"
 msgstr "Einkaufsauftrag"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Einkaufsbestellungen"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6601,14 +6019,10 @@ msgstr "Kaufwert:"
 msgid "Purchase order"
 msgstr "Einkaufsauftrag"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6639,7 +6053,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Menge"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6653,8 +6066,6 @@ msgstr "Menge Ã¼bersteigt verfÃ¼gbare Einheiten am Lager!"
 msgid "Quarter"
 msgstr "Quartal"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6691,9 +6102,7 @@ msgstr "Angebotsnummer fehlt!"
 msgid "Quotation deleted!"
 msgstr "Angebot gelÃ¶scht!"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6714,25 +6123,20 @@ msgstr "Anfragen"
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "Anfragennummer"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "Angebotsanfragen"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "Nachbestellungspunkt"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6744,7 +6148,6 @@ msgstr "Kurs"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6767,13 +6170,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6791,7 +6190,6 @@ msgstr "Beleg"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr "Eingangsergebnisse"
@@ -6805,8 +6203,7 @@ msgstr "Belege"
 msgid "Receivables"
 msgstr "Forderungen"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Empfangen"
 
@@ -6814,7 +6211,6 @@ msgstr "Empfangen"
 msgid "Receive Merchandise"
 msgstr "Waren empfangen"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6835,7 +6231,6 @@ msgstr ""
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr "Kontenabgleichsberichte"
@@ -6856,13 +6251,6 @@ msgstr "Wiederkehrende Transaktion fÃ¼r [_1]"
 msgid "Recurring Transactions"
 msgstr "Wiederkehrende Transaktionen"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6901,12 +6289,10 @@ msgstr "Registrierung [_1]"
 msgid "Regular"
 msgstr "Regulär"
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr "Verwerfen"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr "Restnutzdauer"
@@ -6944,7 +6330,7 @@ msgstr ""
 msgid "Report Name"
 msgstr "Berichtsname"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr "Berichtsergebnisse"
 
@@ -6956,7 +6342,7 @@ msgstr ""
 msgid "Report Type"
 msgstr "Berichtstyp"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr "Bericht [_1] am [_2]"
 
@@ -6969,7 +6355,6 @@ msgstr "Bericht in"
 msgid "Report type"
 msgstr "Berichtstyp"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr "Grundlage des Berichts"
@@ -7019,7 +6404,7 @@ msgstr ""
 msgid "Required By"
 msgstr "Benötigt bis"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr "Bedarfstermin"
 
@@ -7039,13 +6424,10 @@ msgstr "Bedarfstermin"
 msgid "Required by"
 msgstr "BenÃ¶tigt von"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr "BenÃ¶tigte Eingabe nicht erbracht"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7075,7 +6457,6 @@ msgstr "Zum Anmeldebildschirm zurück."
 msgid "Returns"
 msgstr " Rückgaben"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7084,7 +6465,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr "Storno"
@@ -7101,7 +6481,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr "Rückzahlung"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr "RÃ¼ckzahlungen"
@@ -7151,11 +6530,11 @@ msgstr "SKU"
 msgid "SO Number"
 msgstr "Kundenauftragsnummer"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr "SQL-Ledger Datenbank 3.0 erkannt."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr "SQL-Ledger Datenbank erkannt."
 
@@ -7181,7 +6560,6 @@ msgstr "Verkauf"
 msgid "Sales Invoice"
 msgstr "Verkaufsrechnung"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Ausgangsrechnung/Transaktionsnummer ausstehende Rechnung"
@@ -7197,20 +6575,17 @@ msgstr "Ausgangsrechnung/Transaktionsnummer ausstehende Rechnung"
 msgid "Sales Order"
 msgstr "Verkaufsauftrag"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "Kundenauftragsnummer"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Verkaufsbelege"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "Angebotsnummer"
@@ -7233,9 +6608,6 @@ msgstr "Anrede"
 msgid "Sales:"
 msgstr "Verkauf:"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7259,13 +6631,10 @@ msgstr "Anrede"
 msgid "Salvage Value:"
 msgstr "Restwert:"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr "Sat"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7285,7 +6654,7 @@ msgstr "Sat"
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7295,7 +6664,6 @@ msgstr "Speichern"
 msgid "Save As New"
 msgstr "Als Neu speichern"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr "Posten speichern"
@@ -7354,11 +6722,10 @@ msgstr "Als Neu speichern"
 msgid "Save as new"
 msgstr "Als Neu speichern"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7381,10 +6748,8 @@ msgstr "Planen"
 msgid "Scheduled"
 msgstr "Geplant"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Bildschirm"
 
@@ -7404,7 +6769,6 @@ msgstr "Bildschirm"
 msgid "Search"
 msgstr "Suchen"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr "Suche in Verbindlichkeiten"
@@ -7413,7 +6777,6 @@ msgstr "Suche in Verbindlichkeiten"
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr "Suche in Forderungen"
@@ -7466,11 +6829,11 @@ msgstr "Preisgruppen suchen"
 msgid "Search Pricegroups"
 msgstr "Preisgruppen suchen"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr "Einkaufsbestellungen suchen"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr "Angebote suchen"
 
@@ -7482,11 +6845,11 @@ msgstr "Quittung suchen"
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr "Angebotsanfragen durchsuchen"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr "VerkaufsauftrÃ¤ge suchen"
 
@@ -7498,7 +6861,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr "Berichte suchen"
 
@@ -7506,7 +6869,6 @@ msgstr "Berichte suchen"
 msgid "Secondary Phone"
 msgstr "Sekundäres Telefon"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr "Sicherheitseinstellungen"
@@ -7562,7 +6924,6 @@ msgstr "WÃ¤hle TXT, Postscript oder PDF!"
 msgid "Select using"
 msgstr "Ausgewählt mit"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr "GewÃ¤hlt"
@@ -7571,9 +6932,6 @@ msgstr "GewÃ¤hlt"
 msgid "Sell"
 msgstr "Verkaufen"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7627,13 +6985,11 @@ msgstr "Senden von Arbeitsauftrag [_1]"
 msgid "Sep"
 msgstr "Sep"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr "Aufgaben teilen"
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "September"
 
@@ -7654,9 +7010,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "Serien Nr."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7686,7 +7039,6 @@ msgstr "Dienstleistungskennung"
 msgid "Services"
 msgstr "Dienstleistung"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 #, fuzzy
 msgid "Session Timeout (e.g. \"90 minutes\")"
@@ -7700,7 +7052,7 @@ msgstr "Sessions"
 msgid "Setting"
 msgstr "Einstellung"
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr "Einstellungen"
 
@@ -7720,10 +7072,10 @@ msgstr "siebzehn"
 msgid "Seventy"
 msgstr "siebzig"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Versenden"
 
@@ -7750,10 +7102,6 @@ msgstr "Lieferadresse"
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7814,10 +7162,6 @@ msgstr "Versanddatum fehlt!"
 msgid "Shipping Label"
 msgstr "Versandaufkleber"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7859,7 +7203,6 @@ msgstr "Versandaufkleber"
 msgid "Short"
 msgstr "Gering"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr "Kreditlimit anzeigen"
@@ -7901,7 +7244,6 @@ msgstr "sechzig"
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr "Verkauft"
@@ -7914,12 +7256,6 @@ msgstr "Einige"
 msgid "Sort by"
 msgstr "Sortiere nach"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7946,7 +7282,6 @@ msgstr "Quelle"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr "Quelle beginnt mit"
@@ -7968,21 +7303,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Standard"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "Branchenklassifikation SIC"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -8014,8 +7338,6 @@ msgstr "Fange an, LedgerSMB zu benutzen"
 msgid "Startdate"
 msgstr "Anfangsdatum"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8052,13 +7374,11 @@ msgstr "Bundesland:"
 msgid "Statement"
 msgstr "Zahlungserinnerung"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Saldenaufstellung"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8089,7 +7409,7 @@ msgstr "Erzeugnis einlagern"
 msgid "Strength"
 msgstr "Stärke"
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Stilvorlage"
 
@@ -8114,7 +7434,6 @@ msgstr "Eingereicht Status"
 msgid "Submit"
 msgstr "Eingereichen"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8157,7 +7476,6 @@ msgstr "Zusammenfassung"
 msgid "Summary account for"
 msgstr "Zusammenfassung Konto für"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr "Sun"
@@ -8190,12 +7508,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr "TOTAL"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8207,9 +7519,6 @@ msgstr "Kennzeichen"
 msgid "Tag:"
 msgstr "Etikett:"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8228,8 +7537,6 @@ msgstr "Steuerkonto"
 msgid "Tax Code"
 msgstr "Steuernummer"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8240,17 +7547,14 @@ msgstr "Steuerformular"
 msgid "Tax Form Applied"
 msgstr "Steuerformular angewandt"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr "Steuerformular detaillierter Bericht"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr "Steuerformularliste"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr "Steuerform"
@@ -8394,7 +7698,6 @@ msgstr "Tel: [_1]"
 msgid "Template"
 msgstr "Vorlagen"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr "Vorlagenauflistung"
@@ -8403,7 +7706,6 @@ msgstr "Vorlagenauflistung"
 msgid "Template Saved!"
 msgstr "Vorlage gespeichert!"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr "Vorlagentransaktion"
@@ -8456,7 +7758,7 @@ msgstr "Danke für Ihr geschätztes Geschäft!"
 msgid "The amount of"
 msgstr "Die Summe von"
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr "Ihr Saldo"
 
@@ -8468,7 +7770,7 @@ msgstr "Deren Kredite"
 msgid "Their Debits"
 msgstr "Deren Belastungen"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8521,24 +7823,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr "Dieses Dokument wurde genehmigt von"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr "Dieser Hauptbucheintrag ist die Folge einer Zahlung"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr "Dieser Hauptbucheintrag ist die Folge einer Ãœberzahlung"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8561,14 +7860,10 @@ msgstr "Schwellenwert"
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr "Don"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8612,7 +7907,6 @@ msgstr "Zeitkarte"
 msgid "Timecard Criteria"
 msgstr "Zeitkartenkriterien"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr "Zeitkontrollkarten"
@@ -8642,19 +7936,10 @@ msgstr ""
 msgid "To"
 msgstr "An"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr "Zu Betrag"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8691,7 +7976,6 @@ msgstr "An E-mail"
 msgid "To my browser"
 msgstr "Zu meinem Browser"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr "Zu zahlen"
@@ -8716,16 +8000,7 @@ msgstr "Alle Kontrollkästchen zum Entfernen umschalten"
 msgid "Top-level"
 msgstr "Höchststufe"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8768,7 +8043,7 @@ msgstr "Höchststufe"
 msgid "Total"
 msgstr "Gesamtsumme"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr "Summe Gesamtabschreibungen"
 
@@ -8776,7 +8051,6 @@ msgstr "Summe Gesamtabschreibungen"
 msgid "Total Outstanding"
 msgstr "Total ausstehend"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr "Gesamtzahlbetrag"
@@ -8797,7 +8071,6 @@ msgstr "Transaktion"
 msgid "Transaction Approval"
 msgstr " Transaktionsbestätigung"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8813,14 +8086,12 @@ msgstr "Datum der Transaktion fehlt!"
 msgid "Transaction Dates"
 msgstr "Transaktionsdatum"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr "Transaktionstyp"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8859,7 +8130,6 @@ msgstr "Übersetzungen"
 msgid "Translations saved!"
 msgstr "Ãœbersetzungen gespeichert!"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Saldenbilanz"
@@ -8868,7 +8138,6 @@ msgstr "Saldenbilanz"
 msgid "Trillion"
 msgstr "billion"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr "Die"
@@ -8925,10 +8194,6 @@ msgstr "Zweiundzwanzig"
 msgid "Two"
 msgstr "zwei"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8963,39 +8228,33 @@ msgstr "Nicht genehmigt"
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr "Unerwarteter Dateiname, erwartete [_1], aber [_2] erhalten"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr "Einzigartige ausstehende Rechnungsnummern"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr "Einzigartige Kundennummer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr "Einzigartige Lieferantennummer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr "Einzigartige nicht veraltete Teilnummer"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -9014,43 +8273,37 @@ msgstr "Einheit"
 msgid "Unit Price"
 msgstr "Einzelpreis"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr "Unbekannt"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr "Unbekannter Diagrammtyp; sollte H(eader)/A(ccount) sein"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr "Unbekannte Datenbank gefunden."
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr "Freischalten"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr "Stapel freischalten"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr "Nicht unterstützte LedgerSMB Version erkannt."
 
@@ -9058,23 +8311,18 @@ msgstr "Nicht unterstützte LedgerSMB Version erkannt."
 msgid "Unsupported Number"
 msgstr "Nicht unterstützte Nummer"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr "Nicht unterstützte SQL-Ledger Version."
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr "Nicht unterstützte Kontokategorien"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr "Nicht unterstützte Kombination der Kontoverknüpfung"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr "NichtunterstÃ¼tzte Kontenart"
@@ -9091,7 +8339,6 @@ msgstr "unbenutzt"
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9119,21 +8366,16 @@ msgstr "Upgrade-Information"
 msgid "Upload"
 msgstr "Hochladen"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr "hochgeladen bei"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr "hochgeladen von"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9142,7 +8384,6 @@ msgstr ""
 msgid "Url"
 msgstr "Url"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9160,24 +8401,19 @@ msgstr "Überzahlung nutzen"
 msgid "Use Shipto"
 msgstr "Verwenden Sie die Lieferadresse"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr "Ãœberzahlung/Anzahlung nutzen"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr "Gebraucht"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9187,7 +8423,6 @@ msgstr "Benutzer"
 msgid "User Name"
 msgstr "Benutzername"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr "Benutzer besteht bereits. Importieren?"
@@ -9208,7 +8443,6 @@ msgstr "Benutzername"
 msgid "Users"
 msgstr "Benutzer"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9234,8 +8468,6 @@ msgstr "GÃ¼ltig bis"
 msgid "Valuation"
 msgstr "Bewertung"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9245,11 +8477,7 @@ msgstr "Abweichung"
 msgid "Variance:"
 msgstr "Unterschied:"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9265,7 +8493,6 @@ msgstr "Unterschied:"
 msgid "Vendor"
 msgstr "Lieferant"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr "Lieferantenkonto"
@@ -9279,7 +8506,6 @@ msgstr "Alle Belege für Lieferant"
 msgid "Vendor Invoice"
 msgstr "Lieferantenrechnung"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr "Lieferantenrechnung/Lieferantenverbindlichkeiten Transaktionsnummer"
@@ -9289,9 +8515,6 @@ msgstr "Lieferantenrechnung/Lieferantenverbindlichkeiten Transaktionsnummer"
 msgid "Vendor Name"
 msgstr "Lieferantenname"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9321,9 +8544,7 @@ msgstr "Lieferantensuche"
 msgid "Vendor missing!"
 msgstr "Lieferant fehlt!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9331,8 +8552,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Lieferant nicht in der Datei!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9347,7 +8566,6 @@ msgstr ""
 msgid "Void"
 msgstr "Stornieren"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr "Belegliste"
@@ -9360,7 +8578,6 @@ msgstr "Gutschein"
 msgid "Wages and Deductions"
 msgstr "Löhne und Abzüge"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr "LÃ¶hne/Absetzungen"
@@ -9383,7 +8600,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Warenlager"
@@ -9392,11 +8608,31 @@ msgstr "Warenlager"
 msgid "Warning!"
 msgstr "Warnung!"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+#, fuzzy
+msgid "Warning: Your password will expire in [_1] days"
 msgstr "Warnung: Ihr Passwort läuft in [_1] ab"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+#, fuzzy
+msgid "Warning: Your password will expire in [_1] months"
+msgstr "Warnung: Ihr Passwort läuft in [_1] ab"
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+#, fuzzy
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr "Warnung: Ihr Passwort läuft in [_1] ab"
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+#, fuzzy
+msgid "Warning: Your password will expire in [_1] years"
+msgstr "Warnung: Ihr Passwort läuft in [_1] ab"
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+#, fuzzy
+msgid "Warning: Your password will expire today"
+msgstr "Warnung: Ihr Passwort läuft in [_1] ab"
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr "Mit"
@@ -9406,7 +8642,6 @@ msgstr "Mit"
 msgid "Week"
 msgstr "Woche"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr "Woche begonnen am"
@@ -9423,13 +8658,11 @@ msgstr ""
 msgid "Weeks"
 msgstr "Wochen"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Gewicht"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Gewichtseinheit"
@@ -9446,7 +8679,6 @@ msgstr "Wohin sollen wir die Datensicherung schicken?"
 msgid "Whole Month Straight Line"
 msgstr "Ganzer Monat geradlinig"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr "Widgit Themen"
@@ -9464,11 +8696,11 @@ msgstr "Arbeitsblatt"
 msgid "Work order"
 msgstr "Arbeitsblatt"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9511,16 +8743,10 @@ msgstr "Jahresabschluss beendet"
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Ja"
-
-#: UI/users/preferences.html:52
-#, fuzzy
-msgid "Your password will expire in [_1]"
-msgstr "Warnung: Ihr Passwort läuft in [_1] ab"
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9547,7 +8773,7 @@ msgstr "Postleitzahl:"
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9613,17 +8839,12 @@ msgstr "Tage"
 msgid "debits"
 msgstr "Belastungen"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr "lÃ¶schen"
 
@@ -9640,7 +8861,7 @@ msgstr ""
 msgid "done"
 msgstr "Erledigt"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9668,8 +8889,6 @@ msgstr "importieren"
 msgid "in months"
 msgstr "in Monaten"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9678,22 +8897,18 @@ msgstr ""
 msgid "in years"
 msgstr "in Jahren"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr "ist grÃ¶sser als der verfÃ¼gbare Betrag"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr "ist kleiner als 0"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr "ist weniger als der zu zahlende Betrag"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr "ist null"
@@ -9718,7 +8933,6 @@ msgstr "Produktion"
 msgid "sent"
 msgstr "gesendet"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 #, fuzzy
 msgid "system type"
@@ -9744,8 +8958,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr "unerwarteter Fehler!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr "Nutzen einer Ãœberzahlung"
@@ -9818,6 +9030,13 @@ msgstr "Nutzen einer Ãœberzahlung"
 
 #~ msgid "Version"
 #~ msgstr "Version"
+
+#~ msgid "Warning:  Your password will expire in [_1]"
+#~ msgstr "Warnung: Ihr Passwort läuft in [_1] ab"
+
+#, fuzzy
+#~ msgid "Your password will expire in [_1]"
+#~ msgstr "Warnung: Ihr Passwort läuft in [_1] ab"
 
 #~ msgid "cash"
 #~ msgstr "Bar"

--- a/locale/po/de_CH.po
+++ b/locale/po/de_CH.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: German (Switzerland) (http://www.transifex.com/ledgersmb/"
@@ -15,27 +15,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -48,12 +43,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -99,7 +90,6 @@ msgstr "Verbindlichkeiten"
 msgid "AP Aging"
 msgstr "Offene Verbindl."
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -108,7 +98,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -123,7 +112,6 @@ msgstr "Offene Verbindlichkeiten"
 msgid "AP Transaction"
 msgstr "Eingangsbuchung"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Eingangsbuchungen"
@@ -136,9 +124,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -157,7 +143,6 @@ msgstr "Forderungen"
 msgid "AR Aging"
 msgstr "Forderungenspiegel"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -166,7 +151,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -181,7 +165,6 @@ msgstr "Offene Forderungen"
 msgid "AR Transaction"
 msgstr "Ausgangsbuchung"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Ausgangsbuchungen"
@@ -194,9 +177,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -205,8 +186,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Ausgangsbuchung"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -216,16 +195,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -251,38 +225,20 @@ msgstr ""
 msgid "Account"
 msgstr "Konto"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -303,23 +259,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Kontonummer"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -359,17 +310,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -381,7 +330,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -409,12 +358,10 @@ msgstr "Aktiv"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -437,11 +384,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr "Erzeugnis erfassen"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -566,7 +513,6 @@ msgstr "Auftragsbestätigung"
 msgid "Add Service"
 msgstr "Dienstleistung erfassen"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -633,7 +579,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Erneuern"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -658,7 +603,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -668,12 +612,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -693,8 +636,7 @@ msgstr ""
 msgid "Aged"
 msgstr "Veraltet"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -747,7 +689,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr "Zugeteilt"
@@ -756,11 +697,6 @@ msgstr "Zugeteilt"
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -794,14 +730,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Betrag"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -810,27 +742,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Betrag fällig"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -848,14 +774,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -874,17 +800,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -893,13 +816,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -908,7 +824,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -917,14 +832,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -936,19 +849,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Apr"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "April"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -964,7 +874,6 @@ msgstr "Soll die Offerte mit folgender Nummer wirklich gelöscht werden:"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -983,19 +892,17 @@ msgstr "Erzeugnisse wieder eingelagert!"
 msgid "Asset"
 msgstr "Aktiva/Mittelverwendung"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1008,29 +915,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1046,7 +950,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1144,8 +1047,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Aug"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "August"
 
@@ -1157,7 +1059,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1171,7 +1072,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1184,7 +1084,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr "Durchschnittskosten"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1218,8 +1117,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1234,7 +1131,6 @@ msgstr "Bilanz"
 msgid "Balance Sheet"
 msgstr "Bilanz"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1255,7 +1151,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1266,7 +1161,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1276,18 +1170,15 @@ msgstr "Währung"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1300,12 +1191,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1322,13 +1211,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1369,8 +1256,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1417,17 +1302,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1440,12 +1322,10 @@ msgstr ""
 msgid "Business"
 msgstr "Branche"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Firmennummer"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1455,12 +1335,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1482,7 +1360,6 @@ msgstr "Branche gespeichert!"
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1514,18 +1391,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1657,12 +1532,11 @@ msgstr "Passwort ändern"
 msgid "Chargeable"
 msgstr "Verrechenbar"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Kontenübersicht"
 
@@ -1682,7 +1556,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "Inventar prüfen"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1711,7 +1584,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1723,9 +1596,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "Entlastet"
 
@@ -1753,15 +1626,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Geschlossen"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1775,8 +1646,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1791,22 +1660,18 @@ msgstr "Sprachcode fehlt!"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1818,39 +1683,31 @@ msgstr ""
 msgid "Company"
 msgstr "Firmenname"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Firmenname"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1871,7 +1728,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Bestätigen Sie!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1889,7 +1746,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Kontakt"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1905,7 +1761,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1923,9 +1778,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1955,7 +1807,6 @@ msgstr ""
 msgid "Contra"
 msgstr "Gegenkonto"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1963,10 +1814,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1997,20 +1844,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Kosten"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2026,26 +1869,20 @@ msgstr "Konnte nicht gespeichert werden!"
 msgid "Could not transfer Inventory!"
 msgstr "Inventar wurde nicht übertragen!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2057,7 +1894,6 @@ msgstr ""
 msgid "Country"
 msgstr "Land"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2070,7 +1906,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2078,11 +1914,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2110,8 +1946,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2119,17 +1953,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Haben"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2154,29 +1985,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Währung"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2199,18 +2020,14 @@ msgstr "Währung"
 msgid "Currency"
 msgstr "Währung"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Aktuell"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2220,11 +2037,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2239,7 +2052,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Kunde"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2258,9 +2070,6 @@ msgstr "Kunde ist nicht in der Datenbank!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2280,9 +2089,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "Kundenname fehlt!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2294,7 +2101,7 @@ msgstr "Kunde ist nicht in der Datenbank!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2318,12 +2125,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2356,28 +2162,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2424,19 +2218,14 @@ msgstr ""
 msgid "Date"
 msgstr "Datum"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2458,7 +2247,6 @@ msgstr "Eingangsdatum"
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2522,8 +2310,6 @@ msgstr "Tage"
 msgid "Days"
 msgstr "Tage"
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2539,10 +2325,8 @@ msgstr "Debit Invoice"
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2552,17 +2336,14 @@ msgstr ""
 msgid "Dec"
 msgstr "Dez"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Dezember"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2572,7 +2353,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2585,47 +2365,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2638,21 +2409,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "Einstellungen"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2670,7 +2434,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Löschen"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2683,7 +2446,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr "Zeitplan löschen"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2697,37 +2459,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Lieferdatum"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2749,20 +2507,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2773,46 +2528,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2923,12 +2639,10 @@ msgstr "Einzelheiten"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2941,7 +2655,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2950,7 +2663,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Rabatt"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2959,28 +2671,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2988,7 +2700,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2997,7 +2708,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -3005,12 +2716,10 @@ msgstr ""
 msgid "Done"
 msgstr "Fertig"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3023,12 +2732,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3037,19 +2744,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Zeichnung"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3065,10 +2769,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3087,7 +2787,7 @@ msgstr "Fälligkeitsdatum fehlt!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3113,7 +2813,7 @@ msgstr "E-Mail-Nachricht "
 msgid "E-mailed"
 msgstr "E-Mail gesendet"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3143,7 +2843,7 @@ msgstr "Ausgangsbuchung bearbeiten"
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3287,8 +2987,6 @@ msgstr ""
 msgid "Email"
 msgstr "E-Mail"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3302,7 +3000,6 @@ msgstr "E-Mail"
 msgid "Employee"
 msgstr "Verkäufer"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3312,12 +3009,11 @@ msgstr "Mitarbeiternummer"
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3327,37 +3023,26 @@ msgstr "Mitarbeiternummer"
 msgid "Employees"
 msgstr "Mitarbeiter"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3381,7 +3066,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3406,12 +3090,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3421,7 +3103,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3429,7 +3111,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3455,7 +3136,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Firmenname"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3467,14 +3148,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Passiva/Eigenkapital"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3488,16 +3166,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3505,7 +3182,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3518,8 +3195,6 @@ msgstr "Jeden"
 msgid "Exch"
 msgstr "Wkurs."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3534,7 +3209,6 @@ msgstr "Wechselkurs"
 msgid "Exchange rate for payment missing!"
 msgstr "Wechselkurs für Bezahlung fehlt!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3543,7 +3217,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "Wechselkurs fehlt!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3561,13 +3234,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Aufwand/Anlagen"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3645,8 +3315,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Februar"
 
@@ -3662,14 +3331,10 @@ msgstr "fünfzig"
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3680,11 +3345,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3695,7 +3360,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3753,12 +3417,10 @@ msgstr ""
 msgid "For"
 msgstr "für"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Wechselkurserträge"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Wechselkursverluste"
@@ -3767,12 +3429,10 @@ msgstr "Wechselkursverluste"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3789,7 +3449,6 @@ msgstr "vier"
 msgid "Fourteen"
 msgstr "vierzehn"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3808,18 +3467,10 @@ msgstr ""
 msgid "From"
 msgstr "Von"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3840,7 +3491,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr "Vom Lagerhaus"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3851,15 +3501,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3873,10 +3518,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "GIFI"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3897,7 +3540,6 @@ msgstr "GIFI gespeichert!"
 msgid "GL"
 msgstr "Hauptbuch"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr "Hauptbuchreferenz"
@@ -3906,7 +3548,7 @@ msgstr "Hauptbuchreferenz"
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3914,11 +3556,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3927,7 +3568,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3935,9 +3576,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr "Erzeugen"
 
@@ -3953,7 +3593,7 @@ msgstr "Aufträge erstellen"
 msgid "Generate Purchase Orders"
 msgstr "Bestellungen erstellen"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3961,7 +3601,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr "Einkaufsbestellungen erstellen"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3977,12 +3617,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3991,7 +3629,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4065,21 +3702,6 @@ msgstr ""
 msgid "Hundred"
 msgstr "hundert"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4110,7 +3732,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4120,13 +3741,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Bild"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4169,7 +3788,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4203,14 +3821,10 @@ msgstr "In Aufklapp-Menü aufnehmen"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4218,12 +3832,10 @@ msgstr ""
 msgid "Income"
 msgstr "Ertrag"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4234,7 +3846,6 @@ msgstr "Gewinn- und Verlustrechnung"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4244,7 +3855,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Gewinn- und Verlustrechnung"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4264,11 +3874,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4278,30 +3887,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "Interne Notizen"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4311,17 +3916,14 @@ msgstr "Inventar"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4349,11 +3951,7 @@ msgstr "Inventar gespeichert!"
 msgid "Inventory transferred!"
 msgstr "Inventar übertragen"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4395,8 +3993,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4412,11 +4008,6 @@ msgstr "Rechnungsdatum fehlt!"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4435,7 +4026,6 @@ msgstr "Rechnungsnummer"
 msgid "Invoice Number missing!"
 msgstr "Rechnungsnummer fehlt!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4465,12 +4055,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4528,8 +4116,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Jan"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Januar"
 
@@ -4558,8 +4145,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Juli"
 
@@ -4567,8 +4153,8 @@ msgstr "Juli"
 msgid "Jun"
 msgstr "Jun"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Juni"
 
@@ -4581,10 +4167,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "LaTeX Vorlagen"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4606,15 +4188,12 @@ msgstr "Gestehungskosten"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Sprache"
@@ -4635,7 +4214,6 @@ msgstr "Sprachen nicht definiert!"
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4646,7 +4224,6 @@ msgstr "Letzte Kosten"
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4668,40 +4245,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr "Vorlaufzeit"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4713,9 +4289,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4737,9 +4311,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4753,8 +4325,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4771,7 +4341,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4808,7 +4377,6 @@ msgstr "Sprachen aufzeigen"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4834,7 +4402,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4852,7 +4419,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4873,7 +4439,7 @@ msgstr ""
 msgid "Login"
 msgstr "Benutzername"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4901,45 +4467,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Hersteller"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4961,40 +4520,34 @@ msgstr ""
 msgid "Mar"
 msgstr "Mär"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "März"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Marge"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "Mai"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Notiz"
@@ -5011,7 +4564,6 @@ msgstr "Nachricht"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Abrechnungsmethode"
@@ -5020,7 +4572,6 @@ msgstr "Abrechnungsmethode"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5039,14 +4590,11 @@ msgstr ""
 msgid "Million"
 msgstr "million"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5060,7 +4608,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5073,14 +4620,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Modell"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5098,7 +4643,7 @@ msgstr "Monat(e)"
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5122,14 +4667,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5138,15 +4681,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5165,7 +4699,6 @@ msgstr "Name"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5216,8 +4749,6 @@ msgstr "Nächstes Datum"
 msgid "Next Number"
 msgstr "Nächste Nummer"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5239,12 +4770,10 @@ msgstr "neunzehn"
 msgid "Ninety"
 msgstr "neunzig"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Nein"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5253,7 +4782,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5261,11 +4790,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5273,7 +4802,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5282,11 +4810,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5294,21 +4822,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr "Keine offene Projekte!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5327,12 +4852,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5341,12 +4864,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr "Nicht lagernde Artikel"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5384,11 +4905,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5434,23 +4950,18 @@ msgstr "Es gibt nichts zu übertragen!"
 msgid "Nov"
 msgstr "Nov"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "November"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5481,7 +4992,7 @@ msgstr ""
 msgid "Number"
 msgstr "Artikelnummer"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Zahlenformat"
 
@@ -5502,13 +5013,11 @@ msgstr "LU"
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Ungültig"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5517,8 +5026,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Okt"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Oktober"
 
@@ -5530,9 +5038,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5582,7 +5087,6 @@ msgstr ""
 msgid "Open"
 msgstr "Offen"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5604,9 +5108,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5652,7 +5153,6 @@ msgstr "Bestelldatum fehlt!"
 msgid "Order Entry"
 msgstr "Bestellungen"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5674,7 +5174,6 @@ msgstr "Bestellung gelöscht!"
 msgid "Order generation failed!"
 msgstr "Auftragserstellung fehlgeschlagen!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5696,7 +5195,7 @@ msgstr "Bestellungen erstellt!"
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5742,7 +5241,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5761,10 +5259,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5808,11 +5302,6 @@ msgstr "Verpackungslistennummer fehlt!"
 msgid "Packing list"
 msgstr "Packliste"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5830,12 +5319,10 @@ msgstr "Bezahlt"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Artikel"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5845,14 +5332,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5882,14 +5361,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5905,15 +5380,12 @@ msgstr "Materialnummer"
 msgid "Parts"
 msgstr "Artikel"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5923,7 +5395,6 @@ msgstr ""
 msgid "Password"
 msgstr "Passwort"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5936,7 +5407,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5950,7 +5420,6 @@ msgstr ""
 msgid "Payables"
 msgstr "Verbindlichkeiten"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5959,7 +5428,6 @@ msgstr "Verbindlichkeiten"
 msgid "Payment"
 msgstr "Belastung"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5972,7 +5440,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5989,7 +5456,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6025,15 +5491,15 @@ msgstr "Zahlungen"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6052,7 +5518,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6083,108 +5548,88 @@ msgstr "Lagerliste"
 msgid "Pick list"
 msgstr "Lagerliste"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6200,7 +5645,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6209,24 +5653,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6235,13 +5677,11 @@ msgstr ""
 msgid "Post"
 msgstr "Buchen"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6282,7 +5722,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Postscript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6320,20 +5759,16 @@ msgstr ""
 msgid "Price"
 msgstr "Preis"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6369,8 +5804,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6380,7 +5813,6 @@ msgstr ""
 msgid "Print"
 msgstr "Drucken"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6397,7 +5829,7 @@ msgstr "Drucken und als neu speichern"
 msgid "Printed"
 msgstr "Gedruckt"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Standardrucker"
 
@@ -6441,17 +5873,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6480,7 +5910,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6499,7 +5928,6 @@ msgstr "Übersetzung für Projektbeschreibungen"
 msgid "Project Number"
 msgstr "Projektnummer"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6508,9 +5936,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Projekte"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6520,7 +5945,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6538,22 +5962,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Einkaufsbestellung"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "Einkaufsbestellnummer"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Einkaufsbestellungen"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6568,14 +5986,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Einkaufsbestellung"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6606,7 +6020,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Menge"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6620,8 +6033,6 @@ msgstr "Anzahl ist grösser als der Lagerbestand!"
 msgid "Quarter"
 msgstr "Quartal"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6658,9 +6069,7 @@ msgstr "Offertenummer fehlt!"
 msgid "Quotation deleted!"
 msgstr "Offerte gelöscht!"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6681,25 +6090,20 @@ msgstr "Offertanfrage"
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "Einkaufsoffertennummer"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "Offerteanfragen"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "Lagerbestand Untergrenze"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6711,7 +6115,6 @@ msgstr "%"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6734,13 +6137,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6758,7 +6157,6 @@ msgstr "Quittung"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6772,8 +6170,7 @@ msgstr "Quittungen"
 msgid "Receivables"
 msgstr "Forderungen"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Einlagern"
 
@@ -6781,7 +6178,6 @@ msgstr "Einlagern"
 msgid "Receive Merchandise"
 msgstr "Artikeln einlagern"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6802,7 +6198,6 @@ msgstr "Kontenabgleich"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6823,13 +6218,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Wiederkehrende Buchungen"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6868,12 +6256,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6911,7 +6297,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6923,7 +6309,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6936,7 +6322,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6986,7 +6371,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -7006,13 +6391,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Erforderlich bis am"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7042,7 +6424,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7051,7 +6432,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7068,7 +6448,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7118,11 +6497,11 @@ msgstr "Lagerhaltungseinheit"
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7148,7 +6527,6 @@ msgstr "Warenverkauf"
 msgid "Sales Invoice"
 msgstr "Ausgangsrechnung"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Verkaufsrechnung-/Buchungsnummer"
@@ -7164,20 +6542,17 @@ msgstr "Verkaufsrechnung-/Buchungsnummer"
 msgid "Sales Order"
 msgstr "Auftragsbestätigung"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "Auftragsbestätigungsnummer"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Auftragsbestätigungen"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "Offertennummer"
@@ -7200,9 +6575,6 @@ msgstr "Offertennummer"
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7226,13 +6598,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7252,7 +6621,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7262,7 +6631,6 @@ msgstr "Speichern"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7321,11 +6689,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "als neu speichern"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7348,10 +6715,8 @@ msgstr "Buchungstermine"
 msgid "Scheduled"
 msgstr "geplant"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Bildschirm"
 
@@ -7371,7 +6736,6 @@ msgstr "Bildschirm"
 msgid "Search"
 msgstr "Suchen"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7380,7 +6744,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7433,11 +6796,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7449,11 +6812,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7465,7 +6828,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7473,7 +6836,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7529,7 +6891,6 @@ msgstr "Text, Postscript oder PDF auswählen!"
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7538,9 +6899,6 @@ msgstr ""
 msgid "Sell"
 msgstr "Verkaufspreis"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7594,13 +6952,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Sep"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "September"
 
@@ -7621,9 +6977,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "Seriennummer"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7653,7 +7006,6 @@ msgstr "Dienstleistungscode"
 msgid "Services"
 msgstr "Dienstleistung"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 #, fuzzy
 msgid "Session Timeout (e.g. \"90 minutes\")"
@@ -7667,7 +7019,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7687,10 +7039,10 @@ msgstr "siebzehn"
 msgid "Seventy"
 msgstr "siebzig"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Versenden"
 
@@ -7717,10 +7069,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7781,10 +7129,6 @@ msgstr "Versanddatum fehlt!"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7826,7 +7170,6 @@ msgstr "Versanddatum"
 msgid "Short"
 msgstr "Kurz"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7867,7 +7210,6 @@ msgstr "sechzig"
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7880,12 +7222,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7912,7 +7248,6 @@ msgstr "Beleg"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7934,21 +7269,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Standard"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "Standard Industrie Norm"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7979,8 +7303,6 @@ msgstr ""
 msgid "Startdate"
 msgstr "Eintrittsdatum"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8017,13 +7339,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Zahlungserinnerung"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Auszugsbilanz"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8054,7 +7374,7 @@ msgstr "Erzeugnis einlagern"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Stilvorlage"
 
@@ -8079,7 +7399,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8122,7 +7441,6 @@ msgstr "Zusammenfassung"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8155,12 +7473,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8172,9 +7484,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8193,8 +7502,6 @@ msgstr "MWST-Konto"
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8205,17 +7512,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8359,7 +7663,6 @@ msgstr ""
 msgid "Template"
 msgstr "HTML Vorlagen"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8368,7 +7671,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8421,7 +7723,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8433,7 +7735,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8484,24 +7786,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8524,14 +7823,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8575,7 +7870,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8605,19 +7899,10 @@ msgstr ""
 msgid "To"
 msgstr "Bis"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8654,7 +7939,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8679,16 +7963,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8731,7 +8006,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8739,7 +8014,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8760,7 +8034,6 @@ msgstr "Buchung"
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8776,14 +8049,12 @@ msgstr "Buchungsdatum fehlt!"
 msgid "Transaction Dates"
 msgstr "Buchungsdaten"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8822,7 +8093,6 @@ msgstr "Übersetzungen"
 msgid "Translations saved!"
 msgstr "Übersetzung gespeichert!"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Saldenbilanz"
@@ -8831,7 +8101,6 @@ msgstr "Saldenbilanz"
 msgid "Trillion"
 msgstr "billion"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8888,10 +8157,6 @@ msgstr ""
 msgid "Two"
 msgstr "zwei"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8926,39 +8191,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8977,43 +8236,37 @@ msgstr "Einheit"
 msgid "Unit Price"
 msgstr "Preis pro Einheit"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9021,23 +8274,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9054,7 +8302,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9082,21 +8329,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9105,7 +8347,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9123,24 +8364,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9150,7 +8386,6 @@ msgstr "Datenbankbenutzer"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9171,7 +8406,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9197,8 +8431,6 @@ msgstr "Gültig bis"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9208,11 +8440,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9228,7 +8456,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Lieferant"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9242,7 +8469,6 @@ msgstr "Alle Belege für Lieferant"
 msgid "Vendor Invoice"
 msgstr "Einkaufsrechnung"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr "Einkaufsrechnungs-/Buchungsnummer"
@@ -9252,9 +8478,6 @@ msgstr "Einkaufsrechnungs-/Buchungsnummer"
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9284,9 +8507,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "Lieferant fehlt!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9294,8 +8515,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Lieferant ist nicht in der Datenbank!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9310,7 +8529,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9323,7 +8541,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9346,7 +8563,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Warenlager"
@@ -9355,11 +8571,26 @@ msgstr "Warenlager"
 msgid "Warning!"
 msgstr "Warnung!"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9369,7 +8600,6 @@ msgstr ""
 msgid "Week"
 msgstr "Woche"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9386,13 +8616,11 @@ msgstr ""
 msgid "Weeks"
 msgstr "Wochen"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Gewicht"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Gewichtseinheit"
@@ -9409,7 +8637,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9427,11 +8654,11 @@ msgstr "Arbeitsblatt"
 msgid "Work order"
 msgstr "Arbeitsblatt"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9474,15 +8701,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Ja"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9509,7 +8731,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9573,17 +8795,12 @@ msgstr "Tage"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9600,7 +8817,7 @@ msgstr ""
 msgid "done"
 msgstr "fertig"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9628,8 +8845,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9638,22 +8853,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9678,7 +8889,6 @@ msgstr ""
 msgid "sent"
 msgstr "verschickt"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9703,8 +8913,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr "unerwarteter Fehler!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/el.po
+++ b/locale/po/el.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Greek (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -15,27 +15,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -48,12 +43,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -99,7 +90,6 @@ msgstr "Αγορές"
 msgid "AP Aging"
 msgstr "Creditor Aging"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -108,7 +98,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -123,7 +112,6 @@ msgstr ""
 msgid "AP Transaction"
 msgstr "Κινήση Αγοράς"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Κινήσεις Αγορών"
@@ -136,9 +124,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -157,7 +143,6 @@ msgstr "Πωλήσεις"
 msgid "AR Aging"
 msgstr "Debtor Aging"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -166,7 +151,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -181,7 +165,6 @@ msgstr ""
 msgid "AR Transaction"
 msgstr "Κινήσεις Πωλήσεων"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Κινήσεις Πωλήσεων"
@@ -194,9 +177,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -205,8 +186,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Κινήσεις Πωλήσεων"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -216,16 +195,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -251,38 +225,20 @@ msgstr ""
 msgid "Account"
 msgstr "Λογαριασμός"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -303,23 +259,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Κωδικός Λογαριασμού"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -359,17 +310,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -381,7 +330,7 @@ msgstr "Αύξηση"
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -409,12 +358,10 @@ msgstr "Ενεργός"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -437,11 +384,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -566,7 +513,6 @@ msgstr "Προσθήκη Παραγγελίας"
 msgid "Add Service"
 msgstr "Προσθήκη υπηρεσίας"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -632,7 +578,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -657,7 +602,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -667,12 +611,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -692,8 +635,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -745,7 +687,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -754,11 +695,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -792,14 +728,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Ποσό"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -808,27 +740,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -846,14 +772,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -872,17 +798,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -891,13 +814,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -906,7 +822,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -915,14 +830,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -934,19 +847,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Απρ"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "Απρίλιος"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -962,7 +872,6 @@ msgstr ""
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -980,19 +889,17 @@ msgstr ""
 msgid "Asset"
 msgstr "Πάγιο"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1005,29 +912,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1043,7 +947,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1141,8 +1044,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Αυγ"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Αύγουστος"
 
@@ -1154,7 +1056,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1168,7 +1069,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1181,7 +1081,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1215,8 +1114,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1231,7 +1128,6 @@ msgstr "Ισοζύγιο"
 msgid "Balance Sheet"
 msgstr "Ισοζύγιο"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1252,7 +1148,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1263,7 +1158,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1273,18 +1167,15 @@ msgstr "Συνάλλαγμα"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1297,12 +1188,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1319,13 +1208,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1366,8 +1253,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1413,17 +1298,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1436,12 +1318,10 @@ msgstr ""
 msgid "Business"
 msgstr "Επιχείρηση"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Κωδικός Επιχείρησης"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1451,12 +1331,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1478,7 +1356,6 @@ msgstr ""
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1510,18 +1387,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1647,12 +1522,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Γράφημα των Κωδικών"
 
@@ -1672,7 +1546,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "Έλεγχος Απογραφής"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1701,7 +1574,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1713,9 +1586,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr ""
 
@@ -1743,15 +1616,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Κλεισμένο"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1765,8 +1636,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1781,22 +1650,18 @@ msgstr "Ο Κωδικός λείπει"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1808,39 +1673,31 @@ msgstr ""
 msgid "Company"
 msgstr "Εταιρία"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Όνομα εταιρίας"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1861,7 +1718,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Επιβεβαίωση!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1879,7 +1736,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Επαφή"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1895,7 +1751,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1913,9 +1768,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1945,7 +1797,6 @@ msgstr ""
 msgid "Contra"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1953,10 +1804,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1987,20 +1834,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Κόστος"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2016,26 +1859,20 @@ msgstr "Η αποθήκευση δεν είναι δυνατή"
 msgid "Could not transfer Inventory!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2047,7 +1884,6 @@ msgstr ""
 msgid "Country"
 msgstr "Χώρα"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2060,7 +1896,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2068,11 +1904,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2100,8 +1936,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2109,17 +1943,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Πίστωση"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2144,29 +1975,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2189,18 +2010,14 @@ msgstr ""
 msgid "Currency"
 msgstr "Συνάλλαγμα"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Τρέχων"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2210,11 +2027,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2229,7 +2042,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Πελάτης"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2248,9 +2060,6 @@ msgstr "Debtor not on file!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2270,9 +2079,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "Ο Πελάτης λείπει!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2284,7 +2091,7 @@ msgstr "Debtor not on file!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2308,12 +2115,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2346,28 +2152,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2414,19 +2208,14 @@ msgstr ""
 msgid "Date"
 msgstr "Ημερομηνία"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2448,7 +2237,6 @@ msgstr ""
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2512,8 +2300,6 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2529,10 +2315,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2542,17 +2326,14 @@ msgstr ""
 msgid "Dec"
 msgstr "Δεκ"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Δεκέμβριος"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2562,7 +2343,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2575,47 +2355,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2628,21 +2399,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "Προεπιλογές"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2660,7 +2424,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Διαγραφή"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2673,7 +2436,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2687,37 +2449,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2739,20 +2497,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2763,46 +2518,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2913,12 +2629,10 @@ msgstr "Λεπτομέρεια"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2931,7 +2645,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2940,7 +2653,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Έκπτωση"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2949,28 +2661,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2978,7 +2690,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2987,7 +2698,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -2995,12 +2706,10 @@ msgstr ""
 msgid "Done"
 msgstr "Εντάξει"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3013,12 +2722,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3027,19 +2734,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Σχέδιο"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3055,10 +2759,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3077,7 +2777,7 @@ msgstr "Η ημερομηνία λήξης λείπει"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3103,7 +2803,7 @@ msgstr ""
 msgid "E-mailed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3133,7 +2833,7 @@ msgstr ""
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3277,8 +2977,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3292,7 +2990,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Υπάλληλος"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3302,12 +2999,11 @@ msgstr "Αρ. Υπαλλήλου"
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3317,37 +3013,26 @@ msgstr "Αρ. Υπαλλήλου"
 msgid "Employees"
 msgstr "Υπάλληλοι"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3371,7 +3056,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3396,12 +3080,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3411,7 +3093,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3419,7 +3101,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3445,7 +3126,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Όνομα εταιρίας"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3457,14 +3138,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Επιείκια"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3478,16 +3156,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3495,7 +3172,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3508,8 +3185,6 @@ msgstr ""
 msgid "Exch"
 msgstr "Συναλλ"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3524,7 +3199,6 @@ msgstr "Τιμή συναλλάγματος"
 msgid "Exchange rate for payment missing!"
 msgstr "Η τιμή συναλλάγματος λείπει"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3533,7 +3207,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3551,13 +3224,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Έξοδο/Πάγιο"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3635,8 +3305,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Φεβ"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Φεβρουάριος"
 
@@ -3652,14 +3321,10 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3670,11 +3335,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3685,7 +3350,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3743,12 +3407,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Κέρδος από συνναλαγματική διαφορά "
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Ζημία από συναλλαγματική διαφορά"
@@ -3757,12 +3419,10 @@ msgstr "Ζημία από συναλλαγματική διαφορά"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3779,7 +3439,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3798,18 +3457,10 @@ msgstr ""
 msgid "From"
 msgstr "Από"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3830,7 +3481,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3841,15 +3491,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3863,10 +3508,8 @@ msgstr ""
 msgid "GIFI"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3887,7 +3530,6 @@ msgstr ""
 msgid "GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3896,7 +3538,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3904,11 +3546,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3917,7 +3558,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3925,9 +3566,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3943,7 +3583,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3951,7 +3591,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3967,12 +3607,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3981,7 +3619,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4055,21 +3692,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4100,7 +3722,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4110,13 +3731,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Εικόνα"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4159,7 +3778,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4193,14 +3811,10 @@ msgstr ""
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4208,12 +3822,10 @@ msgstr ""
 msgid "Income"
 msgstr "Εισόδημα"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4224,7 +3836,6 @@ msgstr ""
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4233,7 +3844,6 @@ msgstr ""
 msgid "Income statement"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4253,11 +3863,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4267,30 +3876,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4300,17 +3905,14 @@ msgstr "Απογραφή"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4336,11 +3938,7 @@ msgstr "Η Απογραφή αποθηκεύτηκε"
 msgid "Inventory transferred!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4382,8 +3980,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4399,11 +3995,6 @@ msgstr ""
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4422,7 +4013,6 @@ msgstr "Αρ. τιμολογίου"
 msgid "Invoice Number missing!"
 msgstr "Το τιμολόγιο διαγράφηκε"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4452,12 +4042,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4515,8 +4103,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Ιάν"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Ιανουάριος"
 
@@ -4545,8 +4132,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Ιούλ"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Ιούλιος"
 
@@ -4554,8 +4140,8 @@ msgstr "Ιούλιος"
 msgid "Jun"
 msgstr "Ιούν"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Ιούνιος"
 
@@ -4568,10 +4154,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4593,15 +4175,12 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Γλώσσα"
@@ -4622,7 +4201,6 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4633,7 +4211,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4655,40 +4232,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4700,9 +4276,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4724,9 +4298,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4740,8 +4312,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4758,7 +4328,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4795,7 +4364,6 @@ msgstr "Λίστα γλωσσών"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4821,7 +4389,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4839,7 +4406,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4860,7 +4426,7 @@ msgstr ""
 msgid "Login"
 msgstr "Εισαγωγή"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4888,45 +4454,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4948,40 +4507,34 @@ msgstr ""
 msgid "Mar"
 msgstr "Μαρ"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Μάρτιος"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "Μάϊος"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr ""
@@ -4998,7 +4551,6 @@ msgstr "Μύνημα"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Μέθοδος"
@@ -5007,7 +4559,6 @@ msgstr "Μέθοδος"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5026,14 +4577,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5047,7 +4595,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5060,14 +4607,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Μοντέλο"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5085,7 +4630,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5109,14 +4654,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5125,15 +4668,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5152,7 +4686,6 @@ msgstr "Όνομα"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5203,8 +4736,6 @@ msgstr ""
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5226,12 +4757,10 @@ msgstr ""
 msgid "Ninety"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Όχι"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5240,7 +4769,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5248,11 +4777,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5260,7 +4789,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5269,11 +4797,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5281,21 +4809,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5314,12 +4839,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5328,12 +4851,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5371,11 +4892,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5421,23 +4937,18 @@ msgstr ""
 msgid "Nov"
 msgstr "Νοέ"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "Νοέμβριος"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5468,7 +4979,7 @@ msgstr ""
 msgid "Number"
 msgstr "Αριθμός"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr ""
 
@@ -5489,13 +5000,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Απαρχαιωμένος"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5504,8 +5013,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Οκτ"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Οκτώβριος"
 
@@ -5517,9 +5025,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5569,7 +5074,6 @@ msgstr ""
 msgid "Open"
 msgstr "’νοιγμα"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5591,9 +5095,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5639,7 +5140,6 @@ msgstr ""
 msgid "Order Entry"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5661,7 +5161,6 @@ msgstr "Η Παραγγελία διαγράφηκε"
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5683,7 +5182,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5728,7 +5227,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5747,10 +5245,6 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5793,11 +5287,6 @@ msgstr ""
 msgid "Packing list"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5815,12 +5304,10 @@ msgstr ""
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5830,14 +5317,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5867,14 +5346,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5889,15 +5364,12 @@ msgstr ""
 msgid "Parts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5907,7 +5379,6 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5920,7 +5391,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5934,7 +5404,6 @@ msgstr ""
 msgid "Payables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5943,7 +5412,6 @@ msgstr ""
 msgid "Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5956,7 +5424,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5973,7 +5440,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 msgid "Payment batch"
 msgstr ""
@@ -6008,15 +5474,15 @@ msgstr ""
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6035,7 +5501,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6065,108 +5530,88 @@ msgstr ""
 msgid "Pick list"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6182,7 +5627,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6191,24 +5635,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6217,13 +5659,11 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6264,7 +5704,6 @@ msgstr ""
 msgid "Postscript"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6302,20 +5741,16 @@ msgstr ""
 msgid "Price"
 msgstr "Τιμή"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6351,8 +5786,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6362,7 +5795,6 @@ msgstr ""
 msgid "Print"
 msgstr "Εκτύπωση"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6379,7 +5811,7 @@ msgstr ""
 msgid "Printed"
 msgstr "Εκτυπώθηκε"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Εκτυπωτής"
 
@@ -6423,17 +5855,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6462,7 +5892,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6481,7 +5910,6 @@ msgstr ""
 msgid "Project Number"
 msgstr "Αριθμός έργου"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6490,9 +5918,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Έργα"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6502,7 +5927,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6520,22 +5944,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6549,14 +5967,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6587,7 +6001,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Ποσ."
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6601,8 +6014,6 @@ msgstr ""
 msgid "Quarter"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6639,9 +6050,7 @@ msgstr ""
 msgid "Quotation deleted!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6662,25 +6071,20 @@ msgstr ""
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6692,7 +6096,6 @@ msgstr ""
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 msgid "Rate Type"
 msgstr ""
@@ -6713,13 +6116,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6737,7 +6136,6 @@ msgstr "Απόδειξη"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6751,8 +6149,7 @@ msgstr ""
 msgid "Receivables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr ""
 
@@ -6760,7 +6157,6 @@ msgstr ""
 msgid "Receive Merchandise"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6781,7 +6177,6 @@ msgstr ""
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6802,13 +6197,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6847,12 +6235,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6890,7 +6276,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6902,7 +6288,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6915,7 +6301,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6964,7 +6349,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -6984,13 +6369,10 @@ msgstr ""
 msgid "Required by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7020,7 +6402,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7029,7 +6410,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7046,7 +6426,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7096,11 +6475,11 @@ msgstr ""
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7126,7 +6505,6 @@ msgstr ""
 msgid "Sales Invoice"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7142,20 +6520,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr ""
@@ -7178,9 +6553,6 @@ msgstr "Προσθήκη προσφοράς"
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7204,13 +6576,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7230,7 +6599,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7240,7 +6609,6 @@ msgstr "Αποθήκευση"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7299,11 +6667,10 @@ msgstr ""
 msgid "Save as new"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7326,10 +6693,8 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Οθόνη"
 
@@ -7349,7 +6714,6 @@ msgstr "Οθόνη"
 msgid "Search"
 msgstr "Αναζήτηση"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7358,7 +6722,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7411,11 +6774,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7427,11 +6790,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7443,7 +6806,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7451,7 +6814,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7507,7 +6869,6 @@ msgstr ""
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7516,9 +6877,6 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7572,13 +6930,11 @@ msgstr ""
 msgid "Sep"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr ""
 
@@ -7599,9 +6955,6 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7631,7 +6984,6 @@ msgstr ""
 msgid "Services"
 msgstr "Υπηρεσία"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 msgid "Session Timeout (e.g. \"90 minutes\")"
 msgstr ""
@@ -7644,7 +6996,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7664,10 +7016,10 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr ""
 
@@ -7694,10 +7046,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7758,10 +7106,6 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7802,7 +7146,6 @@ msgstr ""
 msgid "Short"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7843,7 +7186,6 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7856,12 +7198,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7888,7 +7224,6 @@ msgstr "Πηγή"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7910,21 +7245,10 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7955,8 +7279,6 @@ msgstr ""
 msgid "Startdate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -7993,13 +7315,11 @@ msgstr ""
 msgid "Statement"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8029,7 +7349,7 @@ msgstr ""
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr ""
 
@@ -8054,7 +7374,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8097,7 +7416,6 @@ msgstr ""
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8130,12 +7448,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8147,9 +7459,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8168,8 +7477,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8180,17 +7487,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8333,7 +7637,6 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8342,7 +7645,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8395,7 +7697,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8407,7 +7709,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8458,24 +7760,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8498,14 +7797,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8549,7 +7844,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8579,19 +7873,10 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8628,7 +7913,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8653,16 +7937,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8705,7 +7980,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8713,7 +7988,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8734,7 +8008,6 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8750,14 +8023,12 @@ msgstr ""
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8796,7 +8067,6 @@ msgstr ""
 msgid "Translations saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr ""
@@ -8805,7 +8075,6 @@ msgstr ""
 msgid "Trillion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8862,10 +8131,6 @@ msgstr ""
 msgid "Two"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8900,39 +8165,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8951,43 +8210,37 @@ msgstr ""
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -8995,23 +8248,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9028,7 +8276,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9056,21 +8303,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9079,7 +8321,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9097,24 +8338,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9124,7 +8360,6 @@ msgstr ""
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9145,7 +8380,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9171,8 +8405,6 @@ msgstr ""
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9182,11 +8414,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9202,7 +8430,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Creditor"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9216,7 +8443,6 @@ msgstr ""
 msgid "Vendor Invoice"
 msgstr "Creditor Invoice"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9226,9 +8452,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9258,9 +8481,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "Creditor missing!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9268,8 +8489,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Creditor not on file!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9284,7 +8503,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9297,7 +8515,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9320,7 +8537,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr ""
@@ -9329,11 +8545,26 @@ msgstr ""
 msgid "Warning!"
 msgstr ""
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9343,7 +8574,6 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9360,13 +8590,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr ""
@@ -9383,7 +8611,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9400,11 +8627,11 @@ msgstr ""
 msgid "Work order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9447,14 +8674,9 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
-msgstr ""
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
 msgstr ""
 
 #: t/data/04-complex_template.html:388
@@ -9482,7 +8704,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9546,17 +8768,12 @@ msgstr ""
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9573,7 +8790,7 @@ msgstr ""
 msgid "done"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9601,8 +8818,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9611,22 +8826,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9651,7 +8862,6 @@ msgstr ""
 msgid "sent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9676,8 +8886,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/en.po
+++ b/locale/po/en.po
@@ -2,32 +2,27 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.1.1\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -40,12 +35,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -91,7 +82,6 @@ msgstr ""
 msgid "AP Aging"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -100,7 +90,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -115,7 +104,6 @@ msgstr ""
 msgid "AP Transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr ""
@@ -128,9 +116,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -148,7 +134,6 @@ msgstr ""
 msgid "AR Aging"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -157,7 +142,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -172,7 +156,6 @@ msgstr ""
 msgid "AR Transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr ""
@@ -185,9 +168,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -195,8 +176,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -206,16 +185,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -241,38 +215,20 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -293,23 +249,18 @@ msgstr ""
 msgid "Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -349,17 +300,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -371,7 +320,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -399,12 +348,10 @@ msgstr ""
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -427,11 +374,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -556,7 +503,6 @@ msgstr ""
 msgid "Add Service"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -622,7 +568,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -647,7 +592,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -657,12 +601,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -682,8 +625,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -735,7 +677,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -744,11 +685,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -782,14 +718,10 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -798,27 +730,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -836,14 +762,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -862,17 +788,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -881,13 +804,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -896,7 +812,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -905,14 +820,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -924,19 +837,16 @@ msgstr ""
 msgid "Apr"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -952,7 +862,6 @@ msgstr ""
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -970,19 +879,17 @@ msgstr ""
 msgid "Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -995,29 +902,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1033,7 +937,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1131,8 +1034,7 @@ msgstr ""
 msgid "Aug"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr ""
 
@@ -1144,7 +1046,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1158,7 +1059,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1171,7 +1071,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1205,8 +1104,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1221,7 +1118,6 @@ msgstr ""
 msgid "Balance Sheet"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1242,7 +1138,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1253,7 +1148,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 msgid "Base Currency"
 msgstr ""
@@ -1262,18 +1156,15 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1286,12 +1177,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1308,13 +1197,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1355,8 +1242,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1402,17 +1287,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1425,12 +1307,10 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1440,12 +1320,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1467,7 +1345,6 @@ msgstr ""
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1499,18 +1376,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1636,12 +1511,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr ""
 
@@ -1661,7 +1535,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1690,7 +1563,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1702,9 +1575,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr ""
 
@@ -1732,15 +1605,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 msgid "Closing Balance"
 msgstr ""
@@ -1753,8 +1624,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1769,22 +1638,18 @@ msgstr ""
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1796,39 +1661,31 @@ msgstr ""
 msgid "Company"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1849,7 +1706,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1867,7 +1724,6 @@ msgstr ""
 msgid "Contact"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1883,7 +1739,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1901,9 +1756,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1933,7 +1785,6 @@ msgstr ""
 msgid "Contra"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1941,10 +1792,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1975,20 +1822,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2004,26 +1847,20 @@ msgstr ""
 msgid "Could not transfer Inventory!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2035,7 +1872,6 @@ msgstr ""
 msgid "Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2048,7 +1884,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2056,11 +1892,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2088,8 +1924,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2097,17 +1931,14 @@ msgstr ""
 msgid "Credit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2132,29 +1963,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2177,18 +1998,14 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2198,11 +2015,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2217,7 +2030,6 @@ msgstr ""
 msgid "Customer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2235,9 +2047,6 @@ msgstr ""
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2257,9 +2066,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2271,7 +2078,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2295,12 +2102,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2333,28 +2139,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2401,19 +2195,14 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2435,7 +2224,6 @@ msgstr ""
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2499,8 +2287,6 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2516,10 +2302,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2529,17 +2313,14 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2549,7 +2330,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2562,47 +2342,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2615,21 +2386,14 @@ msgstr ""
 msgid "Defaults"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2647,7 +2411,6 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2660,7 +2423,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2674,37 +2436,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2726,20 +2484,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2750,46 +2505,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2900,12 +2616,10 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2918,7 +2632,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2927,7 +2640,6 @@ msgstr ""
 msgid "Discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2936,28 +2648,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2965,7 +2677,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2974,7 +2685,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -2982,12 +2693,10 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3000,12 +2709,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3014,19 +2721,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3042,10 +2746,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3064,7 +2764,7 @@ msgstr ""
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3090,7 +2790,7 @@ msgstr ""
 msgid "E-mailed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3120,7 +2820,7 @@ msgstr ""
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3264,8 +2964,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3279,7 +2977,6 @@ msgstr ""
 msgid "Employee"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3289,12 +2986,11 @@ msgstr ""
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 msgid "Employee wage screen"
 msgstr ""
@@ -3303,37 +2999,26 @@ msgstr ""
 msgid "Employees"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3357,7 +3042,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3382,12 +3066,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3397,7 +3079,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3405,7 +3087,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3430,7 +3111,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3442,14 +3123,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3463,16 +3141,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3480,7 +3157,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3493,8 +3170,6 @@ msgstr ""
 msgid "Exch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3509,7 +3184,6 @@ msgstr ""
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3518,7 +3192,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3536,13 +3209,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3620,8 +3290,7 @@ msgstr ""
 msgid "Feb"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr ""
 
@@ -3637,14 +3306,10 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3655,11 +3320,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3670,7 +3335,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3728,12 +3392,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr ""
@@ -3742,12 +3404,10 @@ msgstr ""
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3764,7 +3424,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3783,18 +3442,10 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3815,7 +3466,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3826,15 +3476,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3848,10 +3493,8 @@ msgstr ""
 msgid "GIFI"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3872,7 +3515,6 @@ msgstr ""
 msgid "GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3881,7 +3523,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3889,11 +3531,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3902,7 +3543,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3910,9 +3551,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3928,7 +3568,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3936,7 +3576,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3952,12 +3592,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3966,7 +3604,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4040,21 +3677,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4085,7 +3707,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4095,13 +3716,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4144,7 +3763,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4178,14 +3796,10 @@ msgstr ""
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4193,12 +3807,10 @@ msgstr ""
 msgid "Income"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4209,7 +3821,6 @@ msgstr ""
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4218,7 +3829,6 @@ msgstr ""
 msgid "Income statement"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4238,11 +3848,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4252,30 +3861,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4285,17 +3890,14 @@ msgstr ""
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4321,11 +3923,7 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4367,8 +3965,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4384,11 +3980,6 @@ msgstr ""
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4407,7 +3998,6 @@ msgstr ""
 msgid "Invoice Number missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4437,12 +4027,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4500,8 +4088,7 @@ msgstr ""
 msgid "Jan"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr ""
 
@@ -4530,8 +4117,7 @@ msgstr ""
 msgid "Jul"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr ""
 
@@ -4539,8 +4125,8 @@ msgstr ""
 msgid "Jun"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr ""
 
@@ -4553,10 +4139,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4578,15 +4160,12 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr ""
@@ -4607,7 +4186,6 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4618,7 +4196,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4640,40 +4217,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4685,9 +4261,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4709,9 +4283,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4725,8 +4297,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4743,7 +4313,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4780,7 +4349,6 @@ msgstr ""
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4806,7 +4374,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4824,7 +4391,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4845,7 +4411,7 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4873,45 +4439,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4933,40 +4492,34 @@ msgstr ""
 msgid "Mar"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr ""
@@ -4983,7 +4536,6 @@ msgstr ""
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr ""
@@ -4992,7 +4544,6 @@ msgstr ""
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5011,14 +4562,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5032,7 +4580,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5045,14 +4592,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5070,7 +4615,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5094,14 +4639,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5110,15 +4653,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5137,7 +4671,6 @@ msgstr ""
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5188,8 +4721,6 @@ msgstr ""
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5211,12 +4742,10 @@ msgstr ""
 msgid "Ninety"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5225,7 +4754,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5233,11 +4762,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5245,7 +4774,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5254,11 +4782,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5266,21 +4794,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5299,12 +4824,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5313,12 +4836,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5356,11 +4877,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5406,23 +4922,18 @@ msgstr ""
 msgid "Nov"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5453,7 +4964,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr ""
 
@@ -5474,13 +4985,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5489,8 +4998,7 @@ msgstr ""
 msgid "Oct"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr ""
 
@@ -5502,9 +5010,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5554,7 +5059,6 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 msgid "Opening Balance"
 msgstr ""
@@ -5575,9 +5079,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5623,7 +5124,6 @@ msgstr ""
 msgid "Order Entry"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5645,7 +5145,6 @@ msgstr ""
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5667,7 +5166,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5712,7 +5211,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5731,10 +5229,6 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5777,11 +5271,6 @@ msgstr ""
 msgid "Packing list"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5799,12 +5288,10 @@ msgstr ""
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5814,14 +5301,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5851,14 +5330,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5873,15 +5348,12 @@ msgstr ""
 msgid "Parts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5891,7 +5363,6 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5904,7 +5375,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5918,7 +5388,6 @@ msgstr ""
 msgid "Payables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5927,7 +5396,6 @@ msgstr ""
 msgid "Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5940,7 +5408,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5957,7 +5424,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 msgid "Payment batch"
 msgstr ""
@@ -5992,15 +5458,15 @@ msgstr ""
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6019,7 +5485,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6049,108 +5514,88 @@ msgstr ""
 msgid "Pick list"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6166,7 +5611,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6175,24 +5619,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6201,13 +5643,11 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6248,7 +5688,6 @@ msgstr ""
 msgid "Postscript"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6285,20 +5724,16 @@ msgstr ""
 msgid "Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6334,8 +5769,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6345,7 +5778,6 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6362,7 +5794,7 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr ""
 
@@ -6406,17 +5838,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6445,7 +5875,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6464,7 +5893,6 @@ msgstr ""
 msgid "Project Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6473,9 +5901,6 @@ msgstr ""
 msgid "Projects"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6485,7 +5910,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6503,22 +5927,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6532,14 +5950,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6570,7 +5984,6 @@ msgstr ""
 msgid "Qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6584,8 +5997,6 @@ msgstr ""
 msgid "Quarter"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6622,9 +6033,7 @@ msgstr ""
 msgid "Quotation deleted!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6645,25 +6054,20 @@ msgstr ""
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6675,7 +6079,6 @@ msgstr ""
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 msgid "Rate Type"
 msgstr ""
@@ -6696,13 +6099,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6720,7 +6119,6 @@ msgstr ""
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6734,8 +6132,7 @@ msgstr ""
 msgid "Receivables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr ""
 
@@ -6743,7 +6140,6 @@ msgstr ""
 msgid "Receive Merchandise"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6764,7 +6160,6 @@ msgstr ""
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6785,13 +6180,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6830,12 +6218,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6873,7 +6259,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6885,7 +6271,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6898,7 +6284,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6947,7 +6332,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -6967,13 +6352,10 @@ msgstr ""
 msgid "Required by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7003,7 +6385,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7012,7 +6393,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7029,7 +6409,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7079,11 +6458,11 @@ msgstr ""
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7109,7 +6488,6 @@ msgstr ""
 msgid "Sales Invoice"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7125,20 +6503,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr ""
@@ -7159,9 +6534,6 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7185,13 +6557,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7211,7 +6580,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7221,7 +6590,6 @@ msgstr ""
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7280,11 +6648,10 @@ msgstr ""
 msgid "Save as new"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7307,10 +6674,8 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr ""
 
@@ -7330,7 +6695,6 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7339,7 +6703,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7392,11 +6755,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7408,11 +6771,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7424,7 +6787,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7432,7 +6795,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7488,7 +6850,6 @@ msgstr ""
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7497,9 +6858,6 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7553,13 +6911,11 @@ msgstr ""
 msgid "Sep"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr ""
 
@@ -7580,9 +6936,6 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7611,7 +6964,6 @@ msgstr ""
 msgid "Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 msgid "Session Timeout (e.g. \"90 minutes\")"
 msgstr ""
@@ -7624,7 +6976,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7644,10 +6996,10 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr ""
 
@@ -7674,10 +7026,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7738,10 +7086,6 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7782,7 +7126,6 @@ msgstr ""
 msgid "Short"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7823,7 +7166,6 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7836,12 +7178,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7868,7 +7204,6 @@ msgstr ""
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7890,21 +7225,10 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7935,8 +7259,6 @@ msgstr ""
 msgid "Startdate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -7973,13 +7295,11 @@ msgstr ""
 msgid "Statement"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8009,7 +7329,7 @@ msgstr ""
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr ""
 
@@ -8034,7 +7354,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8077,7 +7396,6 @@ msgstr ""
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8110,12 +7428,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8127,9 +7439,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8148,8 +7457,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8160,17 +7467,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8313,7 +7617,6 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8322,7 +7625,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8375,7 +7677,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8387,7 +7689,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8438,24 +7740,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8478,14 +7777,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8529,7 +7824,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8559,19 +7853,10 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8608,7 +7893,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8633,16 +7917,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8685,7 +7960,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8693,7 +7968,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8714,7 +7988,6 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8730,14 +8003,12 @@ msgstr ""
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8776,7 +8047,6 @@ msgstr ""
 msgid "Translations saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr ""
@@ -8785,7 +8055,6 @@ msgstr ""
 msgid "Trillion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8842,10 +8111,6 @@ msgstr ""
 msgid "Two"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8880,39 +8145,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8931,43 +8190,37 @@ msgstr ""
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -8975,23 +8228,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9008,7 +8256,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9036,21 +8283,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9059,7 +8301,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9077,24 +8318,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9104,7 +8340,6 @@ msgstr ""
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9125,7 +8360,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9151,8 +8385,6 @@ msgstr ""
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9162,11 +8394,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9182,7 +8410,6 @@ msgstr ""
 msgid "Vendor"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9196,7 +8423,6 @@ msgstr ""
 msgid "Vendor Invoice"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9206,9 +8432,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9238,9 +8461,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9248,8 +8469,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 msgid "Vendor/Customer"
@@ -9263,7 +8482,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9276,7 +8494,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9299,7 +8516,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr ""
@@ -9308,11 +8524,26 @@ msgstr ""
 msgid "Warning!"
 msgstr ""
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9322,7 +8553,6 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9339,13 +8569,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr ""
@@ -9362,7 +8590,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9379,11 +8606,11 @@ msgstr ""
 msgid "Work order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9426,14 +8653,9 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
-msgstr ""
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
 msgstr ""
 
 #: t/data/04-complex_template.html:388
@@ -9461,7 +8683,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9525,17 +8747,12 @@ msgstr ""
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9552,7 +8769,7 @@ msgstr ""
 msgid "done"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9580,8 +8797,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9590,22 +8805,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9630,7 +8841,6 @@ msgstr ""
 msgid "sent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9655,8 +8865,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/en_CA.po
+++ b/locale/po/en_CA.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: English (Canada) (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,27 +15,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -48,12 +43,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -99,7 +90,6 @@ msgstr ""
 msgid "AP Aging"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -108,7 +98,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -123,7 +112,6 @@ msgstr ""
 msgid "AP Transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr ""
@@ -136,9 +124,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -156,7 +142,6 @@ msgstr ""
 msgid "AR Aging"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -165,7 +150,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -180,7 +164,6 @@ msgstr ""
 msgid "AR Transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr ""
@@ -193,9 +176,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -203,8 +184,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -214,16 +193,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -249,38 +223,20 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -301,23 +257,18 @@ msgstr ""
 msgid "Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -357,17 +308,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -379,7 +328,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -407,12 +356,10 @@ msgstr ""
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -435,11 +382,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -564,7 +511,6 @@ msgstr ""
 msgid "Add Service"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -630,7 +576,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -655,7 +600,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -665,12 +609,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -690,8 +633,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -743,7 +685,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -752,11 +693,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -790,14 +726,10 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -806,27 +738,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -844,14 +770,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -870,17 +796,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -889,13 +812,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -904,7 +820,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -913,14 +828,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -932,19 +845,16 @@ msgstr ""
 msgid "Apr"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -960,7 +870,6 @@ msgstr ""
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -978,19 +887,17 @@ msgstr ""
 msgid "Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1003,29 +910,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1041,7 +945,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1139,8 +1042,7 @@ msgstr ""
 msgid "Aug"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr ""
 
@@ -1152,7 +1054,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1166,7 +1067,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1179,7 +1079,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1213,8 +1112,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1229,7 +1126,6 @@ msgstr ""
 msgid "Balance Sheet"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1250,7 +1146,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1261,7 +1156,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 msgid "Base Currency"
 msgstr ""
@@ -1270,18 +1164,15 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1294,12 +1185,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1316,13 +1205,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1363,8 +1250,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1410,17 +1295,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1433,12 +1315,10 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1448,12 +1328,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1475,7 +1353,6 @@ msgstr ""
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1507,18 +1384,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1644,12 +1519,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr ""
 
@@ -1669,7 +1543,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1698,7 +1571,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1710,9 +1583,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr ""
 
@@ -1740,15 +1613,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 msgid "Closing Balance"
 msgstr ""
@@ -1761,8 +1632,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1777,22 +1646,18 @@ msgstr ""
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1804,39 +1669,31 @@ msgstr ""
 msgid "Company"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1857,7 +1714,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1875,7 +1732,6 @@ msgstr ""
 msgid "Contact"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1891,7 +1747,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1909,9 +1764,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1941,7 +1793,6 @@ msgstr ""
 msgid "Contra"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1949,10 +1800,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1983,20 +1830,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2012,26 +1855,20 @@ msgstr ""
 msgid "Could not transfer Inventory!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2043,7 +1880,6 @@ msgstr ""
 msgid "Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2056,7 +1892,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2064,11 +1900,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2096,8 +1932,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2105,17 +1939,14 @@ msgstr ""
 msgid "Credit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2140,29 +1971,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2185,18 +2006,14 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2206,11 +2023,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2225,7 +2038,6 @@ msgstr ""
 msgid "Customer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2243,9 +2055,6 @@ msgstr ""
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2265,9 +2074,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2279,7 +2086,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2303,12 +2110,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2341,28 +2147,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2409,19 +2203,14 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2443,7 +2232,6 @@ msgstr ""
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2507,8 +2295,6 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2524,10 +2310,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2537,17 +2321,14 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2557,7 +2338,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2570,47 +2350,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2623,21 +2394,14 @@ msgstr ""
 msgid "Defaults"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2655,7 +2419,6 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2668,7 +2431,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2682,37 +2444,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2734,20 +2492,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2758,46 +2513,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2908,12 +2624,10 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2926,7 +2640,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2935,7 +2648,6 @@ msgstr ""
 msgid "Discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2944,28 +2656,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2973,7 +2685,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2982,7 +2693,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -2990,12 +2701,10 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3008,12 +2717,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3022,19 +2729,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3050,10 +2754,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3072,7 +2772,7 @@ msgstr ""
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3098,7 +2798,7 @@ msgstr "Email message"
 msgid "E-mailed"
 msgstr "Emailed"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3128,7 +2828,7 @@ msgstr ""
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3272,8 +2972,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3287,7 +2985,6 @@ msgstr ""
 msgid "Employee"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3297,12 +2994,11 @@ msgstr ""
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 msgid "Employee wage screen"
 msgstr ""
@@ -3311,37 +3007,26 @@ msgstr ""
 msgid "Employees"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3365,7 +3050,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3390,12 +3074,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3405,7 +3087,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3413,7 +3095,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3438,7 +3119,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3450,14 +3131,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3471,16 +3149,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3488,7 +3165,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3501,8 +3178,6 @@ msgstr ""
 msgid "Exch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3517,7 +3192,6 @@ msgstr ""
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3526,7 +3200,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3544,13 +3217,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3628,8 +3298,7 @@ msgstr ""
 msgid "Feb"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr ""
 
@@ -3645,14 +3314,10 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3663,11 +3328,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3678,7 +3343,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3736,12 +3400,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr ""
@@ -3750,12 +3412,10 @@ msgstr ""
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3772,7 +3432,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3791,18 +3450,10 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3823,7 +3474,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3834,15 +3484,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3856,10 +3501,8 @@ msgstr ""
 msgid "GIFI"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3880,7 +3523,6 @@ msgstr ""
 msgid "GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3889,7 +3531,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3897,11 +3539,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3910,7 +3551,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3918,9 +3559,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3936,7 +3576,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3944,7 +3584,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3960,12 +3600,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3974,7 +3612,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4048,21 +3685,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4093,7 +3715,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4103,13 +3724,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4152,7 +3771,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4186,14 +3804,10 @@ msgstr ""
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4201,12 +3815,10 @@ msgstr ""
 msgid "Income"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4217,7 +3829,6 @@ msgstr ""
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4226,7 +3837,6 @@ msgstr ""
 msgid "Income statement"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4246,11 +3856,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4260,30 +3869,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4293,17 +3898,14 @@ msgstr ""
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4329,11 +3931,7 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4375,8 +3973,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4392,11 +3988,6 @@ msgstr ""
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4415,7 +4006,6 @@ msgstr ""
 msgid "Invoice Number missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4445,12 +4035,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4508,8 +4096,7 @@ msgstr ""
 msgid "Jan"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr ""
 
@@ -4538,8 +4125,7 @@ msgstr ""
 msgid "Jul"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr ""
 
@@ -4547,8 +4133,8 @@ msgstr ""
 msgid "Jun"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr ""
 
@@ -4561,10 +4147,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4586,15 +4168,12 @@ msgstr "Labour/Overhead"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr ""
@@ -4615,7 +4194,6 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4626,7 +4204,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4648,40 +4225,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4693,9 +4269,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4717,9 +4291,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4733,8 +4305,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4751,7 +4321,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4788,7 +4357,6 @@ msgstr ""
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4814,7 +4382,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4832,7 +4399,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4853,7 +4419,7 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4881,45 +4447,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4941,40 +4500,34 @@ msgstr ""
 msgid "Mar"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr ""
@@ -4991,7 +4544,6 @@ msgstr ""
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr ""
@@ -5000,7 +4552,6 @@ msgstr ""
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5019,14 +4570,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5040,7 +4588,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5053,14 +4600,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5078,7 +4623,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5102,14 +4647,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5118,15 +4661,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5145,7 +4679,6 @@ msgstr ""
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5196,8 +4729,6 @@ msgstr ""
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5219,12 +4750,10 @@ msgstr ""
 msgid "Ninety"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5233,7 +4762,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5241,11 +4770,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5253,7 +4782,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5262,11 +4790,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5274,21 +4802,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5307,12 +4832,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5321,12 +4844,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5364,11 +4885,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5414,23 +4930,18 @@ msgstr ""
 msgid "Nov"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5461,7 +4972,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr ""
 
@@ -5482,13 +4993,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5497,8 +5006,7 @@ msgstr ""
 msgid "Oct"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr ""
 
@@ -5510,9 +5018,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5562,7 +5067,6 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 msgid "Opening Balance"
 msgstr ""
@@ -5583,9 +5087,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5631,7 +5132,6 @@ msgstr ""
 msgid "Order Entry"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5653,7 +5153,6 @@ msgstr ""
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5675,7 +5174,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5721,7 +5220,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5740,10 +5238,6 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5786,11 +5280,6 @@ msgstr ""
 msgid "Packing list"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5808,12 +5297,10 @@ msgstr ""
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5823,14 +5310,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5860,14 +5339,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5882,15 +5357,12 @@ msgstr ""
 msgid "Parts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5900,7 +5372,6 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5913,7 +5384,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5927,7 +5397,6 @@ msgstr ""
 msgid "Payables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5936,7 +5405,6 @@ msgstr ""
 msgid "Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5949,7 +5417,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5966,7 +5433,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 msgid "Payment batch"
 msgstr ""
@@ -6001,15 +5467,15 @@ msgstr ""
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6028,7 +5494,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6058,108 +5523,88 @@ msgstr ""
 msgid "Pick list"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6175,7 +5620,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6184,24 +5628,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6210,13 +5652,11 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6257,7 +5697,6 @@ msgstr ""
 msgid "Postscript"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6294,20 +5733,16 @@ msgstr ""
 msgid "Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6343,8 +5778,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6354,7 +5787,6 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6371,7 +5803,7 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr ""
 
@@ -6415,17 +5847,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6454,7 +5884,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6473,7 +5902,6 @@ msgstr ""
 msgid "Project Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6482,9 +5910,6 @@ msgstr ""
 msgid "Projects"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6494,7 +5919,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6512,22 +5936,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6541,14 +5959,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6579,7 +5993,6 @@ msgstr ""
 msgid "Qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6593,8 +6006,6 @@ msgstr ""
 msgid "Quarter"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6631,9 +6042,7 @@ msgstr ""
 msgid "Quotation deleted!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6654,25 +6063,20 @@ msgstr ""
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6684,7 +6088,6 @@ msgstr ""
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 msgid "Rate Type"
 msgstr ""
@@ -6705,13 +6108,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6729,7 +6128,6 @@ msgstr ""
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6743,8 +6141,7 @@ msgstr ""
 msgid "Receivables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr ""
 
@@ -6752,7 +6149,6 @@ msgstr ""
 msgid "Receive Merchandise"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6773,7 +6169,6 @@ msgstr ""
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6794,13 +6189,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6839,12 +6227,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6882,7 +6268,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6894,7 +6280,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6907,7 +6293,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6956,7 +6341,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -6976,13 +6361,10 @@ msgstr ""
 msgid "Required by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7012,7 +6394,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7021,7 +6402,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7038,7 +6418,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7088,11 +6467,11 @@ msgstr ""
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7118,7 +6497,6 @@ msgstr ""
 msgid "Sales Invoice"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7134,20 +6512,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr ""
@@ -7168,9 +6543,6 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7194,13 +6566,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7220,7 +6589,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7230,7 +6599,6 @@ msgstr ""
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7289,11 +6657,10 @@ msgstr ""
 msgid "Save as new"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7316,10 +6683,8 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr ""
 
@@ -7339,7 +6704,6 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7348,7 +6712,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7401,11 +6764,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7417,11 +6780,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7433,7 +6796,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7441,7 +6804,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7497,7 +6859,6 @@ msgstr ""
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7506,9 +6867,6 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7562,13 +6920,11 @@ msgstr ""
 msgid "Sep"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr ""
 
@@ -7589,9 +6945,6 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7620,7 +6973,6 @@ msgstr ""
 msgid "Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 msgid "Session Timeout (e.g. \"90 minutes\")"
 msgstr ""
@@ -7633,7 +6985,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7653,10 +7005,10 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr ""
 
@@ -7683,10 +7035,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7747,10 +7095,6 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7791,7 +7135,6 @@ msgstr ""
 msgid "Short"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7832,7 +7175,6 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7845,12 +7187,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7877,7 +7213,6 @@ msgstr ""
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7899,21 +7234,10 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7944,8 +7268,6 @@ msgstr ""
 msgid "Startdate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -7982,13 +7304,11 @@ msgstr ""
 msgid "Statement"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8018,7 +7338,7 @@ msgstr ""
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr ""
 
@@ -8043,7 +7363,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8086,7 +7405,6 @@ msgstr ""
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8119,12 +7437,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8136,9 +7448,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8157,8 +7466,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8169,17 +7476,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8322,7 +7626,6 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8331,7 +7634,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8384,7 +7686,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8396,7 +7698,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8447,24 +7749,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8487,14 +7786,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8538,7 +7833,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8568,19 +7862,10 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8617,7 +7902,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8642,16 +7926,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8694,7 +7969,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8702,7 +7977,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8723,7 +7997,6 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8739,14 +8012,12 @@ msgstr ""
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8785,7 +8056,6 @@ msgstr ""
 msgid "Translations saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr ""
@@ -8794,7 +8064,6 @@ msgstr ""
 msgid "Trillion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8851,10 +8120,6 @@ msgstr ""
 msgid "Two"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8889,39 +8154,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8940,43 +8199,37 @@ msgstr ""
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -8984,23 +8237,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9017,7 +8265,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9045,21 +8292,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9068,7 +8310,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9086,24 +8327,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9113,7 +8349,6 @@ msgstr ""
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9134,7 +8369,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9160,8 +8394,6 @@ msgstr ""
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9171,11 +8403,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9191,7 +8419,6 @@ msgstr ""
 msgid "Vendor"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9205,7 +8432,6 @@ msgstr ""
 msgid "Vendor Invoice"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9215,9 +8441,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9247,9 +8470,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9257,8 +8478,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 msgid "Vendor/Customer"
@@ -9272,7 +8491,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9285,7 +8503,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9308,7 +8525,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr ""
@@ -9317,11 +8533,26 @@ msgstr ""
 msgid "Warning!"
 msgstr ""
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9331,7 +8562,6 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9348,13 +8578,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr ""
@@ -9371,7 +8599,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9388,11 +8615,11 @@ msgstr ""
 msgid "Work order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9435,14 +8662,9 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
-msgstr ""
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
 msgstr ""
 
 #: t/data/04-complex_template.html:388
@@ -9470,7 +8692,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9534,17 +8756,12 @@ msgstr ""
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9561,7 +8778,7 @@ msgstr ""
 msgid "done"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9589,8 +8806,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9599,22 +8814,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9639,7 +8850,6 @@ msgstr ""
 msgid "sent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9664,8 +8874,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/en_GB.po
+++ b/locale/po/en_GB.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: English (United Kingdom) (http://www.transifex.com/ledgersmb/"
@@ -16,27 +16,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -49,12 +44,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -100,7 +91,6 @@ msgstr "Purchases"
 msgid "AP Aging"
 msgstr "Creditor Aging"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -109,7 +99,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -124,7 +113,6 @@ msgstr ""
 msgid "AP Transaction"
 msgstr "Purchase Transaction"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr ""
@@ -137,9 +125,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -158,7 +144,6 @@ msgstr "Sales"
 msgid "AR Aging"
 msgstr "Debtor Aging"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -167,7 +152,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -182,7 +166,6 @@ msgstr ""
 msgid "AR Transaction"
 msgstr "Sales Transaction"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr ""
@@ -195,9 +178,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -206,8 +187,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Sales Transaction"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -217,16 +196,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -252,38 +226,20 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -304,23 +260,18 @@ msgstr ""
 msgid "Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -360,17 +311,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -382,7 +331,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -410,12 +359,10 @@ msgstr ""
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -438,11 +385,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -567,7 +514,6 @@ msgstr ""
 msgid "Add Service"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -633,7 +579,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -658,7 +603,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -668,12 +612,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -693,8 +636,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -746,7 +688,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -755,11 +696,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -793,14 +729,10 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -809,27 +741,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -847,14 +773,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -873,17 +799,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -892,13 +815,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -907,7 +823,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -916,14 +831,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -935,19 +848,16 @@ msgstr ""
 msgid "Apr"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -963,7 +873,6 @@ msgstr ""
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -981,19 +890,17 @@ msgstr ""
 msgid "Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1006,29 +913,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1044,7 +948,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1142,8 +1045,7 @@ msgstr ""
 msgid "Aug"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr ""
 
@@ -1155,7 +1057,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1169,7 +1070,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1182,7 +1082,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1216,8 +1115,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1232,7 +1129,6 @@ msgstr ""
 msgid "Balance Sheet"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1253,7 +1149,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1264,7 +1159,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 msgid "Base Currency"
 msgstr ""
@@ -1273,18 +1167,15 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1297,12 +1188,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1319,13 +1208,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1366,8 +1253,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1413,17 +1298,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1436,12 +1318,10 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1451,12 +1331,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1478,7 +1356,6 @@ msgstr ""
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1510,18 +1387,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1647,12 +1522,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr ""
 
@@ -1672,7 +1546,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr "Cheque Prefix"
@@ -1701,7 +1574,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1713,9 +1586,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr ""
 
@@ -1743,15 +1616,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 msgid "Closing Balance"
 msgstr ""
@@ -1764,8 +1635,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1780,22 +1649,18 @@ msgstr ""
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1807,39 +1672,31 @@ msgstr ""
 msgid "Company"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1860,7 +1717,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1878,7 +1735,6 @@ msgstr ""
 msgid "Contact"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1894,7 +1750,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1912,9 +1767,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1944,7 +1796,6 @@ msgstr ""
 msgid "Contra"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1952,10 +1803,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1986,20 +1833,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2015,26 +1858,20 @@ msgstr ""
 msgid "Could not transfer Inventory!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2046,7 +1883,6 @@ msgstr ""
 msgid "Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2059,7 +1895,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2067,11 +1903,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2099,8 +1935,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2108,17 +1942,14 @@ msgstr ""
 msgid "Credit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2143,29 +1974,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2188,18 +2009,14 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2209,11 +2026,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2228,7 +2041,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Debtor"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2247,9 +2059,6 @@ msgstr "Debtor not on file!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2269,9 +2078,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "Debtor missing!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2283,7 +2090,7 @@ msgstr "Debtor not on file!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2307,12 +2114,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2345,28 +2151,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2413,19 +2207,14 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2447,7 +2236,6 @@ msgstr ""
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2511,8 +2299,6 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2528,10 +2314,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2541,17 +2325,14 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2561,7 +2342,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2574,47 +2354,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2627,21 +2398,14 @@ msgstr ""
 msgid "Defaults"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2659,7 +2423,6 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2672,7 +2435,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2686,37 +2448,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2738,20 +2496,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2762,46 +2517,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2912,12 +2628,10 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2930,7 +2644,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2939,7 +2652,6 @@ msgstr ""
 msgid "Discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2948,28 +2660,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2977,7 +2689,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2986,7 +2697,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -2994,12 +2705,10 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3012,12 +2721,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3026,19 +2733,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3054,10 +2758,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3076,7 +2776,7 @@ msgstr ""
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3102,7 +2802,7 @@ msgstr "Email message"
 msgid "E-mailed"
 msgstr "Emailed"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3132,7 +2832,7 @@ msgstr ""
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3276,8 +2976,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3291,7 +2989,6 @@ msgstr ""
 msgid "Employee"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3301,12 +2998,11 @@ msgstr ""
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 msgid "Employee wage screen"
 msgstr ""
@@ -3315,37 +3011,26 @@ msgstr ""
 msgid "Employees"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3369,7 +3054,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3394,12 +3078,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3409,7 +3091,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3417,7 +3099,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3442,7 +3123,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3454,14 +3135,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3475,16 +3153,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3492,7 +3169,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3505,8 +3182,6 @@ msgstr ""
 msgid "Exch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3521,7 +3196,6 @@ msgstr ""
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3530,7 +3204,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3548,13 +3221,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3632,8 +3302,7 @@ msgstr ""
 msgid "Feb"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr ""
 
@@ -3649,14 +3318,10 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3667,11 +3332,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3682,7 +3347,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3740,12 +3404,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr ""
@@ -3754,12 +3416,10 @@ msgstr ""
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3776,7 +3436,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3795,18 +3454,10 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3827,7 +3478,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3838,15 +3488,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3860,10 +3505,8 @@ msgstr ""
 msgid "GIFI"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3884,7 +3527,6 @@ msgstr ""
 msgid "GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3893,7 +3535,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3901,11 +3543,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3914,7 +3555,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3922,9 +3563,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3940,7 +3580,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3948,7 +3588,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3964,12 +3604,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3978,7 +3616,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4052,21 +3689,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4097,7 +3719,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4107,13 +3728,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4156,7 +3775,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4190,14 +3808,10 @@ msgstr ""
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4205,12 +3819,10 @@ msgstr ""
 msgid "Income"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4221,7 +3833,6 @@ msgstr ""
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4230,7 +3841,6 @@ msgstr ""
 msgid "Income statement"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4250,11 +3860,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4264,30 +3873,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4297,17 +3902,14 @@ msgstr ""
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4333,11 +3935,7 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4379,8 +3977,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4396,11 +3992,6 @@ msgstr ""
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4419,7 +4010,6 @@ msgstr ""
 msgid "Invoice Number missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4449,12 +4039,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4512,8 +4100,7 @@ msgstr ""
 msgid "Jan"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr ""
 
@@ -4542,8 +4129,7 @@ msgstr ""
 msgid "Jul"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr ""
 
@@ -4551,8 +4137,8 @@ msgstr ""
 msgid "Jun"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr ""
 
@@ -4565,10 +4151,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4590,15 +4172,12 @@ msgstr "Labour/Overhead"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr ""
@@ -4619,7 +4198,6 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4630,7 +4208,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4652,40 +4229,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4697,9 +4273,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4721,9 +4295,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4737,8 +4309,6 @@ msgstr "Less Outstanding Cheques:"
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4755,7 +4325,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4792,7 +4361,6 @@ msgstr ""
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4818,7 +4386,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4836,7 +4403,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4857,7 +4423,7 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4885,45 +4451,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4945,40 +4504,34 @@ msgstr ""
 msgid "Mar"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr "Max Invoices per Cheque Stub"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr ""
@@ -4995,7 +4548,6 @@ msgstr ""
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr ""
@@ -5004,7 +4556,6 @@ msgstr ""
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5023,14 +4574,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5044,7 +4592,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5057,14 +4604,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5082,7 +4627,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5106,14 +4651,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5122,15 +4665,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5149,7 +4683,6 @@ msgstr ""
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5200,8 +4733,6 @@ msgstr ""
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5223,12 +4754,10 @@ msgstr ""
 msgid "Ninety"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5237,7 +4766,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5245,11 +4774,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5257,7 +4786,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5266,11 +4794,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5278,21 +4806,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5311,12 +4836,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5325,12 +4848,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5368,11 +4889,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5418,23 +4934,18 @@ msgstr ""
 msgid "Nov"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5465,7 +4976,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr ""
 
@@ -5486,13 +4997,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5501,8 +5010,7 @@ msgstr ""
 msgid "Oct"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr ""
 
@@ -5514,9 +5022,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5566,7 +5071,6 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 msgid "Opening Balance"
 msgstr ""
@@ -5587,9 +5091,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5635,7 +5136,6 @@ msgstr ""
 msgid "Order Entry"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5657,7 +5157,6 @@ msgstr ""
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5679,7 +5178,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5725,7 +5224,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5744,10 +5242,6 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5790,11 +5284,6 @@ msgstr ""
 msgid "Packing list"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5812,12 +5301,10 @@ msgstr ""
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5827,14 +5314,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5864,14 +5343,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5886,15 +5361,12 @@ msgstr ""
 msgid "Parts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5904,7 +5376,6 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5917,7 +5388,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5931,7 +5401,6 @@ msgstr ""
 msgid "Payables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5940,7 +5409,6 @@ msgstr ""
 msgid "Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5953,7 +5421,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5970,7 +5437,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 msgid "Payment batch"
 msgstr ""
@@ -6005,15 +5471,15 @@ msgstr ""
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6032,7 +5498,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6062,108 +5527,88 @@ msgstr ""
 msgid "Pick list"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6179,7 +5624,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6188,24 +5632,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6214,13 +5656,11 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6261,7 +5701,6 @@ msgstr ""
 msgid "Postscript"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6298,20 +5737,16 @@ msgstr ""
 msgid "Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6347,8 +5782,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6358,7 +5791,6 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6375,7 +5807,7 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr ""
 
@@ -6419,17 +5851,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6458,7 +5888,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6477,7 +5906,6 @@ msgstr ""
 msgid "Project Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6486,9 +5914,6 @@ msgstr ""
 msgid "Projects"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6498,7 +5923,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6516,22 +5940,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6545,14 +5963,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6583,7 +5997,6 @@ msgstr ""
 msgid "Qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6597,8 +6010,6 @@ msgstr ""
 msgid "Quarter"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6635,9 +6046,7 @@ msgstr ""
 msgid "Quotation deleted!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6658,25 +6067,20 @@ msgstr ""
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6688,7 +6092,6 @@ msgstr ""
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 msgid "Rate Type"
 msgstr ""
@@ -6709,13 +6112,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6733,7 +6132,6 @@ msgstr ""
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6747,8 +6145,7 @@ msgstr ""
 msgid "Receivables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr ""
 
@@ -6756,7 +6153,6 @@ msgstr ""
 msgid "Receive Merchandise"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6777,7 +6173,6 @@ msgstr ""
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6798,13 +6193,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6843,12 +6231,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6886,7 +6272,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6898,7 +6284,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6911,7 +6297,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6960,7 +6345,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -6980,13 +6365,10 @@ msgstr ""
 msgid "Required by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7016,7 +6398,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7025,7 +6406,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7042,7 +6422,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7092,11 +6471,11 @@ msgstr ""
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7122,7 +6501,6 @@ msgstr ""
 msgid "Sales Invoice"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7138,20 +6516,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr ""
@@ -7172,9 +6547,6 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7198,13 +6570,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7224,7 +6593,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7234,7 +6603,6 @@ msgstr ""
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7293,11 +6661,10 @@ msgstr ""
 msgid "Save as new"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7320,10 +6687,8 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr ""
 
@@ -7343,7 +6708,6 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7352,7 +6716,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7405,11 +6768,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7421,11 +6784,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7437,7 +6800,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7445,7 +6808,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7501,7 +6863,6 @@ msgstr ""
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7510,9 +6871,6 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7566,13 +6924,11 @@ msgstr ""
 msgid "Sep"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr ""
 
@@ -7593,9 +6949,6 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7624,7 +6977,6 @@ msgstr ""
 msgid "Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 msgid "Session Timeout (e.g. \"90 minutes\")"
 msgstr ""
@@ -7637,7 +6989,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7657,10 +7009,10 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr ""
 
@@ -7687,10 +7039,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7751,10 +7099,6 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7795,7 +7139,6 @@ msgstr ""
 msgid "Short"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7836,7 +7179,6 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7849,12 +7191,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7881,7 +7217,6 @@ msgstr ""
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7903,21 +7238,10 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7948,8 +7272,6 @@ msgstr ""
 msgid "Startdate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -7986,13 +7308,11 @@ msgstr ""
 msgid "Statement"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8022,7 +7342,7 @@ msgstr ""
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr ""
 
@@ -8047,7 +7367,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8090,7 +7409,6 @@ msgstr ""
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8123,12 +7441,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8140,9 +7452,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8161,8 +7470,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8173,17 +7480,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8326,7 +7630,6 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8335,7 +7638,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8388,7 +7690,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8400,7 +7702,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8451,24 +7753,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8491,14 +7790,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8542,7 +7837,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8572,19 +7866,10 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8621,7 +7906,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8646,16 +7930,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8698,7 +7973,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8706,7 +7981,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8727,7 +8001,6 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8743,14 +8016,12 @@ msgstr ""
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8789,7 +8060,6 @@ msgstr ""
 msgid "Translations saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr ""
@@ -8798,7 +8068,6 @@ msgstr ""
 msgid "Trillion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8855,10 +8124,6 @@ msgstr ""
 msgid "Two"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8893,39 +8158,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8944,43 +8203,37 @@ msgstr ""
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -8988,23 +8241,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9021,7 +8269,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9049,21 +8296,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9072,7 +8314,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9090,24 +8331,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9117,7 +8353,6 @@ msgstr ""
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9138,7 +8373,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9164,8 +8398,6 @@ msgstr ""
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9175,11 +8407,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9195,7 +8423,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Creditor"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9209,7 +8436,6 @@ msgstr ""
 msgid "Vendor Invoice"
 msgstr "Creditor Invoice"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9219,9 +8445,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9251,9 +8474,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "Creditor missing!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9261,8 +8482,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Creditor not on file!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9277,7 +8496,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9290,7 +8508,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9313,7 +8530,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr ""
@@ -9322,11 +8538,26 @@ msgstr ""
 msgid "Warning!"
 msgstr ""
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9336,7 +8567,6 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9353,13 +8583,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr ""
@@ -9376,7 +8604,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9393,11 +8620,11 @@ msgstr ""
 msgid "Work order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9440,14 +8667,9 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
-msgstr ""
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
 msgstr ""
 
 #: t/data/04-complex_template.html:388
@@ -9475,7 +8697,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9539,17 +8761,12 @@ msgstr ""
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9566,7 +8783,7 @@ msgstr ""
 msgid "done"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9594,8 +8811,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9604,22 +8819,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9644,7 +8855,6 @@ msgstr ""
 msgid "sent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9669,8 +8879,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/en_NZ.po
+++ b/locale/po/en_NZ.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: English (New Zealand) (http://www.transifex.com/ledgersmb/"
@@ -16,27 +16,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -49,12 +44,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -103,7 +94,6 @@ msgstr ""
 msgid "AP Aging"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -112,7 +102,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -127,7 +116,6 @@ msgstr ""
 msgid "AP Transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr ""
@@ -140,9 +128,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -160,7 +146,6 @@ msgstr ""
 msgid "AR Aging"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -169,7 +154,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -184,7 +168,6 @@ msgstr ""
 msgid "AR Transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr ""
@@ -197,9 +180,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -207,8 +188,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -218,16 +197,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -253,38 +227,20 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -305,23 +261,18 @@ msgstr ""
 msgid "Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -361,17 +312,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -383,7 +332,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -411,12 +360,10 @@ msgstr ""
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -439,11 +386,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -568,7 +515,6 @@ msgstr ""
 msgid "Add Service"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -634,7 +580,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -659,7 +604,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -669,12 +613,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -694,8 +637,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -747,7 +689,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -756,11 +697,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -794,14 +730,10 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr "Amount Budgeted"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -810,27 +742,21 @@ msgstr "Amount Budgeted"
 msgid "Amount Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -848,14 +774,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -874,17 +800,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -893,13 +816,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -908,7 +824,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -917,14 +832,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -936,19 +849,16 @@ msgstr ""
 msgid "Apr"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -964,7 +874,6 @@ msgstr "Are you sure you want to delete Quotation Number?"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -982,19 +891,17 @@ msgstr ""
 msgid "Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1007,29 +914,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1045,7 +949,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1143,8 +1046,7 @@ msgstr ""
 msgid "Aug"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr ""
 
@@ -1156,7 +1058,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1170,7 +1071,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1183,7 +1083,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1217,8 +1116,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1233,7 +1130,6 @@ msgstr ""
 msgid "Balance Sheet"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1254,7 +1150,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1265,7 +1160,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 msgid "Base Currency"
 msgstr ""
@@ -1274,18 +1168,15 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1298,12 +1189,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1320,13 +1209,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1367,8 +1254,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1414,17 +1299,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1437,12 +1319,10 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1452,12 +1332,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1479,7 +1357,6 @@ msgstr ""
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1511,18 +1388,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1648,12 +1523,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr ""
 
@@ -1673,7 +1547,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1702,7 +1575,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1714,9 +1587,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr ""
 
@@ -1744,15 +1617,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 msgid "Closing Balance"
 msgstr ""
@@ -1765,8 +1636,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1781,22 +1650,18 @@ msgstr ""
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1808,39 +1673,31 @@ msgstr ""
 msgid "Company"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1861,7 +1718,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1879,7 +1736,6 @@ msgstr ""
 msgid "Contact"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1895,7 +1751,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1913,9 +1768,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1945,7 +1797,6 @@ msgstr ""
 msgid "Contra"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1953,10 +1804,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1987,20 +1834,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2016,26 +1859,20 @@ msgstr ""
 msgid "Could not transfer Inventory!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2047,7 +1884,6 @@ msgstr ""
 msgid "Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2060,7 +1896,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2068,11 +1904,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2100,8 +1936,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2109,17 +1943,14 @@ msgstr ""
 msgid "Credit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2144,29 +1975,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2189,18 +2010,14 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2210,11 +2027,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2229,7 +2042,6 @@ msgstr ""
 msgid "Customer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2247,9 +2059,6 @@ msgstr ""
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2269,9 +2078,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2283,7 +2090,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2307,12 +2114,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2345,28 +2151,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2413,19 +2207,14 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2447,7 +2236,6 @@ msgstr ""
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2511,8 +2299,6 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2528,10 +2314,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2541,17 +2325,14 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2561,7 +2342,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2574,47 +2354,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2627,21 +2398,14 @@ msgstr ""
 msgid "Defaults"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2659,7 +2423,6 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2672,7 +2435,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2686,37 +2448,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2738,20 +2496,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2762,46 +2517,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2912,12 +2628,10 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2930,7 +2644,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2939,7 +2652,6 @@ msgstr ""
 msgid "Discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2948,28 +2660,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2977,7 +2689,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2986,7 +2697,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -2994,12 +2705,10 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3012,12 +2721,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3026,19 +2733,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3054,10 +2758,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3076,7 +2776,7 @@ msgstr ""
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3102,7 +2802,7 @@ msgstr ""
 msgid "E-mailed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3132,7 +2832,7 @@ msgstr ""
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3276,8 +2976,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3291,7 +2989,6 @@ msgstr ""
 msgid "Employee"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3301,12 +2998,11 @@ msgstr ""
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 msgid "Employee wage screen"
 msgstr ""
@@ -3315,37 +3011,26 @@ msgstr ""
 msgid "Employees"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3369,7 +3054,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3394,12 +3078,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3409,7 +3091,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3417,7 +3099,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3442,7 +3123,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3454,14 +3135,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3475,16 +3153,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3492,7 +3169,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3505,8 +3182,6 @@ msgstr ""
 msgid "Exch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3521,7 +3196,6 @@ msgstr ""
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3530,7 +3204,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3548,13 +3221,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3632,8 +3302,7 @@ msgstr ""
 msgid "Feb"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr ""
 
@@ -3649,14 +3318,10 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3667,11 +3332,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3682,7 +3347,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3740,12 +3404,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr ""
@@ -3754,12 +3416,10 @@ msgstr ""
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3776,7 +3436,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3795,18 +3454,10 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3827,7 +3478,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3838,15 +3488,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3860,10 +3505,8 @@ msgstr ""
 msgid "GIFI"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3884,7 +3527,6 @@ msgstr ""
 msgid "GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3893,7 +3535,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3901,11 +3543,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3914,7 +3555,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3922,9 +3563,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3940,7 +3580,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3948,7 +3588,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3964,12 +3604,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3978,7 +3616,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4052,21 +3689,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4097,7 +3719,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4107,13 +3728,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4156,7 +3775,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4190,14 +3808,10 @@ msgstr ""
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4205,12 +3819,10 @@ msgstr ""
 msgid "Income"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4221,7 +3833,6 @@ msgstr ""
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4230,7 +3841,6 @@ msgstr ""
 msgid "Income statement"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4250,11 +3860,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4264,30 +3873,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4297,17 +3902,14 @@ msgstr ""
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4333,11 +3935,7 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4379,8 +3977,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4396,11 +3992,6 @@ msgstr ""
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4419,7 +4010,6 @@ msgstr ""
 msgid "Invoice Number missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4449,12 +4039,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4512,8 +4100,7 @@ msgstr ""
 msgid "Jan"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr ""
 
@@ -4542,8 +4129,7 @@ msgstr ""
 msgid "Jul"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr ""
 
@@ -4551,8 +4137,8 @@ msgstr ""
 msgid "Jun"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr ""
 
@@ -4565,10 +4151,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4590,15 +4172,12 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr ""
@@ -4619,7 +4198,6 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4630,7 +4208,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4652,40 +4229,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4697,9 +4273,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4721,9 +4295,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4737,8 +4309,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4755,7 +4325,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4792,7 +4361,6 @@ msgstr ""
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4818,7 +4386,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4836,7 +4403,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4857,7 +4423,7 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4885,45 +4451,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4945,40 +4504,34 @@ msgstr ""
 msgid "Mar"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr ""
@@ -4995,7 +4548,6 @@ msgstr ""
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr ""
@@ -5004,7 +4556,6 @@ msgstr ""
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5023,14 +4574,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5044,7 +4592,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5057,14 +4604,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5082,7 +4627,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5106,14 +4651,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5122,15 +4665,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5149,7 +4683,6 @@ msgstr ""
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5200,8 +4733,6 @@ msgstr ""
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5223,12 +4754,10 @@ msgstr ""
 msgid "Ninety"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5237,7 +4766,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5245,11 +4774,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5257,7 +4786,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5266,11 +4794,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5278,21 +4806,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5311,12 +4836,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5325,12 +4848,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5368,11 +4889,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5418,23 +4934,18 @@ msgstr ""
 msgid "Nov"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5465,7 +4976,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr ""
 
@@ -5486,13 +4997,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5501,8 +5010,7 @@ msgstr ""
 msgid "Oct"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr ""
 
@@ -5514,9 +5022,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5566,7 +5071,6 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 msgid "Opening Balance"
 msgstr ""
@@ -5587,9 +5091,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5635,7 +5136,6 @@ msgstr ""
 msgid "Order Entry"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5657,7 +5157,6 @@ msgstr ""
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5679,7 +5178,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5724,7 +5223,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5743,10 +5241,6 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5789,11 +5283,6 @@ msgstr ""
 msgid "Packing list"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5811,12 +5300,10 @@ msgstr ""
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5826,14 +5313,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5863,14 +5342,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5885,15 +5360,12 @@ msgstr ""
 msgid "Parts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5903,7 +5375,6 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5916,7 +5387,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5930,7 +5400,6 @@ msgstr ""
 msgid "Payables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5939,7 +5408,6 @@ msgstr ""
 msgid "Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5952,7 +5420,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5969,7 +5436,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 msgid "Payment batch"
 msgstr ""
@@ -6004,15 +5470,15 @@ msgstr ""
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6031,7 +5497,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6061,108 +5526,88 @@ msgstr ""
 msgid "Pick list"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6178,7 +5623,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6187,24 +5631,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6213,13 +5655,11 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6260,7 +5700,6 @@ msgstr ""
 msgid "Postscript"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6297,20 +5736,16 @@ msgstr ""
 msgid "Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6346,8 +5781,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6357,7 +5790,6 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6374,7 +5806,7 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr ""
 
@@ -6418,17 +5850,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6457,7 +5887,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6476,7 +5905,6 @@ msgstr ""
 msgid "Project Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6485,9 +5913,6 @@ msgstr ""
 msgid "Projects"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6497,7 +5922,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6515,22 +5939,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6544,14 +5962,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6582,7 +5996,6 @@ msgstr ""
 msgid "Qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6596,8 +6009,6 @@ msgstr ""
 msgid "Quarter"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6634,9 +6045,7 @@ msgstr ""
 msgid "Quotation deleted!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6657,25 +6066,20 @@ msgstr ""
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6687,7 +6091,6 @@ msgstr ""
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 msgid "Rate Type"
 msgstr ""
@@ -6708,13 +6111,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6732,7 +6131,6 @@ msgstr ""
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6746,8 +6144,7 @@ msgstr ""
 msgid "Receivables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr ""
 
@@ -6755,7 +6152,6 @@ msgstr ""
 msgid "Receive Merchandise"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6776,7 +6172,6 @@ msgstr ""
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6797,13 +6192,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6842,12 +6230,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6885,7 +6271,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6897,7 +6283,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6910,7 +6296,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6959,7 +6344,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -6979,13 +6364,10 @@ msgstr ""
 msgid "Required by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7015,7 +6397,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7024,7 +6405,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7041,7 +6421,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7091,11 +6470,11 @@ msgstr ""
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7121,7 +6500,6 @@ msgstr ""
 msgid "Sales Invoice"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7137,20 +6515,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr ""
@@ -7171,9 +6546,6 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7197,13 +6569,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7223,7 +6592,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7233,7 +6602,6 @@ msgstr ""
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7292,11 +6660,10 @@ msgstr ""
 msgid "Save as new"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7319,10 +6686,8 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr ""
 
@@ -7342,7 +6707,6 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7351,7 +6715,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7404,11 +6767,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7420,11 +6783,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7436,7 +6799,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7444,7 +6807,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7500,7 +6862,6 @@ msgstr ""
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7509,9 +6870,6 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7565,13 +6923,11 @@ msgstr ""
 msgid "Sep"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr ""
 
@@ -7592,9 +6948,6 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7623,7 +6976,6 @@ msgstr ""
 msgid "Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 msgid "Session Timeout (e.g. \"90 minutes\")"
 msgstr ""
@@ -7636,7 +6988,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7656,10 +7008,10 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr ""
 
@@ -7686,10 +7038,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7750,10 +7098,6 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7794,7 +7138,6 @@ msgstr ""
 msgid "Short"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7835,7 +7178,6 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7848,12 +7190,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7880,7 +7216,6 @@ msgstr ""
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7902,21 +7237,10 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7947,8 +7271,6 @@ msgstr ""
 msgid "Startdate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -7985,13 +7307,11 @@ msgstr ""
 msgid "Statement"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8021,7 +7341,7 @@ msgstr ""
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr ""
 
@@ -8046,7 +7366,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8089,7 +7408,6 @@ msgstr ""
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8122,12 +7440,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8139,9 +7451,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8160,8 +7469,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8172,17 +7479,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8325,7 +7629,6 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8334,7 +7637,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8387,7 +7689,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8399,7 +7701,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8450,24 +7752,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8490,14 +7789,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8541,7 +7836,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8571,19 +7865,10 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8620,7 +7905,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8645,16 +7929,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8697,7 +7972,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8705,7 +7980,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8726,7 +8000,6 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8742,14 +8015,12 @@ msgstr ""
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8788,7 +8059,6 @@ msgstr ""
 msgid "Translations saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr ""
@@ -8797,7 +8067,6 @@ msgstr ""
 msgid "Trillion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8854,10 +8123,6 @@ msgstr ""
 msgid "Two"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8892,39 +8157,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8943,43 +8202,37 @@ msgstr ""
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -8987,23 +8240,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9020,7 +8268,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9048,21 +8295,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9071,7 +8313,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9089,24 +8330,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9116,7 +8352,6 @@ msgstr ""
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9137,7 +8372,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9163,8 +8397,6 @@ msgstr ""
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9174,11 +8406,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9194,7 +8422,6 @@ msgstr ""
 msgid "Vendor"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9208,7 +8435,6 @@ msgstr ""
 msgid "Vendor Invoice"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9218,9 +8444,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9250,9 +8473,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9260,8 +8481,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 msgid "Vendor/Customer"
@@ -9275,7 +8494,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9288,7 +8506,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9311,7 +8528,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr ""
@@ -9320,11 +8536,26 @@ msgstr ""
 msgid "Warning!"
 msgstr ""
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9334,7 +8565,6 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9351,13 +8581,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr ""
@@ -9374,7 +8602,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9391,11 +8618,11 @@ msgstr ""
 msgid "Work order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9438,14 +8665,9 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
-msgstr ""
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
 msgstr ""
 
 #: t/data/04-complex_template.html:388
@@ -9473,7 +8695,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9537,17 +8759,12 @@ msgstr ""
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9564,7 +8781,7 @@ msgstr ""
 msgid "done"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9592,8 +8809,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9602,22 +8817,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9642,7 +8853,6 @@ msgstr ""
 msgid "sent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9667,8 +8877,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/es.po
+++ b/locale/po/es.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Spanish (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -16,27 +16,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -49,12 +44,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -100,7 +91,6 @@ msgstr "Cartera de pagos"
 msgid "AP Aging"
 msgstr "Diario resumido de pagos"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -109,7 +99,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -124,7 +113,6 @@ msgstr ""
 msgid "AP Transaction"
 msgstr "Gestión se pago"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Gestiones de pagos"
@@ -137,9 +125,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -158,7 +144,6 @@ msgstr "Cartera de cobros"
 msgid "AR Aging"
 msgstr "Diario resumido de cobros "
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -167,7 +152,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -182,7 +166,6 @@ msgstr ""
 msgid "AR Transaction"
 msgstr "Gestión de cobro"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Gestiones de cobros"
@@ -195,9 +178,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -206,8 +187,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Gestión de cobro"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -217,16 +196,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -252,38 +226,20 @@ msgstr ""
 msgid "Account"
 msgstr "Cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -304,23 +260,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Número de cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -360,17 +311,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -382,7 +331,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -410,12 +359,10 @@ msgstr "Activo"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -438,11 +385,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr "Añadir compuesto"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -567,7 +514,6 @@ msgstr "Añadir presupuesto"
 msgid "Add Service"
 msgstr "Añadir servicio"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -634,7 +580,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Actualizar"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -659,7 +604,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -669,12 +613,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -694,8 +637,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -748,7 +690,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -757,11 +698,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -795,14 +731,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Total"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -811,27 +743,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Cantidad adeudada"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -849,14 +775,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -875,17 +801,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -894,13 +817,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -909,7 +825,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -918,14 +833,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -937,19 +850,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Abr"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "Abril"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -965,7 +875,6 @@ msgstr ""
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -984,19 +893,17 @@ msgstr "¡Compuestos actualizados en almacen!"
 msgid "Asset"
 msgstr "Activo"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1009,29 +916,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1047,7 +951,6 @@ msgstr "Total de Capital y Pasivos"
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1145,8 +1048,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Ago"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Agosto"
 
@@ -1158,7 +1060,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1172,7 +1073,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1185,7 +1085,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1219,8 +1118,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1235,7 +1132,6 @@ msgstr "Balance"
 msgid "Balance Sheet"
 msgstr "Hoja de balance"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1256,7 +1152,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1267,7 +1162,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1277,18 +1171,15 @@ msgstr "Moneda"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1301,12 +1192,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1323,13 +1212,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1370,8 +1257,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1417,17 +1302,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1440,12 +1322,10 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Numero de negocio"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1455,12 +1335,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1482,7 +1360,6 @@ msgstr ""
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1514,18 +1391,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1651,12 +1526,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Cuadro de cuentas"
 
@@ -1676,7 +1550,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1705,7 +1578,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1717,9 +1590,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr ""
 
@@ -1747,15 +1620,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Cerrado"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1769,8 +1640,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1785,22 +1654,18 @@ msgstr ""
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1812,39 +1677,31 @@ msgstr ""
 msgid "Company"
 msgstr "Compañía"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1865,7 +1722,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Confirmar"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1883,7 +1740,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Contacto"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1899,7 +1755,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1917,9 +1772,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1949,7 +1801,6 @@ msgstr ""
 msgid "Contra"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1957,10 +1808,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1991,20 +1838,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2020,26 +1863,20 @@ msgstr ""
 msgid "Could not transfer Inventory!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2051,7 +1888,6 @@ msgstr ""
 msgid "Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2064,7 +1900,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2072,11 +1908,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2104,8 +1940,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2113,17 +1947,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Crédito"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2148,29 +1979,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Mon."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2193,18 +2014,14 @@ msgstr "Mon."
 msgid "Currency"
 msgstr "Moneda"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Actual"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2214,11 +2031,7 @@ msgstr "Resultado"
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2233,7 +2046,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Cliente"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2252,9 +2064,6 @@ msgstr "¡El cliente no existe!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2274,9 +2083,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "¡Falta el cliente!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2288,7 +2095,7 @@ msgstr "¡El cliente no existe!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2312,12 +2119,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2350,28 +2156,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2418,19 +2212,14 @@ msgstr ""
 msgid "Date"
 msgstr "Fecha"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2452,7 +2241,6 @@ msgstr ""
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2516,8 +2304,6 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2533,10 +2319,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2546,17 +2330,14 @@ msgstr ""
 msgid "Dec"
 msgstr "Dic"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Diciembre"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2566,7 +2347,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2579,47 +2359,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2632,21 +2403,14 @@ msgstr ""
 msgid "Defaults"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2664,7 +2428,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Borrar"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2677,7 +2440,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2691,37 +2453,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Fecha de entrega"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2743,20 +2501,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2767,46 +2522,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2917,12 +2633,10 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2935,7 +2649,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2944,7 +2657,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Descuento"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2953,28 +2665,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2982,7 +2694,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2991,7 +2702,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -2999,12 +2710,10 @@ msgstr ""
 msgid "Done"
 msgstr "Hecho"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3017,12 +2726,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3031,19 +2738,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Reintegro"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3059,10 +2763,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3081,7 +2781,7 @@ msgstr "Falta la fecha de vencimiento"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3107,7 +2807,7 @@ msgstr ""
 msgid "E-mailed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3137,7 +2837,7 @@ msgstr ""
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3281,8 +2981,6 @@ msgstr "once"
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3296,7 +2994,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Colaborador/Empleado"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3306,12 +3003,11 @@ msgstr ""
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 msgid "Employee wage screen"
 msgstr ""
@@ -3320,37 +3016,26 @@ msgstr ""
 msgid "Employees"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3374,7 +3059,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3399,12 +3083,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3414,7 +3096,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3422,7 +3104,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3447,7 +3128,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3459,14 +3140,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Capital"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr "Total de Capital y Pasivos"
@@ -3480,16 +3158,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3497,7 +3174,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3510,8 +3187,6 @@ msgstr ""
 msgid "Exch"
 msgstr "Cambio"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3526,7 +3201,6 @@ msgstr "Tasa de cambio"
 msgid "Exchange rate for payment missing!"
 msgstr "¡Falta la tasa de cambio para el pago!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3535,7 +3209,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "¡Falta la tasa de cambio!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3553,13 +3226,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Gastos/Activo"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr "Gastos"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3637,8 +3307,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Febrero"
 
@@ -3654,14 +3323,10 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3672,11 +3337,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3687,7 +3352,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3745,12 +3409,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Ganancia en moneda extranjera"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Pérdida en moneda extranjera"
@@ -3759,12 +3421,10 @@ msgstr "Pérdida en moneda extranjera"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3781,7 +3441,6 @@ msgstr "cuatro"
 msgid "Fourteen"
 msgstr "catorce"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3800,18 +3459,10 @@ msgstr ""
 msgid "From"
 msgstr "Desde"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3832,7 +3483,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3843,15 +3493,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3865,10 +3510,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "Código GIFI"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3889,7 +3532,6 @@ msgstr "¡Guardado el código GIFI!"
 msgid "GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3898,7 +3540,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3906,11 +3548,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3919,7 +3560,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3927,9 +3568,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3945,7 +3585,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3953,7 +3593,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3969,12 +3609,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3983,7 +3621,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4057,21 +3694,6 @@ msgstr ""
 msgid "Hundred"
 msgstr "ciento"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4102,7 +3724,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4112,13 +3733,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Imagen"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4161,7 +3780,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4195,14 +3813,10 @@ msgstr "Incluir en menúes desplegables:"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4210,12 +3824,10 @@ msgstr ""
 msgid "Income"
 msgstr "Ingresos"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4226,7 +3838,6 @@ msgstr "Balance de situación"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4236,7 +3847,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Balance de situación"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4256,11 +3866,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4270,30 +3879,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4303,17 +3908,14 @@ msgstr "Inventario"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4341,11 +3943,7 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4387,8 +3985,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4404,11 +4000,6 @@ msgstr "No se ha definido la fecha de la factura"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4427,7 +4018,6 @@ msgstr "Número de factura"
 msgid "Invoice Number missing!"
 msgstr "No se ha definido el número de la factura"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4457,12 +4047,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4520,8 +4108,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Ene"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Enero"
 
@@ -4550,8 +4137,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Julio"
 
@@ -4559,8 +4145,8 @@ msgstr "Julio"
 msgid "Jun"
 msgstr "Jun"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Junio"
 
@@ -4573,10 +4159,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "Plantillas LaTeX"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4598,15 +4180,12 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Lenguaje"
@@ -4627,7 +4206,6 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4638,7 +4216,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4660,40 +4237,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4705,9 +4281,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4729,9 +4303,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4745,8 +4317,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr "Pasivos"
@@ -4763,7 +4333,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4800,7 +4369,6 @@ msgstr ""
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4826,7 +4394,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4844,7 +4411,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4865,7 +4431,7 @@ msgstr ""
 msgid "Login"
 msgstr "Entrar"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4893,45 +4459,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Marca"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4953,40 +4512,34 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Marzo"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "May"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr ""
@@ -5003,7 +4556,6 @@ msgstr "Mensaje"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr ""
@@ -5012,7 +4564,6 @@ msgstr ""
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5031,14 +4582,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5052,7 +4600,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5065,14 +4612,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Modelo"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5090,7 +4635,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5114,14 +4659,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5130,15 +4673,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5157,7 +4691,6 @@ msgstr "Nombre"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5208,8 +4741,6 @@ msgstr ""
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5231,12 +4762,10 @@ msgstr "diecinueve"
 msgid "Ninety"
 msgstr "noventa"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "No"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5245,7 +4774,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5253,11 +4782,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5265,7 +4794,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5274,11 +4802,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5286,21 +4814,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5319,12 +4844,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5333,12 +4856,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5376,11 +4897,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5426,23 +4942,18 @@ msgstr ""
 msgid "Nov"
 msgstr "Nov"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "Noviembre"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5473,7 +4984,7 @@ msgstr ""
 msgid "Number"
 msgstr "Número"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Formato de número"
 
@@ -5494,13 +5005,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Obsoleto"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5509,8 +5018,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Oct"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Octubre"
 
@@ -5522,9 +5030,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5574,7 +5079,6 @@ msgstr ""
 msgid "Open"
 msgstr "Abierto"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5596,9 +5100,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5644,7 +5145,6 @@ msgstr "No se ha definido la fecha de la elaboración"
 msgid "Order Entry"
 msgstr "Presupuestos y pedidos"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5666,7 +5166,6 @@ msgstr "¡Orden borrada!"
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5688,7 +5187,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5733,7 +5232,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5752,10 +5250,6 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5799,11 +5293,6 @@ msgstr "No se ha definido el número del albarán"
 msgid "Packing list"
 msgstr "Albarán"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5821,12 +5310,10 @@ msgstr "Pagado"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Artículo"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5836,14 +5323,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5873,14 +5352,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5896,15 +5371,12 @@ msgstr ""
 msgid "Parts"
 msgstr "Artículo"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5914,7 +5386,6 @@ msgstr ""
 msgid "Password"
 msgstr "Contraseña"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5927,7 +5398,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5941,7 +5411,6 @@ msgstr ""
 msgid "Payables"
 msgstr "Pagos"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5950,7 +5419,6 @@ msgstr "Pagos"
 msgid "Payment"
 msgstr "Pago"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5963,7 +5431,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5980,7 +5447,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6016,15 +5482,15 @@ msgstr "Vencimientos impagados"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6043,7 +5509,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6073,108 +5538,88 @@ msgstr ""
 msgid "Pick list"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6190,7 +5635,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6199,24 +5643,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6225,13 +5667,11 @@ msgstr ""
 msgid "Post"
 msgstr "Registrar"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6272,7 +5712,6 @@ msgstr ""
 msgid "Postscript"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6310,20 +5749,16 @@ msgstr ""
 msgid "Price"
 msgstr "Precio"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6359,8 +5794,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6370,7 +5803,6 @@ msgstr ""
 msgid "Print"
 msgstr "Imprimir"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6387,7 +5819,7 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Impresora"
 
@@ -6431,17 +5863,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6470,7 +5900,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6489,7 +5918,6 @@ msgstr ""
 msgid "Project Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6498,9 +5926,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Proyectos"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6510,7 +5935,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6528,22 +5952,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Pedido"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Pedidos"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6558,14 +5976,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Pedido"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6596,7 +6010,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Cantidad"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6610,8 +6023,6 @@ msgstr ""
 msgid "Quarter"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6648,9 +6059,7 @@ msgstr ""
 msgid "Quotation deleted!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6671,25 +6080,20 @@ msgstr ""
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "Tope de envio"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6701,7 +6105,6 @@ msgstr "Tarifa"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6724,13 +6127,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6748,7 +6147,6 @@ msgstr "Recibo"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6762,8 +6160,7 @@ msgstr "Recibos"
 msgid "Receivables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr ""
 
@@ -6771,7 +6168,6 @@ msgstr ""
 msgid "Receive Merchandise"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6792,7 +6188,6 @@ msgstr "Reconciliación"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6813,13 +6208,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6858,12 +6246,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6901,7 +6287,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6913,7 +6299,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6926,7 +6312,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6975,7 +6360,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -6995,13 +6380,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Aceptado el"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7031,7 +6413,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7040,7 +6421,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7057,7 +6437,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7107,11 +6486,11 @@ msgstr ""
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7137,7 +6516,6 @@ msgstr "Ventas"
 msgid "Sales Invoice"
 msgstr "Facturas de ventas"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7153,20 +6531,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr "Presupuesto"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Presupuestos"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr ""
@@ -7188,9 +6563,6 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7214,13 +6586,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7240,7 +6609,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7250,7 +6619,6 @@ msgstr "Guardar"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7309,11 +6677,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "Guardar como nuevo"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7336,10 +6703,8 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Pantalla"
 
@@ -7359,7 +6724,6 @@ msgstr "Pantalla"
 msgid "Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7368,7 +6732,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7421,11 +6784,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7437,11 +6800,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7453,7 +6816,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7461,7 +6824,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7517,7 +6879,6 @@ msgstr ""
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7526,9 +6887,6 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7582,13 +6940,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Sep"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "Septiembre"
 
@@ -7609,9 +6965,6 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7641,7 +6994,6 @@ msgstr ""
 msgid "Services"
 msgstr "Servicio"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 msgid "Session Timeout (e.g. \"90 minutes\")"
 msgstr ""
@@ -7654,7 +7006,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7674,10 +7026,10 @@ msgstr "diecisiete"
 msgid "Seventy"
 msgstr "setenta"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Envio"
 
@@ -7704,10 +7056,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7768,10 +7116,6 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7812,7 +7156,6 @@ msgstr ""
 msgid "Short"
 msgstr "Corto"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7853,7 +7196,6 @@ msgstr "sesenta"
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7866,12 +7208,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7898,7 +7234,6 @@ msgstr "Fuente"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7920,21 +7255,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Estándard"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7965,8 +7289,6 @@ msgstr ""
 msgid "Startdate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8003,13 +7325,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Estado de cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Balance de cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8039,7 +7359,7 @@ msgstr "Inventariar compuesto"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Hoja de estilo"
 
@@ -8064,7 +7384,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8107,7 +7426,6 @@ msgstr ""
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8140,12 +7458,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8157,9 +7469,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8178,8 +7487,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8190,17 +7497,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8344,7 +7648,6 @@ msgstr ""
 msgid "Template"
 msgstr "Plantillas HTML"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8353,7 +7656,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8406,7 +7708,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8418,7 +7720,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8469,24 +7771,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8509,14 +7808,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8560,7 +7855,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8590,19 +7884,10 @@ msgstr ""
 msgid "To"
 msgstr "Hasta "
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8639,7 +7924,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8664,16 +7948,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8716,7 +7991,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8724,7 +7999,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8745,7 +8019,6 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8761,14 +8034,12 @@ msgstr "No se ha definido la fecha de la transacción"
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8807,7 +8078,6 @@ msgstr ""
 msgid "Translations saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Balance de comprobación"
@@ -8816,7 +8086,6 @@ msgstr "Balance de comprobación"
 msgid "Trillion"
 msgstr "billón"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8873,10 +8142,6 @@ msgstr "veintidós"
 msgid "Two"
 msgstr "dos"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8911,39 +8176,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8962,43 +8221,37 @@ msgstr "Unidad"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9006,23 +8259,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9039,7 +8287,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9067,21 +8314,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9090,7 +8332,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9108,24 +8349,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9135,7 +8371,6 @@ msgstr "Usuario"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9156,7 +8391,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9182,8 +8416,6 @@ msgstr ""
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9193,11 +8425,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9213,7 +8441,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Proveedor"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9227,7 +8454,6 @@ msgstr ""
 msgid "Vendor Invoice"
 msgstr "Factura de compras"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9237,9 +8463,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9269,9 +8492,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "¡Falta el proveedor!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9279,8 +8500,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "¡No se encuentra el proveedor en la base de datos!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9295,7 +8514,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9308,7 +8526,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9331,7 +8548,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr ""
@@ -9340,11 +8556,26 @@ msgstr ""
 msgid "Warning!"
 msgstr ""
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9354,7 +8585,6 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9371,13 +8601,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Peso"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Unidad de peso"
@@ -9394,7 +8622,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9411,11 +8638,11 @@ msgstr ""
 msgid "Work order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9458,15 +8685,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Si"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9493,7 +8715,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9557,17 +8779,12 @@ msgstr "días"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9584,7 +8801,7 @@ msgstr ""
 msgid "done"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9612,8 +8829,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9622,22 +8837,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9662,7 +8873,6 @@ msgstr ""
 msgid "sent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9687,8 +8897,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/es_AR.po
+++ b/locale/po/es_AR.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Spanish (Argentina) (http://www.transifex.com/ledgersmb/"
@@ -15,27 +15,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr "(+) Valor Salvado"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr "(-) Depre. Acumulada"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr "(=) Valor Neto"
@@ -48,12 +43,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -99,7 +90,6 @@ msgstr "Egreso"
 msgid "AP Aging"
 msgstr "Envejecimiento de Egreso"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -108,7 +98,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -123,7 +112,6 @@ msgstr ""
 msgid "AP Transaction"
 msgstr "Transaccion de Egreso"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr ""
@@ -136,9 +124,7 @@ msgstr "Cupon de Egreso"
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -157,7 +143,6 @@ msgstr "Ingreso"
 msgid "AR Aging"
 msgstr "Envejecimiento de Ingreso"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -166,7 +151,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -181,7 +165,6 @@ msgstr ""
 msgid "AR Transaction"
 msgstr "Transaccion de Ingreso"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr ""
@@ -194,9 +177,7 @@ msgstr "Cupon de Ingreso"
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -205,8 +186,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Transaccion de Ingreso"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -216,16 +195,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr "Acceso Denegado"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -251,38 +225,20 @@ msgstr "Acceso Denegado"
 msgid "Account"
 msgstr "Cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -303,23 +259,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Numero de Cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr "Titulo de Cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -359,17 +310,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -381,7 +330,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr "Depre. Acumulada"
 
@@ -409,12 +358,10 @@ msgstr "Activo"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr "Sesiones Activas"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -437,11 +384,11 @@ msgstr "Agregar Cuentas"
 msgid "Add Assembly"
 msgstr "Agregar Manufacturado"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr "Agregar Activo"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr "Agregar Clase de Activos"
 
@@ -566,7 +513,6 @@ msgstr "Nueva Orden de Venta"
 msgid "Add Service"
 msgstr "Aregar Servicio"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr "Agregar Forma de Impuesto"
@@ -633,7 +579,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Actualizar"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -658,7 +603,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -668,12 +612,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr "Ajustar Basicos"
 
@@ -693,8 +636,7 @@ msgstr ""
 msgid "Aged"
 msgstr "Antiguedad"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -747,7 +689,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr "Alocado"
@@ -756,11 +697,6 @@ msgstr "Alocado"
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -794,14 +730,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Cantidad"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -810,27 +742,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Monto Adeudado"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -848,14 +774,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -874,17 +800,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr "Descuento aplicado"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr "Aplicar descuento de un sobrepago"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr "Aplicar Descuento"
@@ -893,13 +816,6 @@ msgstr "Aplicar Descuento"
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -908,7 +824,6 @@ msgstr ""
 msgid "Approve"
 msgstr "Aprobar"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -917,14 +832,12 @@ msgstr "Aprobar"
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr "Aprovado en"
 
@@ -936,19 +849,16 @@ msgstr ""
 msgid "Apr"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr "Valor Adquirido"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr "Valor Adquirido Remanente"
 
@@ -964,7 +874,6 @@ msgstr "Esta seguro de eliminar el Numero de Presupuesto?"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -983,19 +892,17 @@ msgstr "Manufacturas re-stockeadas!"
 msgid "Asset"
 msgstr "Activo"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr "Cuenta de Activos"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr "Clase de Activo"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1008,29 +915,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr "Clases de Activo"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr "Reporte de Depreciacion de Activos"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr "Reporte de Disposicion"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr "Reporte Parcial de Disposicion de Activo"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr "Etiqueta de Activo"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1046,7 +950,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1144,8 +1047,7 @@ msgstr ""
 msgid "Aug"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr ""
 
@@ -1157,7 +1059,6 @@ msgstr ""
 msgid "Automatic"
 msgstr "Automatico"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1171,7 +1072,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1184,7 +1084,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr "Promedio de Costo"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1218,8 +1117,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1234,7 +1131,6 @@ msgstr ""
 msgid "Balance Sheet"
 msgstr "Hoja de Balance"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1255,7 +1151,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1266,7 +1161,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1276,18 +1170,15 @@ msgstr "Moneda"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr "Basico"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr "Lote"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1300,12 +1191,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr "Descripcion del Lote"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1322,13 +1211,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1369,8 +1256,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1417,17 +1302,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1440,12 +1322,10 @@ msgstr ""
 msgid "Business"
 msgstr "Negocio"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1455,12 +1335,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1482,7 +1360,6 @@ msgstr "Negocio guardado!"
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1514,18 +1391,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr "Cancelar?"
 
@@ -1655,12 +1530,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr "Cobrable"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Plan de Cuentas"
 
@@ -1680,7 +1554,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "Chequear Inventario"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr "Prefijo para Cheque"
@@ -1709,7 +1582,7 @@ msgstr ""
 msgid "Class"
 msgstr "Clase"
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr "eliminar fecha"
 
@@ -1721,9 +1594,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "Borrado"
 
@@ -1751,15 +1624,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Cerrado"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1773,8 +1644,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1789,22 +1658,18 @@ msgstr "Falta el codigo!"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1816,39 +1681,31 @@ msgstr ""
 msgid "Company"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr "Direccion de la Empresa"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr "Fax de la Empresa"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Nombre de la Empresa"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr "Telefono de la Empresa"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1869,7 +1726,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Confirmar!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1887,7 +1744,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Contacto"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1903,7 +1759,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1921,9 +1776,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1953,7 +1805,6 @@ msgstr ""
 msgid "Contra"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1961,10 +1812,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1995,20 +1842,16 @@ msgstr "Copiar como Nuevo"
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Costo"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2024,26 +1867,20 @@ msgstr "No se puede salvar!"
 msgid "Could not transfer Inventory!"
 msgstr "No se puede transferir Inventario!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2055,7 +1892,6 @@ msgstr ""
 msgid "Country"
 msgstr "Pais"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2068,7 +1904,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2076,11 +1912,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr "Crear Base de Datos?"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2108,8 +1944,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2117,17 +1951,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Haber"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2152,29 +1983,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr "Nota de Credito"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr "Creditos"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Moneda"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2197,18 +2018,14 @@ msgstr "Moneda"
 msgid "Currency"
 msgstr "Moneda"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Actual"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2218,11 +2035,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2237,7 +2050,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Cliente"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2256,9 +2068,6 @@ msgstr "Archivo sin cliente!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2278,9 +2087,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "Falta el Cliente!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2292,7 +2099,7 @@ msgstr "Archivo sin cliente!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2316,12 +2123,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr "Informacion no salvada. Por favor vuelva a intentarlo."
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr "Informacion no salvada. Por favor actualice nuevamente."
 
@@ -2354,28 +2160,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr "La base de datos no existe."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2422,19 +2216,14 @@ msgstr ""
 msgid "Date"
 msgstr "Fecha"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2456,7 +2245,6 @@ msgstr "Fecha de Recibido"
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2520,8 +2308,6 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2537,10 +2323,8 @@ msgstr "Factura de Debito"
 msgid "Debit Note"
 msgstr "Nota de Debito"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2550,17 +2334,14 @@ msgstr "Debitos"
 msgid "Dec"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2570,7 +2351,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2583,47 +2363,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr "Correo por Defecto Con Copia Oculta a"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr "Correo por Defecto Con Copia a"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr "Correo por Defecto Desde"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr "Correo por Defecto Para"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr "Reportable por Defecto"
@@ -2636,21 +2407,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "Predeterminados"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2668,7 +2432,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Eliminar"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr "Eliminar Lote"
@@ -2681,7 +2444,6 @@ msgstr "Eliminar Idioma"
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr "Eliminar Cupones"
@@ -2695,37 +2457,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Fecha Entrega"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr "Depresiacion Basica"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr "Metodo de Depresiacion"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr "Comienzo de Depreciacion"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr "Depre. de año hasta la fecha"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr "Depre. esta corrida"
 
@@ -2747,20 +2505,17 @@ msgstr "Depreciar"
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr "Depreciacion"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr "Cuenta de Depreciacion"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2771,46 +2526,7 @@ msgstr "Metodo de Depreciacion"
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2921,12 +2637,10 @@ msgstr "Detalle"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2939,7 +2653,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2948,7 +2661,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Descuento"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2957,28 +2669,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr "Valor de Dispo. Adquirida"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr "Disposicion"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr "Fecha de Disposicion"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr "Metodo de Disposicion"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2986,7 +2698,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2995,7 +2706,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -3003,12 +2714,10 @@ msgstr ""
 msgid "Done"
 msgstr "Hecho"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3021,12 +2730,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr "Borrador Anunciado"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3035,19 +2742,16 @@ msgstr ""
 msgid "Drafts"
 msgstr "Borradores"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Dibujo"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3063,10 +2767,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3085,7 +2785,7 @@ msgstr ""
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3111,7 +2811,7 @@ msgstr ""
 msgid "E-mailed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3141,7 +2841,7 @@ msgstr ""
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr "Editar Clases de Activos"
 
@@ -3285,8 +2985,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3300,7 +2998,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Empleado"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3310,12 +3007,11 @@ msgstr "Numero de Empleado"
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3325,37 +3021,26 @@ msgstr "Numero de Empleado"
 msgid "Employees"
 msgstr "Empleados"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3379,7 +3064,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3404,12 +3088,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3419,7 +3101,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr "Ingresado en"
 
@@ -3427,7 +3109,6 @@ msgstr "Ingresado en"
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3453,7 +3134,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Nombre"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3465,14 +3146,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Patrimonio Neto"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3486,16 +3164,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr "Error creando lote recurrente. Por favor intente nuevamente."
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3503,7 +3180,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr "Vida Estimada"
 
@@ -3516,8 +3193,6 @@ msgstr "Cada"
 msgid "Exch"
 msgstr "Inter"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3532,7 +3207,6 @@ msgstr "Tasa de Cambio"
 msgid "Exchange rate for payment missing!"
 msgstr "Falta la tasa de cambio para el pago!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3541,7 +3215,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "Falta la tasa de cambio!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3559,13 +3232,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3643,8 +3313,7 @@ msgstr ""
 msgid "Feb"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr ""
 
@@ -3660,14 +3329,10 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr "Archivo Importado!"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3678,11 +3343,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr "Nombre de Archivo"
 
@@ -3693,7 +3358,6 @@ msgstr "Nombre de Archivo"
 msgid "File type"
 msgstr "Tipo de Archivo"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3751,12 +3415,10 @@ msgstr "Activos Fijo"
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr ""
@@ -3765,12 +3427,10 @@ msgstr ""
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3787,7 +3447,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3806,18 +3465,10 @@ msgstr ""
 msgid "From"
 msgstr "De"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3838,7 +3489,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr "Desde Deposito"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3849,15 +3499,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr "Todos los Permisos"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3871,10 +3516,8 @@ msgstr "Todos los Permisos"
 msgid "GIFI"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3895,7 +3538,6 @@ msgstr "Codigo GIFI guardado!"
 msgid "GL"
 msgstr "Libro Mayor"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr "Numero de Referencia para Libro Mayor"
@@ -3904,7 +3546,7 @@ msgstr "Numero de Referencia para Libro Mayor"
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr "Ganancia (Perdida)"
 
@@ -3912,12 +3554,11 @@ msgstr "Ganancia (Perdida)"
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 #, fuzzy
 msgid "Gain/Loss"
 msgstr "Ganancia (Perdida)"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3926,7 +3567,7 @@ msgstr ""
 msgid "General Journal"
 msgstr "Libro Diario"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3934,9 +3575,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr "Generar"
 
@@ -3952,7 +3592,7 @@ msgstr "Generar Ordenes"
 msgid "Generate Purchase Orders"
 msgstr "Generar Ordenes de Compra"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3960,7 +3600,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr "Generar Ordenes de Venta"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3976,12 +3616,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr "Bienes y Sevicios"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3990,7 +3628,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4064,21 +3701,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4109,7 +3731,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4119,13 +3740,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Imagen"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4168,7 +3787,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4202,14 +3820,10 @@ msgstr ""
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4217,12 +3831,10 @@ msgstr ""
 msgid "Income"
 msgstr "Ingreso"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4233,7 +3845,6 @@ msgstr "Declaracion de Ganancias"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4243,7 +3854,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Declaracion de Ganancias"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4263,11 +3873,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4277,30 +3886,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "Notas Internas"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4310,17 +3915,14 @@ msgstr "Inventario"
 msgid "Inventory Activity"
 msgstr "Actividad del Inventario"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4346,11 +3948,7 @@ msgstr "Inventario guardado!"
 msgid "Inventory transferred!"
 msgstr "Inventario transferido!"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4392,8 +3990,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4409,11 +4005,6 @@ msgstr "Falta la fecha de factura!"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4432,7 +4023,6 @@ msgstr "Numero de Factura"
 msgid "Invoice Number missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4462,12 +4052,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4525,8 +4113,7 @@ msgstr ""
 msgid "Jan"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr ""
 
@@ -4555,8 +4142,7 @@ msgstr ""
 msgid "Jul"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr ""
 
@@ -4564,8 +4150,8 @@ msgstr ""
 msgid "Jun"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr ""
 
@@ -4578,10 +4164,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "Plantilla LaTeX"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4603,15 +4185,12 @@ msgstr "Tarea/Costos Generales"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Idioma"
@@ -4632,7 +4211,6 @@ msgstr "Idioma no definido!"
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4643,7 +4221,6 @@ msgstr "Ultimo Costo"
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4665,40 +4242,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr "Tiempo de Espera"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4710,9 +4286,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4734,9 +4308,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4750,8 +4322,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr "Encabezado"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4768,7 +4338,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4805,7 +4374,6 @@ msgstr "Listar Idioma"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4831,7 +4399,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr "Listar Depositos"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4849,7 +4416,6 @@ msgstr "Ubicacion"
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4870,7 +4436,7 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4898,45 +4464,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Hacer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr "Administrar Usuarios"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4958,40 +4517,34 @@ msgstr ""
 msgid "Mar"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Margen de Ganancia"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr "Maximo por menu desplegable"
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Memo"
@@ -5008,7 +4561,6 @@ msgstr ""
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Metodo"
@@ -5017,7 +4569,6 @@ msgstr "Metodo"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5036,14 +4587,11 @@ msgstr "Segundo Nombre"
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5057,7 +4605,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5070,14 +4617,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Modelo"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5095,7 +4640,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5119,14 +4664,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5135,15 +4678,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5162,7 +4696,6 @@ msgstr "Nombre"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr "Valor Neto de Libro"
@@ -5213,8 +4746,6 @@ msgstr ""
 msgid "Next Number"
 msgstr "Proximo Numero"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5236,12 +4767,10 @@ msgstr ""
 msgid "Ninety"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5250,7 +4779,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5258,11 +4787,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5270,7 +4799,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5279,11 +4807,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr "Archivo no subido"
 
@@ -5291,21 +4819,18 @@ msgstr "Archivo no subido"
 msgid "No open Projects!"
 msgstr "No hay Proyectos abiertos!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5324,12 +4849,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5338,12 +4861,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5381,11 +4902,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5431,23 +4947,18 @@ msgstr "Nada para transferir!"
 msgid "Nov"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5478,7 +4989,7 @@ msgstr ""
 msgid "Number"
 msgstr "Numero"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr ""
 
@@ -5499,13 +5010,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Obsoleto"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5514,8 +5023,7 @@ msgstr ""
 msgid "Oct"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr ""
 
@@ -5527,9 +5035,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5579,7 +5084,6 @@ msgstr ""
 msgid "Open"
 msgstr "Abrir"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5602,9 +5106,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5650,7 +5151,6 @@ msgstr "Falta la Fecha de Orden!"
 msgid "Order Entry"
 msgstr "Entrada de Orden"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5672,7 +5172,6 @@ msgstr "Orden eliminada!"
 msgid "Order generation failed!"
 msgstr "Fallo la generacion de Orden!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5694,7 +5193,7 @@ msgstr "Ordenes generadas!"
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr "Balance Nuestro"
 
@@ -5740,7 +5239,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5759,10 +5257,6 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5806,11 +5300,6 @@ msgstr ""
 msgid "Packing list"
 msgstr "Lista de Envios"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5828,12 +5317,10 @@ msgstr "Pagado"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5843,14 +5330,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5880,14 +5359,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5903,15 +5378,12 @@ msgstr ""
 msgid "Parts"
 msgstr "Grupo de Partes"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr "Grupo de Partes"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5921,7 +5393,6 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5934,7 +5405,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5948,7 +5418,6 @@ msgstr ""
 msgid "Payables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5957,7 +5426,6 @@ msgstr ""
 msgid "Payment"
 msgstr "Pago"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5970,7 +5438,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr "Resultado de Pagos"
@@ -5987,7 +5454,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6023,15 +5489,15 @@ msgstr "Pagos"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr "Porcentaje"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr "Porcentaje Disposcionado"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr "Porcentaje Remanente"
 
@@ -6050,7 +5516,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6081,108 +5546,88 @@ msgstr "Lista de Retiros"
 msgid "Pick list"
 msgstr "Lista de Retiros"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6198,7 +5643,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6207,24 +5651,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6233,13 +5675,11 @@ msgstr ""
 msgid "Post"
 msgstr "Anunciar"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr "Anunciar Lote"
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr "Fecha Anuncio"
 
@@ -6280,7 +5720,6 @@ msgstr ""
 msgid "Postscript"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6318,20 +5757,16 @@ msgstr ""
 msgid "Price"
 msgstr "Precio"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6367,8 +5802,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6378,7 +5811,6 @@ msgstr ""
 msgid "Print"
 msgstr "Imprimir"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6395,7 +5827,7 @@ msgstr "Imprimir y Salvar como nuevo"
 msgid "Printed"
 msgstr "Impreso"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr ""
 
@@ -6439,17 +5871,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr "Depre. Previa"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr "Atravez Previo"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr "Recaudacion"
 
@@ -6478,7 +5908,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6497,7 +5926,6 @@ msgstr "Traducciones de Descripciones de Proyecto"
 msgid "Project Number"
 msgstr "Numero de Proyecto"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6506,9 +5934,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Proyectos"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6518,7 +5943,6 @@ msgstr "Fecha de Compra"
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6536,22 +5960,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Orden de Compra"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Ordenes de Compra"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6566,14 +5984,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Orden de Compra"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6604,7 +6018,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Ctd."
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6618,8 +6031,6 @@ msgstr "La cantidad excede las unidades disponibles para stockear!"
 msgid "Quarter"
 msgstr "Cuarto"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6656,9 +6067,7 @@ msgstr "Falta el Numero de Presupuesto!"
 msgid "Quotation deleted!"
 msgstr "Presupuesto eliminado!"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6679,25 +6088,20 @@ msgstr "Pedido de Presupuesto"
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "Numero de Pedido para Presupuesto"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "Pedio de Presupuestos"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6709,7 +6113,6 @@ msgstr "Tasa"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6732,13 +6135,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6756,7 +6155,6 @@ msgstr "Recibo"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6770,8 +6168,7 @@ msgstr "Recibos"
 msgid "Receivables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Recibo"
 
@@ -6779,7 +6176,6 @@ msgstr "Recibo"
 msgid "Receive Merchandise"
 msgstr "Recibo de Mercancias"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6800,7 +6196,6 @@ msgstr "Reconciliacion"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6821,13 +6216,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Trans. Recurrentes"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6866,12 +6254,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr "Vida Remanente"
@@ -6909,7 +6295,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr "Resultados de Reportes"
 
@@ -6921,7 +6307,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6934,7 +6320,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6984,7 +6369,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -7004,13 +6389,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Requerido por"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7040,7 +6422,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7049,7 +6430,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7066,7 +6446,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr "Pago Inverso"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr "Pagos Inversos"
@@ -7116,11 +6495,11 @@ msgstr ""
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7146,7 +6525,6 @@ msgstr "Ventas"
 msgid "Sales Invoice"
 msgstr "Factura de Ventas"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Factura/Numero de Transaccion para Ingreso"
@@ -7162,20 +6540,17 @@ msgstr "Factura/Numero de Transaccion para Ingreso"
 msgid "Sales Order"
 msgstr "Orden de Venta"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "Numero de Orden para Ventas"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Ordenes de Venta"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "Numero de Presupuesto para Ventas"
@@ -7198,9 +6573,6 @@ msgstr "Numero de Presupuesto para Ventas"
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7224,13 +6596,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7250,7 +6619,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7260,7 +6629,6 @@ msgstr "Guardar"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr "Salvar Lote"
@@ -7319,11 +6687,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "Guardar como nuevo"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7346,10 +6713,8 @@ msgstr "Temporizar"
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Pantalla"
 
@@ -7369,7 +6734,6 @@ msgstr "Pantalla"
 msgid "Search"
 msgstr "Buscar"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7378,7 +6742,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7431,11 +6794,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7447,11 +6810,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7463,7 +6826,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr "Buscar Reportes"
 
@@ -7471,7 +6834,6 @@ msgstr "Buscar Reportes"
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7527,7 +6889,6 @@ msgstr ""
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7536,9 +6897,6 @@ msgstr ""
 msgid "Sell"
 msgstr "Venta"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7592,13 +6950,11 @@ msgstr ""
 msgid "Sep"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr ""
 
@@ -7619,9 +6975,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "Numero de Serie"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7651,7 +7004,6 @@ msgstr "Codigo de Servicio"
 msgid "Services"
 msgstr "Aregar Servicio"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 msgid "Session Timeout (e.g. \"90 minutes\")"
 msgstr ""
@@ -7664,7 +7016,7 @@ msgstr "Sesiones"
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7684,10 +7036,10 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Despachar"
 
@@ -7714,10 +7066,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7778,10 +7126,6 @@ msgstr "Falta la Fecha de Envio!"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7823,7 +7167,6 @@ msgstr "Fecha de Envio"
 msgid "Short"
 msgstr "Ordenar"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7864,7 +7207,6 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7877,12 +7219,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7909,7 +7245,6 @@ msgstr "Fuente"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7931,21 +7266,10 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "Codigo de Actividad (SIC)"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7976,8 +7300,6 @@ msgstr ""
 msgid "Startdate"
 msgstr "Fecha de Inicio"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8014,13 +7336,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Declaracion"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8050,7 +7370,7 @@ msgstr "Provicion de Manufacturas"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Hoja de Estilo"
 
@@ -8075,7 +7395,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8118,7 +7437,6 @@ msgstr "Resumen"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8151,12 +7469,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8168,9 +7480,6 @@ msgstr "Etiqueta"
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8189,8 +7498,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr "Codigo de Impuesto"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8201,17 +7508,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr "Forma de Impuesto Aplicada"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr "Lista Forma de Impuesto"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8355,7 +7659,6 @@ msgstr ""
 msgid "Template"
 msgstr "Guardar Plantilla"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8364,7 +7667,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8417,7 +7719,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr "Balance Suyo"
 
@@ -8429,7 +7731,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8480,27 +7782,24 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 "Este movimiento del Libro General es consecuencia de una transaccion de pago"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 "Este movimiento del Libro General es consecuencia de una transaccion de "
 "sobrepago"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8523,14 +7822,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8574,7 +7869,6 @@ msgstr "Ficha de Horario"
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8604,19 +7898,10 @@ msgstr ""
 msgid "To"
 msgstr "A"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8653,7 +7938,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr "Pagar a"
@@ -8678,16 +7962,7 @@ msgstr ""
 msgid "Top-level"
 msgstr "Nivel Raiz"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8730,7 +8005,7 @@ msgstr "Nivel Raiz"
 msgid "Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr "Depre. Acumulada Total"
 
@@ -8738,7 +8013,6 @@ msgstr "Depre. Acumulada Total"
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8759,7 +8033,6 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr "Aprobaciones"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8775,14 +8048,12 @@ msgstr "Falta la fecha en la transaccion!"
 msgid "Transaction Dates"
 msgstr "Fecha de Traduccion"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8821,7 +8092,6 @@ msgstr "Traducciones"
 msgid "Translations saved!"
 msgstr "Traduccion salvada!"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Balance de Comprobacion"
@@ -8830,7 +8100,6 @@ msgstr "Balance de Comprobacion"
 msgid "Trillion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8887,10 +8156,6 @@ msgstr ""
 msgid "Two"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8925,39 +8190,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr "Numero Unico de Factura de Ingreso"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr "Numero Unico de Cliente"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr "Numero Unico de Proveedor"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr "Numero Unico de Parte no obsoleta"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8976,43 +8235,37 @@ msgstr "Unidad"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr "Se encontro una base de datos desconocida."
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9020,23 +8273,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9053,7 +8301,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9081,21 +8328,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9104,7 +8346,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9122,24 +8363,19 @@ msgstr "Usar Sobrepago"
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr "Usar sobrepago/prepago"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9149,7 +8385,6 @@ msgstr ""
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr "Usuario existe. Importar?"
@@ -9170,7 +8405,6 @@ msgstr "Usuario"
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9196,8 +8430,6 @@ msgstr "Valido hasta"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9207,11 +8439,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9227,7 +8455,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Proveedor"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9241,7 +8468,6 @@ msgstr ""
 msgid "Vendor Invoice"
 msgstr "Factura de Proveedor"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr "Factura de Proveedor/Numero de Transaccion para Egreso"
@@ -9251,9 +8477,6 @@ msgstr "Factura de Proveedor/Numero de Transaccion para Egreso"
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9283,9 +8506,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "Falta el proveedor!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9293,8 +8514,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Archivo sin proveedor!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9309,7 +8528,6 @@ msgstr ""
 msgid "Void"
 msgstr "Vacio"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9322,7 +8540,6 @@ msgstr "Cupones"
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9345,7 +8562,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Depositos"
@@ -9354,11 +8570,26 @@ msgstr "Depositos"
 msgid "Warning!"
 msgstr "Advertencia!"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9368,7 +8599,6 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9385,13 +8615,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Peso"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr ""
@@ -9408,7 +8636,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9426,11 +8653,11 @@ msgstr "Orden de Trabajo"
 msgid "Work order"
 msgstr "Orden de Trabajo"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9473,15 +8700,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Si"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9508,7 +8730,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9572,17 +8794,12 @@ msgstr "dias"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr "eliminar"
 
@@ -9599,7 +8816,7 @@ msgstr ""
 msgid "done"
 msgstr "hecho"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9627,8 +8844,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9637,22 +8852,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr "es mayor que el monto disponible"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr "es menor que 0"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr "es menor que el monto a ser pagado"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr "es nada"
@@ -9677,7 +8888,6 @@ msgstr ""
 msgid "sent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 #, fuzzy
 msgid "system type"
@@ -9703,8 +8913,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr "error inesperado!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr "uso de un sobrepago"

--- a/locale/po/es_CO.po
+++ b/locale/po/es_CO.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Spanish (Colombia) (http://www.transifex.com/ledgersmb/"
@@ -15,27 +15,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr "# Factura"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -48,12 +43,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -99,7 +90,6 @@ msgstr "Facturas de Proveedores"
 msgid "AP Aging"
 msgstr "Cartera"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -108,7 +98,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -123,7 +112,6 @@ msgstr "Impagados Proveedores"
 msgid "AP Transaction"
 msgstr "Transaccion Proveedor"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Gestiones de pagos"
@@ -136,9 +124,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -157,7 +143,6 @@ msgstr "Factura de Ventas"
 msgid "AR Aging"
 msgstr "Cartera "
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -166,7 +151,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -181,7 +165,6 @@ msgstr "Impagados Cartera"
 msgid "AR Transaction"
 msgstr "Cuentas por Cobrar"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Cuentas por Cobrar"
@@ -194,9 +177,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -205,8 +186,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Cuentas por Cobrar"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -216,16 +195,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr "Acceso restringido"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -251,38 +225,20 @@ msgstr "Acceso restringido"
 msgid "Account"
 msgstr "Cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -303,23 +259,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Número de cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -359,17 +310,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -381,7 +330,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -409,12 +358,10 @@ msgstr "Activo"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -437,11 +384,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr "Añadir Compuesto"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -566,7 +513,6 @@ msgstr "Añadir Cotización"
 msgid "Add Service"
 msgstr "Añadir Servicio"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -633,7 +579,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Actualizar"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -658,7 +603,6 @@ msgstr "Dirección:"
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -668,12 +612,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -693,8 +636,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -747,7 +689,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -756,11 +697,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -794,14 +730,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Total"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -810,27 +742,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Por Pagar"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -848,14 +774,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -874,17 +800,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -893,13 +816,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -908,7 +824,6 @@ msgstr ""
 msgid "Approve"
 msgstr "Aprobar"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -917,14 +832,12 @@ msgstr "Aprobar"
 msgid "Approved"
 msgstr "Aprobada"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr "Aprobada por"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -936,19 +849,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Abr"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "Abril"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -964,7 +874,6 @@ msgstr "Seguro que quiere borrar la cotización número"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -983,19 +892,17 @@ msgstr "¡Compuestos actualizados en almacen!"
 msgid "Asset"
 msgstr "Activo"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1008,29 +915,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1046,7 +950,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1144,8 +1047,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Ago"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Agosto"
 
@@ -1157,7 +1059,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1171,7 +1072,6 @@ msgstr "Bases de datos disponibles"
 msgid "Available Users"
 msgstr "Usuarios disponibles"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1184,7 +1084,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1218,8 +1117,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1234,7 +1131,6 @@ msgstr "Balance"
 msgid "Balance Sheet"
 msgstr "Hoja de balance"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1255,7 +1151,6 @@ msgstr "Cuenta bancaria"
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1266,7 +1161,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1276,18 +1170,15 @@ msgstr "Moneda"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1300,12 +1191,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1322,13 +1211,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1369,8 +1256,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1417,17 +1302,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1440,12 +1322,10 @@ msgstr ""
 msgid "Business"
 msgstr "Empresa"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Numero de negocio"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1455,12 +1335,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1482,7 +1360,6 @@ msgstr "Empresa guardada!"
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1514,18 +1391,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1651,12 +1526,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Plan de cuentas"
 
@@ -1676,7 +1550,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "Revisar Inventario"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1705,7 +1578,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1717,9 +1590,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "Borrado"
 
@@ -1747,15 +1620,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Cerrado"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1769,8 +1640,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1785,22 +1654,18 @@ msgstr "Falta código"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1812,39 +1677,31 @@ msgstr ""
 msgid "Company"
 msgstr "Empresa"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Nombre de la empresa"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1865,7 +1722,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Confirmar"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1883,7 +1740,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Contacto"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1899,7 +1755,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1917,9 +1772,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1949,7 +1801,6 @@ msgstr ""
 msgid "Contra"
 msgstr "Cuentas del Orden"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1957,10 +1808,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1991,20 +1838,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Costo"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2020,26 +1863,20 @@ msgstr "No pude guardar"
 msgid "Could not transfer Inventory!"
 msgstr "No puedo transferir inventario!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2051,7 +1888,6 @@ msgstr ""
 msgid "Country"
 msgstr "País"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2064,7 +1900,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2072,11 +1908,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2104,8 +1940,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2113,17 +1947,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Crédito"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2148,29 +1979,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Mon."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2193,18 +2014,14 @@ msgstr "Mon."
 msgid "Currency"
 msgstr "Moneda"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Actual"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2214,11 +2031,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2233,7 +2046,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Cliente"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2252,9 +2064,6 @@ msgstr "¡El cliente no existe!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2274,9 +2083,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "¡Falta el cliente!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2288,7 +2095,7 @@ msgstr "¡El cliente no existe!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2312,12 +2119,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2350,28 +2156,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr "La base de datos no existe."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2418,19 +2212,14 @@ msgstr ""
 msgid "Date"
 msgstr "Fecha"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2452,7 +2241,6 @@ msgstr "Fecha recibido"
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2516,8 +2304,6 @@ msgstr ""
 msgid "Days"
 msgstr "Dias"
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2533,10 +2319,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2546,17 +2330,14 @@ msgstr ""
 msgid "Dec"
 msgstr "Dic"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Diciembre"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2566,7 +2347,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2579,47 +2359,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2632,21 +2403,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "Preferencias"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2664,7 +2428,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Borrar"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2677,7 +2440,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr "Borrar Programación"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2691,37 +2453,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Fecha de entrega"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2743,20 +2501,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2767,46 +2522,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2917,12 +2633,10 @@ msgstr "Detalle"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2935,7 +2649,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2944,7 +2657,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Descuento"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2953,28 +2665,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2982,7 +2694,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2991,7 +2702,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -2999,12 +2710,10 @@ msgstr ""
 msgid "Done"
 msgstr "Hecho"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3017,12 +2726,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3031,19 +2738,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Reintegro"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3059,10 +2763,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3081,7 +2781,7 @@ msgstr "Falta la fecha de vencimiento"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3107,7 +2807,7 @@ msgstr "Mensaje Email"
 msgid "E-mailed"
 msgstr "Enviado por mail"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3137,7 +2837,7 @@ msgstr "Editar Asiento de CxC"
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3281,8 +2981,6 @@ msgstr "once"
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3296,7 +2994,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Colaborador/Empleado"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3306,12 +3003,11 @@ msgstr "Número de Empleado"
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3321,37 +3017,26 @@ msgstr "Número de Empleado"
 msgid "Employees"
 msgstr "Empleados"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3375,7 +3060,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3400,12 +3084,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3415,7 +3097,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3423,7 +3105,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3449,7 +3130,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Nombre de la empresa"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3461,14 +3142,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Balance"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3482,16 +3160,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3499,7 +3176,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3512,8 +3189,6 @@ msgstr "Cada"
 msgid "Exch"
 msgstr "Cambio"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3528,7 +3203,6 @@ msgstr "Tasa de Cambio"
 msgid "Exchange rate for payment missing!"
 msgstr "Falta Tasa de Cambio"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3537,7 +3211,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "Falta Tasa de Cambio"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3555,13 +3228,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Gastos/Activo"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3639,8 +3309,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Febrero"
 
@@ -3656,14 +3325,10 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3674,11 +3339,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3689,7 +3354,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3747,12 +3411,10 @@ msgstr ""
 msgid "For"
 msgstr "Para"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Ganancia en moneda extranjera"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Pérdida en moneda extranjera"
@@ -3761,12 +3423,10 @@ msgstr "Pérdida en moneda extranjera"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3783,7 +3443,6 @@ msgstr "cuatro"
 msgid "Fourteen"
 msgstr "catorce"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3802,18 +3461,10 @@ msgstr ""
 msgid "From"
 msgstr "De"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3834,7 +3485,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3845,15 +3495,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3867,10 +3512,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "Plan Único de Cuentas (PUC)"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3891,7 +3534,6 @@ msgstr "¡Guardado el código PUC!"
 msgid "GL"
 msgstr "Nota Contable"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3900,7 +3542,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3908,11 +3550,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3921,7 +3562,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3929,9 +3570,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr "Elaborar"
 
@@ -3947,7 +3587,7 @@ msgstr "Elaborar Pedidos"
 msgid "Generate Purchase Orders"
 msgstr "Elaborar Orden de Venta"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3955,7 +3595,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3971,12 +3611,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3985,7 +3623,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4059,21 +3696,6 @@ msgstr ""
 msgid "Hundred"
 msgstr "ciento"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4104,7 +3726,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4114,13 +3735,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Imagen"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4163,7 +3782,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4197,14 +3815,10 @@ msgstr "Incluir en menúes desplegables:"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4212,12 +3826,10 @@ msgstr ""
 msgid "Income"
 msgstr "Ingreso"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4228,7 +3840,6 @@ msgstr "Estado de Resultados"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4238,7 +3849,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Estado de Resultados"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4258,11 +3868,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4272,30 +3881,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "Notas internas"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4305,17 +3910,14 @@ msgstr "Inventario"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4343,11 +3945,7 @@ msgstr "Inventario guardado!"
 msgid "Inventory transferred!"
 msgstr "Inventario transferido!"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4389,8 +3987,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4406,11 +4002,6 @@ msgstr "No se ha definido la fecha de la factura"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4429,7 +4020,6 @@ msgstr "Número de factura"
 msgid "Invoice Number missing!"
 msgstr "No se ha definido el número de la factura"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4459,12 +4049,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4522,8 +4110,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Ene"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Enero"
 
@@ -4552,8 +4139,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Julio"
 
@@ -4561,8 +4147,8 @@ msgstr "Julio"
 msgid "Jun"
 msgstr "Jun"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Junio"
 
@@ -4575,10 +4161,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "Plantillas LaTeX"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4600,15 +4182,12 @@ msgstr "Honorarios"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Idioma"
@@ -4629,7 +4208,6 @@ msgstr "Idiomas no configuradas!"
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4640,7 +4218,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4662,40 +4239,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr "Plazo"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4707,9 +4283,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4731,9 +4305,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4747,8 +4319,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4765,7 +4335,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4802,7 +4371,6 @@ msgstr "Mostrar Idiomas"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4828,7 +4396,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4846,7 +4413,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4867,7 +4433,7 @@ msgstr ""
 msgid "Login"
 msgstr "Entrar"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4895,45 +4461,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Marca"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4955,40 +4514,34 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Marzo"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Margen"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "Mayo"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Memo"
@@ -5005,7 +4558,6 @@ msgstr "Mensaje"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Metódo"
@@ -5014,7 +4566,6 @@ msgstr "Metódo"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5033,14 +4584,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5054,7 +4602,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5067,14 +4614,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Modelo"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5092,7 +4637,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5116,14 +4661,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5132,15 +4675,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5159,7 +4693,6 @@ msgstr "Nombre"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5210,8 +4743,6 @@ msgstr "Proxima Fecha"
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5233,12 +4764,10 @@ msgstr "diecinueve"
 msgid "Ninety"
 msgstr "noventa"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "No"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5247,7 +4776,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5255,11 +4784,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5267,7 +4796,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5276,11 +4804,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5288,21 +4816,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5321,12 +4846,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5335,12 +4858,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5378,11 +4899,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5428,23 +4944,18 @@ msgstr "Nada para transferir"
 msgid "Nov"
 msgstr "Nov"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "Noviembre"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5475,7 +4986,7 @@ msgstr ""
 msgid "Number"
 msgstr "Número"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Formato de número"
 
@@ -5496,13 +5007,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Obsoleto"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5511,8 +5020,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Oct"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Octubre"
 
@@ -5524,9 +5032,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5576,7 +5081,6 @@ msgstr ""
 msgid "Open"
 msgstr "Abierto"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5598,9 +5102,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5646,7 +5147,6 @@ msgstr "No se ha definido la fecha de la elaboración"
 msgid "Order Entry"
 msgstr "Cotizaciones y pedidos"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5668,7 +5168,6 @@ msgstr "¡Orden borrada!"
 msgid "Order generation failed!"
 msgstr "Fallo Elaboración Pedido"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5690,7 +5189,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5736,7 +5235,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5755,10 +5253,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5802,11 +5296,6 @@ msgstr "No se ha definido el número del albarán"
 msgid "Packing list"
 msgstr "Albarán"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5824,12 +5313,10 @@ msgstr "Pagado"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Artículo"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5839,14 +5326,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5876,14 +5355,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5899,15 +5374,12 @@ msgstr "Número parte"
 msgid "Parts"
 msgstr "Artículo"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5917,7 +5389,6 @@ msgstr ""
 msgid "Password"
 msgstr "Contraseña"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5930,7 +5401,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5944,7 +5414,6 @@ msgstr ""
 msgid "Payables"
 msgstr "Por Pagar"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5953,7 +5422,6 @@ msgstr "Por Pagar"
 msgid "Payment"
 msgstr "Comprobante de Egreso"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5966,7 +5434,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5983,7 +5450,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6019,15 +5485,15 @@ msgstr "Pagos"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr "Porcentaje"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6046,7 +5512,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6077,108 +5542,88 @@ msgstr "Lista de Empaque"
 msgid "Pick list"
 msgstr "Lista de Empaque"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6194,7 +5639,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6203,24 +5647,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6229,13 +5671,11 @@ msgstr ""
 msgid "Post"
 msgstr "Registrar"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6276,7 +5716,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Postscript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6314,20 +5753,16 @@ msgstr ""
 msgid "Price"
 msgstr "Precio"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6363,8 +5798,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6374,7 +5807,6 @@ msgstr ""
 msgid "Print"
 msgstr "Imprimir"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6391,7 +5823,7 @@ msgstr ""
 msgid "Printed"
 msgstr "Impreso"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Impresora"
 
@@ -6435,17 +5867,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6474,7 +5904,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6493,7 +5922,6 @@ msgstr "Descripción Traducción del Proyecto"
 msgid "Project Number"
 msgstr "Número del Proyecto"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6502,9 +5930,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Proyectos"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6514,7 +5939,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6532,22 +5956,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Pedido"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "Número de Orden de Compra"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Pedidos"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6562,14 +5980,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Pedido"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6600,7 +6014,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Cantidad"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6614,8 +6027,6 @@ msgstr "No hay esta cantidad disponible en el Inventario!"
 msgid "Quarter"
 msgstr "Trimestre"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6652,9 +6063,7 @@ msgstr "Falta número de cotización"
 msgid "Quotation deleted!"
 msgstr "Cotización borrado"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6675,25 +6084,20 @@ msgstr "Solicitar Cotización"
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "Número de Cotización"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "Cotizaciones solicitados"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "Tope de envio"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6705,7 +6109,6 @@ msgstr "Tarifa"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6728,13 +6131,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6752,7 +6151,6 @@ msgstr "Recibo"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6766,8 +6164,7 @@ msgstr "Recibos"
 msgid "Receivables"
 msgstr "Cobros"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Recibir"
 
@@ -6775,7 +6172,6 @@ msgstr "Recibir"
 msgid "Receive Merchandise"
 msgstr "Recibir mercancia"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6796,7 +6192,6 @@ msgstr "Reconciliación"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6817,13 +6212,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Transacciones Recurrentes"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6862,12 +6250,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6905,7 +6291,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6917,7 +6303,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6930,7 +6316,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6980,7 +6365,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -7000,13 +6385,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Aceptado el"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7036,7 +6418,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7045,7 +6426,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7062,7 +6442,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7112,11 +6491,11 @@ msgstr "SKU"
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7142,7 +6521,6 @@ msgstr "Ventas"
 msgid "Sales Invoice"
 msgstr "Facturas de Ventas"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7158,20 +6536,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr "Orden de Venta"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "N°de Pedido"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Ordenes de Venta"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "N°de Cotización de Venta"
@@ -7194,9 +6569,6 @@ msgstr "N°de Cotización de Venta"
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7220,13 +6592,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7246,7 +6615,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7256,7 +6625,6 @@ msgstr "Guardar"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7315,11 +6683,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "Guardar como nuevo"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7342,10 +6709,8 @@ msgstr "Programar Recurrencia"
 msgid "Scheduled"
 msgstr "Programado"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Pantalla"
 
@@ -7365,7 +6730,6 @@ msgstr "Pantalla"
 msgid "Search"
 msgstr "Búsqueda"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7374,7 +6738,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7427,11 +6790,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7443,11 +6806,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7459,7 +6822,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7467,7 +6830,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7523,7 +6885,6 @@ msgstr "¡Seleccione txt, postscript o PDF!"
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7532,9 +6893,6 @@ msgstr ""
 msgid "Sell"
 msgstr "Vender"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7588,13 +6946,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Sep"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "Septiembre"
 
@@ -7615,9 +6971,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "No de Serial"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7647,7 +7000,6 @@ msgstr ""
 msgid "Services"
 msgstr "Servicio"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 #, fuzzy
 msgid "Session Timeout (e.g. \"90 minutes\")"
@@ -7661,7 +7013,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7681,10 +7033,10 @@ msgstr "diecisiete"
 msgid "Seventy"
 msgstr "setenta"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Envio"
 
@@ -7711,10 +7063,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7775,10 +7123,6 @@ msgstr "Falta Fecha del Envio"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7820,7 +7164,6 @@ msgstr "Fecha del Envio"
 msgid "Short"
 msgstr "Corto"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7861,7 +7204,6 @@ msgstr "sesenta"
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7874,12 +7216,6 @@ msgstr ""
 msgid "Sort by"
 msgstr "Ordenar por"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7906,7 +7242,6 @@ msgstr "Fuente"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7928,21 +7263,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Estándard"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "Standard Industrial Codes (Código Industrial)"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7973,8 +7297,6 @@ msgstr ""
 msgid "Startdate"
 msgstr "Fecha inicial"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8011,13 +7333,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Estado de Cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Balance de Cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8048,7 +7368,7 @@ msgstr "Inventariar Compuesto"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Hoja de Estilo"
 
@@ -8073,7 +7393,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8116,7 +7435,6 @@ msgstr "Résumen"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8149,12 +7467,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8166,9 +7478,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8187,8 +7496,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8199,17 +7506,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8353,7 +7657,6 @@ msgstr ""
 msgid "Template"
 msgstr "Plantillas HTML"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8362,7 +7665,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8415,7 +7717,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8427,7 +7729,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8478,24 +7780,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8518,14 +7817,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8569,7 +7864,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8599,19 +7893,10 @@ msgstr ""
 msgid "To"
 msgstr "Hasta "
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8648,7 +7933,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8673,16 +7957,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8725,7 +8000,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8733,7 +8008,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8754,7 +8028,6 @@ msgstr "Asiento"
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8770,14 +8043,12 @@ msgstr "No se ha definido la fecha de la transacción"
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8816,7 +8087,6 @@ msgstr "Traducciones"
 msgid "Translations saved!"
 msgstr "Guardado"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Balance de Comprobación"
@@ -8825,7 +8095,6 @@ msgstr "Balance de Comprobación"
 msgid "Trillion"
 msgstr "billón"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8882,10 +8151,6 @@ msgstr "veintidós"
 msgid "Two"
 msgstr "dos"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8920,39 +8185,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8971,43 +8230,37 @@ msgstr "Unidad"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9015,23 +8268,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9048,7 +8296,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9076,21 +8323,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9099,7 +8341,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9117,24 +8358,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9144,7 +8380,6 @@ msgstr "Usuario"
 msgid "User Name"
 msgstr "Nombre de usuario"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9165,7 +8400,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9191,8 +8425,6 @@ msgstr "Válido hasta"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9202,11 +8434,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9222,7 +8450,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Proveedor"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9236,7 +8463,6 @@ msgstr "Historial Proveedor"
 msgid "Vendor Invoice"
 msgstr "Factura de Proveedor"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9246,9 +8472,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9278,9 +8501,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "¡Falta el proveedor!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9288,8 +8509,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "¡No se encuentra el proveedor en la base de datos!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9304,7 +8523,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9317,7 +8535,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9340,7 +8557,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Bodegas"
@@ -9349,11 +8565,26 @@ msgstr "Bodegas"
 msgid "Warning!"
 msgstr "Alerta!"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9363,7 +8594,6 @@ msgstr ""
 msgid "Week"
 msgstr "Semana"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9380,13 +8610,11 @@ msgstr ""
 msgid "Weeks"
 msgstr "Semanas"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Peso"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Unidad de peso"
@@ -9403,7 +8631,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9421,11 +8648,11 @@ msgstr "Orden de Trabajo"
 msgid "Work order"
 msgstr "Orden de Trabajo"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9468,15 +8695,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Si"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9503,7 +8725,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9567,17 +8789,12 @@ msgstr "días"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9594,7 +8811,7 @@ msgstr ""
 msgid "done"
 msgstr "hecho"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9622,8 +8839,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9632,22 +8847,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr "Es menor a 0"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9672,7 +8883,6 @@ msgstr ""
 msgid "sent"
 msgstr "Enviado"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9697,8 +8907,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr "¡Error inesperado!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/es_EC.po
+++ b/locale/po/es_EC.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Spanish (Ecuador) (http://www.transifex.com/ledgersmb/"
@@ -15,27 +15,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -48,12 +43,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -99,7 +90,6 @@ msgstr "Facturas de Proveedores"
 msgid "AP Aging"
 msgstr "Diario resumido de pagos"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -108,7 +98,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -123,7 +112,6 @@ msgstr "Impagados Proveedores"
 msgid "AP Transaction"
 msgstr "Transaccion Proveedor"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr ""
@@ -136,9 +124,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -157,7 +143,6 @@ msgstr "Facturas de Ventas"
 msgid "AR Aging"
 msgstr "Diario resumido de cobros "
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -166,7 +151,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -181,7 +165,6 @@ msgstr "Impagados Cartera"
 msgid "AR Transaction"
 msgstr "Gestión de cobro"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Gestiones de cobros"
@@ -194,9 +177,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -205,8 +186,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Gestión de cobro"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -216,16 +195,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -251,38 +225,20 @@ msgstr ""
 msgid "Account"
 msgstr "Cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -303,23 +259,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Número de cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -359,17 +310,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -381,7 +330,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -409,12 +358,10 @@ msgstr "Activo"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -437,11 +384,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr "Añadir compuesto"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -566,7 +513,6 @@ msgstr "Añadir cotización"
 msgid "Add Service"
 msgstr "Añadir servicio"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -633,7 +579,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Actualizar"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -658,7 +603,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -668,12 +612,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -693,8 +636,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -747,7 +689,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -756,11 +697,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -794,14 +730,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Total"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -810,27 +742,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Cantidad adeudada"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -848,14 +774,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -874,17 +800,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -893,13 +816,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -908,7 +824,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -917,14 +832,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -936,19 +849,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Abr"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "Abril"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -964,7 +874,6 @@ msgstr "¿Está seguro que quiere borrar el número de la Cotización?"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -983,19 +892,17 @@ msgstr "¡Compuestos actualizados en almacen!"
 msgid "Asset"
 msgstr "Activo"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1008,29 +915,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1046,7 +950,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1144,8 +1047,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Ago"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Agosto"
 
@@ -1157,7 +1059,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1171,7 +1072,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1184,7 +1084,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1218,8 +1117,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1234,7 +1131,6 @@ msgstr "Balance"
 msgid "Balance Sheet"
 msgstr "Hoja de balance"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1255,7 +1151,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1266,7 +1161,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1276,18 +1170,15 @@ msgstr "Moneda"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1300,12 +1191,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1322,13 +1211,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1369,8 +1256,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1417,17 +1302,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1440,12 +1322,10 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Numero de negocio"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1455,12 +1335,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1482,7 +1360,6 @@ msgstr "¡Negocio guardado!"
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1514,18 +1391,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1651,12 +1526,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Plan de cuentas"
 
@@ -1676,7 +1550,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1705,7 +1578,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1717,9 +1590,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "¡Limpiado!"
 
@@ -1747,15 +1620,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Cerrado"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1769,8 +1640,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1785,22 +1654,18 @@ msgstr "¡Falta Código!"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1812,39 +1677,31 @@ msgstr ""
 msgid "Company"
 msgstr "Empresa"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Nombre de Compañía"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1865,7 +1722,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Confirmar"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1883,7 +1740,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Contacto"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1899,7 +1755,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1917,9 +1772,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1949,7 +1801,6 @@ msgstr ""
 msgid "Contra"
 msgstr "Contra"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1957,10 +1808,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1991,20 +1838,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2020,26 +1863,20 @@ msgstr "¡No se puede grabar!"
 msgid "Could not transfer Inventory!"
 msgstr "¡No se puede transferir el Inventario!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2051,7 +1888,6 @@ msgstr ""
 msgid "Country"
 msgstr "País"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2064,7 +1900,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2072,11 +1908,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2104,8 +1940,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2113,17 +1947,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Crédito"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2148,29 +1979,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Mon."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2193,18 +2014,14 @@ msgstr "Mon."
 msgid "Currency"
 msgstr "Moneda"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Actual"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2214,11 +2031,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2233,7 +2046,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Cliente"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2252,9 +2064,6 @@ msgstr "¡El cliente no existe!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2274,9 +2083,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "¡Falta el cliente!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2288,7 +2095,7 @@ msgstr "¡El cliente no existe!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2312,12 +2119,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2350,28 +2156,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2418,19 +2212,14 @@ msgstr ""
 msgid "Date"
 msgstr "Fecha"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2452,7 +2241,6 @@ msgstr ""
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2516,8 +2304,6 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2533,10 +2319,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2546,17 +2330,14 @@ msgstr ""
 msgid "Dec"
 msgstr "Dic"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Diciembre"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2566,7 +2347,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2579,47 +2359,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2632,21 +2403,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "Pre-estableciodos"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2664,7 +2428,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Borrar"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2677,7 +2440,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2691,37 +2453,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Fecha de entrega"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2743,20 +2501,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2767,46 +2522,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2917,12 +2633,10 @@ msgstr "Detalle"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2935,7 +2649,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2944,7 +2657,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Descuento"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2953,28 +2665,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2982,7 +2694,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2991,7 +2702,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -2999,12 +2710,10 @@ msgstr ""
 msgid "Done"
 msgstr "Hecho"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3017,12 +2726,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3031,19 +2738,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Reintegro"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3059,10 +2763,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3081,7 +2781,7 @@ msgstr "Falta la fecha de vencimiento"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3107,7 +2807,7 @@ msgstr ""
 msgid "E-mailed"
 msgstr "¡Enviado por Correo-e!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3137,7 +2837,7 @@ msgstr "Editar Asiento de CxC"
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3281,8 +2981,6 @@ msgstr "once"
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3296,7 +2994,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Colaborador/Empleado"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3306,12 +3003,11 @@ msgstr "Número de Empleado"
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3321,37 +3017,26 @@ msgstr "Número de Empleado"
 msgid "Employees"
 msgstr "Empleados"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3375,7 +3060,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3400,12 +3084,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3415,7 +3097,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3423,7 +3105,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3449,7 +3130,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Nombre de Compañía"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3461,14 +3142,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Balance"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3482,16 +3160,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3499,7 +3176,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3512,8 +3189,6 @@ msgstr ""
 msgid "Exch"
 msgstr "Cambio"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3528,7 +3203,6 @@ msgstr "Tasa de Cambio"
 msgid "Exchange rate for payment missing!"
 msgstr "¡Falta tasa de Cambio para pago!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3537,7 +3211,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "¡Falta Tasa de Cambio!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3555,13 +3228,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Gastos/Activo"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3639,8 +3309,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Febrero"
 
@@ -3656,14 +3325,10 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3674,11 +3339,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3689,7 +3354,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3747,12 +3411,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Ganancia en moneda extranjera"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Pérdida en moneda extranjera"
@@ -3761,12 +3423,10 @@ msgstr "Pérdida en moneda extranjera"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3783,7 +3443,6 @@ msgstr "cuatro"
 msgid "Fourteen"
 msgstr "catorce"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3802,18 +3461,10 @@ msgstr ""
 msgid "From"
 msgstr "Desde"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3834,7 +3485,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3845,15 +3495,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3867,10 +3512,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "Plan Único de Cuentas (PUC)"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3891,7 +3534,6 @@ msgstr "¡Guardado el código PUC!"
 msgid "GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3900,7 +3542,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3908,11 +3550,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3921,7 +3562,7 @@ msgstr ""
 msgid "General Journal"
 msgstr "Notas de Contabilidad"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3929,9 +3570,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3947,7 +3587,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3955,7 +3595,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3971,12 +3611,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3985,7 +3623,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4059,21 +3696,6 @@ msgstr ""
 msgid "Hundred"
 msgstr "ciento"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4104,7 +3726,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4114,13 +3735,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Imagen"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4163,7 +3782,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4197,14 +3815,10 @@ msgstr "Incluir en menúes desplegables:"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4212,12 +3826,10 @@ msgstr ""
 msgid "Income"
 msgstr "Ingresos"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4228,7 +3840,6 @@ msgstr "Estado de Resultados"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4238,7 +3849,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Estado de Resultados"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4258,11 +3868,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4272,30 +3881,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "Notas Internas"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4305,17 +3910,14 @@ msgstr "Inventario"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4343,11 +3945,7 @@ msgstr "¡Inventario salvado!"
 msgid "Inventory transferred!"
 msgstr "¡Inventario transferido!"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4389,8 +3987,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4406,11 +4002,6 @@ msgstr "No se ha definido la fecha de la factura"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4429,7 +4020,6 @@ msgstr "Número de factura"
 msgid "Invoice Number missing!"
 msgstr "No se ha definido el número de la factura"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4459,12 +4049,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4522,8 +4110,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Ene"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Enero"
 
@@ -4552,8 +4139,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Julio"
 
@@ -4561,8 +4147,8 @@ msgstr "Julio"
 msgid "Jun"
 msgstr "Jun"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Junio"
 
@@ -4575,10 +4161,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4600,15 +4182,12 @@ msgstr "Mano de Obra"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Lenguaje"
@@ -4629,7 +4208,6 @@ msgstr "¡Idiomas no definidos!"
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4640,7 +4218,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4662,40 +4239,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4707,9 +4283,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4731,9 +4305,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4747,8 +4319,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4765,7 +4335,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4802,7 +4371,6 @@ msgstr "Lista de Lenguages"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4828,7 +4396,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4846,7 +4413,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4867,7 +4433,7 @@ msgstr ""
 msgid "Login"
 msgstr "Entrar"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4895,45 +4461,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Marca"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4955,40 +4514,34 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Marzo"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Margen de Beneficio"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Memo"
@@ -5005,7 +4558,6 @@ msgstr "Mensaje"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Método"
@@ -5014,7 +4566,6 @@ msgstr "Método"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5033,14 +4584,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5054,7 +4602,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5067,14 +4614,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Modelo"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5092,7 +4637,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5116,14 +4661,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5132,15 +4675,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5159,7 +4693,6 @@ msgstr "Nombre"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5210,8 +4743,6 @@ msgstr ""
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5233,12 +4764,10 @@ msgstr "diecinueve"
 msgid "Ninety"
 msgstr "noventa"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "No"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5247,7 +4776,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5255,11 +4784,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5267,7 +4796,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5276,11 +4804,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5288,21 +4816,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5321,12 +4846,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5335,12 +4858,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5378,11 +4899,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5428,23 +4944,18 @@ msgstr "¡Nada para Transferir!"
 msgid "Nov"
 msgstr "Nov"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "Noviembre"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5475,7 +4986,7 @@ msgstr ""
 msgid "Number"
 msgstr "Número"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Formato de número"
 
@@ -5496,13 +5007,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Obsoleto"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5511,8 +5020,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Oct"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Octubre"
 
@@ -5524,9 +5032,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5576,7 +5081,6 @@ msgstr ""
 msgid "Open"
 msgstr "Abierto"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5598,9 +5102,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5646,7 +5147,6 @@ msgstr "No se ha definido la fecha de la elaboración"
 msgid "Order Entry"
 msgstr "Cotizaciones y pedidos"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5668,7 +5168,6 @@ msgstr "¡Orden borrada!"
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5690,7 +5189,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5736,7 +5235,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5755,10 +5253,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5802,11 +5296,6 @@ msgstr "No se ha definido el número del albarán"
 msgid "Packing list"
 msgstr "Lista de Empaque"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5824,12 +5313,10 @@ msgstr "Pagado"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5839,14 +5326,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5876,14 +5355,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5899,15 +5374,12 @@ msgstr "Número de Parte"
 msgid "Parts"
 msgstr "Añadir artículo"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5917,7 +5389,6 @@ msgstr ""
 msgid "Password"
 msgstr "Contraseña"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5930,7 +5401,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5944,7 +5414,6 @@ msgstr ""
 msgid "Payables"
 msgstr "Pagos"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5953,7 +5422,6 @@ msgstr "Pagos"
 msgid "Payment"
 msgstr "Comprobante de Egreso"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5966,7 +5434,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5983,7 +5450,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6019,15 +5485,15 @@ msgstr "Vencimientos impagados"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6046,7 +5512,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6077,108 +5542,88 @@ msgstr "Lista de Selección"
 msgid "Pick list"
 msgstr "Lista de Selección"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6194,7 +5639,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6203,24 +5647,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6229,13 +5671,11 @@ msgstr ""
 msgid "Post"
 msgstr "Registrar"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6276,7 +5716,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Postscript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6314,20 +5753,16 @@ msgstr ""
 msgid "Price"
 msgstr "Precio"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6363,8 +5798,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6374,7 +5807,6 @@ msgstr ""
 msgid "Print"
 msgstr "Imprimir"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6391,7 +5823,7 @@ msgstr ""
 msgid "Printed"
 msgstr "Impreso"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Impresora"
 
@@ -6435,17 +5867,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6474,7 +5904,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6493,7 +5922,6 @@ msgstr "Traducciones de Descripción de Proyecto"
 msgid "Project Number"
 msgstr "número del projecto"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6502,9 +5930,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Proyectos"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6514,7 +5939,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6532,22 +5956,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Pedido"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "Número de Orden de Compra"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Pedidos"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6562,14 +5980,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Pedido"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6600,7 +6014,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Cantidad"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6614,8 +6027,6 @@ msgstr "¡La cantidad exede la unidades disponibles en inventario!"
 msgid "Quarter"
 msgstr "Trimestre"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6652,9 +6063,7 @@ msgstr "Falta número de Cotización"
 msgid "Quotation deleted!"
 msgstr "¡Cotización borrada!"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6675,25 +6084,20 @@ msgstr "Requerimiento de Cotización"
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "Número de Requerimiento de Cotización"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "Requerimiento de Cotizaciónes"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "Tope de envio"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6705,7 +6109,6 @@ msgstr ""
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 msgid "Rate Type"
 msgstr ""
@@ -6726,13 +6129,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6750,7 +6149,6 @@ msgstr "Recibo"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6764,8 +6162,7 @@ msgstr "Recibos"
 msgid "Receivables"
 msgstr "Cobros"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Cobro"
 
@@ -6773,7 +6170,6 @@ msgstr "Cobro"
 msgid "Receive Merchandise"
 msgstr "Recepción de Mercadería"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6794,7 +6190,6 @@ msgstr ""
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6815,13 +6210,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6860,12 +6248,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6903,7 +6289,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6915,7 +6301,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6928,7 +6314,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6978,7 +6363,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -6998,13 +6383,10 @@ msgstr ""
 msgid "Required by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7034,7 +6416,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7043,7 +6424,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7060,7 +6440,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7110,11 +6489,11 @@ msgstr "Unidad de Mantenimiento de Stock"
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7140,7 +6519,6 @@ msgstr "Ventas"
 msgid "Sales Invoice"
 msgstr "Factura de venta"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7156,20 +6534,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr "Orden de Venta"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "N°de Pedido"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Ordenes de Venta"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "N°de Cotización de Venta"
@@ -7192,9 +6567,6 @@ msgstr "N°de Cotización de Venta"
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7218,13 +6590,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7244,7 +6613,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7254,7 +6623,6 @@ msgstr "Guardar"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7313,11 +6681,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "Guardar como nuevo"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7340,10 +6707,8 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Pantalla"
 
@@ -7363,7 +6728,6 @@ msgstr "Pantalla"
 msgid "Search"
 msgstr "Buscar"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7372,7 +6736,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7425,11 +6788,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7441,11 +6804,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7457,7 +6820,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7465,7 +6828,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7521,7 +6883,6 @@ msgstr "¡Seleccione txt, postscript o PDF!"
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7530,9 +6891,6 @@ msgstr ""
 msgid "Sell"
 msgstr "Venta"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7586,13 +6944,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Sep"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "Septiembre"
 
@@ -7613,9 +6969,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "Nº de Serie"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7645,7 +6998,6 @@ msgstr ""
 msgid "Services"
 msgstr "Servicio"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 #, fuzzy
 msgid "Session Timeout (e.g. \"90 minutes\")"
@@ -7659,7 +7011,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7679,10 +7031,10 @@ msgstr "diecisiete"
 msgid "Seventy"
 msgstr "setenta"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Envio"
 
@@ -7709,10 +7061,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7773,10 +7121,6 @@ msgstr "¡Falta Fecha de Embarque!"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7818,7 +7162,6 @@ msgstr "Fecha de Embarque"
 msgid "Short"
 msgstr "Corto"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7859,7 +7202,6 @@ msgstr "sesenta"
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7872,12 +7214,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7904,7 +7240,6 @@ msgstr "Fuente"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7926,21 +7261,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Estándard"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "Códigos Standart Industriales"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7971,8 +7295,6 @@ msgstr ""
 msgid "Startdate"
 msgstr "FechaInicio"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8009,13 +7331,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Estado de cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Balance de cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8046,7 +7366,7 @@ msgstr "Inventariar compuesto"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Hoja de estilo"
 
@@ -8071,7 +7391,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8114,7 +7433,6 @@ msgstr "Resúmen"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8147,12 +7465,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8164,9 +7476,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8185,8 +7494,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8197,17 +7504,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8351,7 +7655,6 @@ msgstr ""
 msgid "Template"
 msgstr "Plantillas HTML"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8360,7 +7663,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8413,7 +7715,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8425,7 +7727,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8476,24 +7778,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8516,14 +7815,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8567,7 +7862,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8597,19 +7891,10 @@ msgstr ""
 msgid "To"
 msgstr "Hasta "
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8646,7 +7931,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8671,16 +7955,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8723,7 +7998,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8731,7 +8006,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8752,7 +8026,6 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8768,14 +8041,12 @@ msgstr "No se ha definido la fecha de la transacción"
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8814,7 +8085,6 @@ msgstr "Traducciones"
 msgid "Translations saved!"
 msgstr "Traducciones guardadas"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Balance de comprobación"
@@ -8823,7 +8093,6 @@ msgstr "Balance de comprobación"
 msgid "Trillion"
 msgstr "billón"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8880,10 +8149,6 @@ msgstr "veintidós"
 msgid "Two"
 msgstr "dos"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8918,39 +8183,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8969,43 +8228,37 @@ msgstr "Unidad"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9013,23 +8266,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9046,7 +8294,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9074,21 +8321,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9097,7 +8339,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9115,24 +8356,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9142,7 +8378,6 @@ msgstr "Usuario"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9163,7 +8398,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9189,8 +8423,6 @@ msgstr ""
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9200,11 +8432,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9220,7 +8448,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Proveedor"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9234,7 +8461,6 @@ msgstr "Historia de Proveedor"
 msgid "Vendor Invoice"
 msgstr "Factura de proveedor"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9244,9 +8470,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9276,9 +8499,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "¡Falta el proveedor!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9286,8 +8507,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "¡No se encuentra el proveedor en la base de datos!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9302,7 +8521,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9315,7 +8533,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9338,7 +8555,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Bodegas"
@@ -9347,11 +8563,26 @@ msgstr "Bodegas"
 msgid "Warning!"
 msgstr "¡Precaución!"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9361,7 +8592,6 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9378,13 +8608,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Peso"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr ""
@@ -9401,7 +8629,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9419,11 +8646,11 @@ msgstr "Orden de Trabajo"
 msgid "Work order"
 msgstr "Orden de Trabajo"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9466,15 +8693,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Si"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9501,7 +8723,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9565,17 +8787,12 @@ msgstr "días"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9592,7 +8809,7 @@ msgstr ""
 msgid "done"
 msgstr "hecho"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9620,8 +8837,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9630,22 +8845,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9670,7 +8881,6 @@ msgstr ""
 msgid "sent"
 msgstr "enviado"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9695,8 +8905,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/es_MX.po
+++ b/locale/po/es_MX.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Spanish (Mexico) (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,27 +15,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -48,12 +43,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -99,7 +90,6 @@ msgstr "Ctas. x pagar"
 msgid "AP Aging"
 msgstr "Vencimiento CxP"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -108,7 +98,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -123,7 +112,6 @@ msgstr "CxP pendientes"
 msgid "AP Transaction"
 msgstr "Movimiento CxP"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Movimientos de CxP"
@@ -136,9 +124,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -157,7 +143,6 @@ msgstr "Ctas. x cobrar"
 msgid "AR Aging"
 msgstr "Vencimiento CxC"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -166,7 +151,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -181,7 +165,6 @@ msgstr "CxC pendientes"
 msgid "AR Transaction"
 msgstr "Movimiento CxC"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Movimientos de Ctas. x cobrar"
@@ -194,9 +177,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -205,8 +186,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Movimiento CxC"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -216,16 +195,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -251,38 +225,20 @@ msgstr ""
 msgid "Account"
 msgstr "Cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -303,23 +259,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Número de cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -359,17 +310,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -381,7 +330,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -409,12 +358,10 @@ msgstr "Activa"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -437,11 +384,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr "Nuevo ensamblaje"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -566,7 +513,6 @@ msgstr "Nueva orden de venta"
 msgid "Add Service"
 msgstr "Nuevo servicio"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -633,7 +579,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Actualizar"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -658,7 +603,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -668,12 +612,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -693,8 +636,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -747,7 +689,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -756,11 +697,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -794,14 +730,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Importe"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -810,27 +742,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Saldo"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -848,14 +774,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -874,17 +800,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -893,13 +816,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -908,7 +824,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -917,14 +832,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -936,19 +849,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Abr"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "Abril"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -964,7 +874,6 @@ msgstr "¿Está Ud. seguro de querer borrar la cotización No.:"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -983,19 +892,17 @@ msgstr "Ensamblajes inventariados!"
 msgid "Asset"
 msgstr "Activo"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1008,29 +915,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1046,7 +950,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1144,8 +1047,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Ago"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Agosto"
 
@@ -1157,7 +1059,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1171,7 +1072,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1184,7 +1084,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1218,8 +1117,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1234,7 +1131,6 @@ msgstr "Saldo"
 msgid "Balance Sheet"
 msgstr "Balance general"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1255,7 +1151,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1266,7 +1161,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1276,18 +1170,15 @@ msgstr "Moneda"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1300,12 +1191,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1322,13 +1211,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1369,8 +1256,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1417,17 +1302,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1440,12 +1322,10 @@ msgstr ""
 msgid "Business"
 msgstr "Negocio"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "RFC"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1455,12 +1335,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1482,7 +1360,6 @@ msgstr "¡Negocio guardado!"
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1514,18 +1391,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1651,12 +1526,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Catálogo de cuentas"
 
@@ -1676,7 +1550,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "Verificar inventario"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1705,7 +1578,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1717,9 +1590,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "Aclarado"
 
@@ -1747,15 +1620,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Cerrada"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1769,8 +1640,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1785,22 +1654,18 @@ msgstr "¡Falta el código!"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1812,39 +1677,31 @@ msgstr ""
 msgid "Company"
 msgstr "Empresa"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Nombre de la empresa"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1865,7 +1722,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "¡Confirmar!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1883,7 +1740,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Contacto"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1899,7 +1755,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1917,9 +1772,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1949,7 +1801,6 @@ msgstr ""
 msgid "Contra"
 msgstr "Contra"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1957,10 +1808,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1991,20 +1838,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Costo"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2020,26 +1863,20 @@ msgstr "¡No se pudo guardar!"
 msgid "Could not transfer Inventory!"
 msgstr "¡No se pudo transferir el inventario"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2051,7 +1888,6 @@ msgstr ""
 msgid "Country"
 msgstr "País"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2064,7 +1900,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2072,11 +1908,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2104,8 +1940,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2113,17 +1947,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Abono"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2148,29 +1979,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Mon."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2193,18 +2014,14 @@ msgstr "Mon."
 msgid "Currency"
 msgstr "Moneda"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Actual"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2214,11 +2031,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2233,7 +2046,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Cliente"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2252,9 +2064,6 @@ msgstr "¡El cliente no está registrado!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2274,9 +2083,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "¡Falta el cliente!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2288,7 +2095,7 @@ msgstr "¡El cliente no está registrado!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2312,12 +2119,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2350,28 +2156,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2418,19 +2212,14 @@ msgstr ""
 msgid "Date"
 msgstr "Fecha"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2452,7 +2241,6 @@ msgstr "Fecha de recibo"
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2516,8 +2304,6 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2533,10 +2319,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2546,17 +2330,14 @@ msgstr ""
 msgid "Dec"
 msgstr "Dic"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Diciembre"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2566,7 +2347,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2579,47 +2359,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2632,21 +2403,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "Defaults"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2664,7 +2428,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Borrar"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2677,7 +2440,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2691,37 +2453,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Fecha de entrega"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2743,20 +2501,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2767,46 +2522,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2917,12 +2633,10 @@ msgstr "Detalle"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2935,7 +2649,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2944,7 +2657,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Descuento"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2953,28 +2665,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2982,7 +2694,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2991,7 +2702,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -2999,12 +2710,10 @@ msgstr ""
 msgid "Done"
 msgstr "Listo"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3017,12 +2726,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3031,19 +2738,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Plano"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3059,10 +2763,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3081,7 +2781,7 @@ msgstr "Falta fecha de vencimiento!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3107,7 +2807,7 @@ msgstr ""
 msgid "E-mailed"
 msgstr "Enviado por correo-e"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3137,7 +2837,7 @@ msgstr "Modificar Asiento de CxC"
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3281,8 +2981,6 @@ msgstr "once"
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3296,7 +2994,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Empleado"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3306,12 +3003,11 @@ msgstr "Número de Empleado"
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3321,37 +3017,26 @@ msgstr "Número de Empleado"
 msgid "Employees"
 msgstr "Empleados"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3375,7 +3060,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3400,12 +3084,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3415,7 +3097,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3423,7 +3105,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3449,7 +3130,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Nombre de la empresa"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3461,14 +3142,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Capital"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3482,16 +3160,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3499,7 +3176,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3512,8 +3189,6 @@ msgstr ""
 msgid "Exch"
 msgstr "T. de C."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3528,7 +3203,6 @@ msgstr "Tipo de cambio"
 msgid "Exchange rate for payment missing!"
 msgstr "¡Falta el tipo de cambio para el pago!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3537,7 +3211,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "¡Falta el tipo de cambio!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3555,13 +3228,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Egreso/Activo"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3639,8 +3309,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Febrero"
 
@@ -3656,14 +3325,10 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3674,11 +3339,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3689,7 +3354,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3747,12 +3411,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Utilidad cambiaria"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Perdida cambiaria"
@@ -3761,12 +3423,10 @@ msgstr "Perdida cambiaria"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3783,7 +3443,6 @@ msgstr "cuatro"
 msgid "Fourteen"
 msgstr "catorce"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3802,18 +3461,10 @@ msgstr ""
 msgid "From"
 msgstr "De"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3834,7 +3485,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3845,15 +3495,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3867,10 +3512,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "Código GIFI"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3891,7 +3534,6 @@ msgstr "¡GIFI guardado!"
 msgid "GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3900,7 +3542,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3908,11 +3550,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3921,7 +3562,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3929,9 +3570,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3947,7 +3587,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3955,7 +3595,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3971,12 +3611,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3985,7 +3623,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4059,21 +3696,6 @@ msgstr ""
 msgid "Hundred"
 msgstr "ciento"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4104,7 +3726,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4114,13 +3735,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Imagen"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4163,7 +3782,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4197,14 +3815,10 @@ msgstr "Incluir en listas desplegables"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4212,12 +3826,10 @@ msgstr ""
 msgid "Income"
 msgstr "Ingreso"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4228,7 +3840,6 @@ msgstr "Estado de resultados"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4238,7 +3849,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Estado de resultados"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4258,11 +3868,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4272,30 +3881,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "Notas internas"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4305,17 +3910,14 @@ msgstr "Inventario"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4343,11 +3945,7 @@ msgstr "¡Existencias guardadas!"
 msgid "Inventory transferred!"
 msgstr "¡Existencias transferidas!"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4389,8 +3987,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4406,11 +4002,6 @@ msgstr "¡Falta la fecha de la factura!"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4429,7 +4020,6 @@ msgstr "Número de factura"
 msgid "Invoice Number missing!"
 msgstr "Falta el número de factura!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4459,12 +4049,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4522,8 +4110,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Ene"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Enero"
 
@@ -4552,8 +4139,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Julio"
 
@@ -4561,8 +4147,8 @@ msgstr "Julio"
 msgid "Jun"
 msgstr "Jun"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Junio"
 
@@ -4575,10 +4161,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "Plantillas LaTeX"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4600,15 +4182,12 @@ msgstr "Mano de obra/Indirecto"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Lenguaje"
@@ -4629,7 +4208,6 @@ msgstr "¡Lenguajes no definido!"
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4640,7 +4218,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4662,40 +4239,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr "Duración del proceso"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4707,9 +4283,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4731,9 +4305,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4747,8 +4319,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4765,7 +4335,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4802,7 +4371,6 @@ msgstr "Enlistar lenguajes"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4828,7 +4396,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4846,7 +4413,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4867,7 +4433,7 @@ msgstr ""
 msgid "Login"
 msgstr "Entrada al sistema"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4895,45 +4461,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Marca"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4955,40 +4514,34 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Marzo"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Marcar"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "May"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Nota"
@@ -5005,7 +4558,6 @@ msgstr "Mensaje"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Método"
@@ -5014,7 +4566,6 @@ msgstr "Método"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5033,14 +4584,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5054,7 +4602,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5067,14 +4614,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Modelo"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5092,7 +4637,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5116,14 +4661,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5132,15 +4675,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5159,7 +4693,6 @@ msgstr "Nombre"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5210,8 +4743,6 @@ msgstr ""
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5233,12 +4764,10 @@ msgstr "diecinueve"
 msgid "Ninety"
 msgstr "noventa"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "No"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5247,7 +4776,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5255,11 +4784,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5267,7 +4796,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5276,11 +4804,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5288,21 +4816,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5321,12 +4846,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5335,12 +4858,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5378,11 +4899,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5428,23 +4944,18 @@ msgstr "¡Nada que transferir!"
 msgid "Nov"
 msgstr "Nov"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "Noviembre"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5475,7 +4986,7 @@ msgstr ""
 msgid "Number"
 msgstr "Número"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Formato de número"
 
@@ -5496,13 +5007,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Obsoleto"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5511,8 +5020,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Oct"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Octubre"
 
@@ -5524,9 +5032,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5576,7 +5081,6 @@ msgstr ""
 msgid "Open"
 msgstr "Abierto"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5598,9 +5102,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5646,7 +5147,6 @@ msgstr "¡Falta la fecha de la orden!"
 msgid "Order Entry"
 msgstr "Ordenes"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5668,7 +5168,6 @@ msgstr "¡Orden borrada!"
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5690,7 +5189,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5736,7 +5235,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5755,10 +5253,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5802,11 +5296,6 @@ msgstr "¡Falta le número en la lista de empaque!"
 msgid "Packing list"
 msgstr "Lista de empaque"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5824,12 +5313,10 @@ msgstr "Pagado"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Parte"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5839,14 +5326,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5876,14 +5355,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5899,15 +5374,12 @@ msgstr "Número de Parte"
 msgid "Parts"
 msgstr "Parte"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5917,7 +5389,6 @@ msgstr ""
 msgid "Password"
 msgstr "Contraseña"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5930,7 +5401,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5944,7 +5414,6 @@ msgstr ""
 msgid "Payables"
 msgstr "Por Pagar"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5953,7 +5422,6 @@ msgstr "Por Pagar"
 msgid "Payment"
 msgstr "Pago"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5966,7 +5434,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5983,7 +5450,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6019,15 +5485,15 @@ msgstr "Pagos"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6046,7 +5512,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6077,108 +5542,88 @@ msgstr "Lista de Selección"
 msgid "Pick list"
 msgstr "Lista de Selección"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6194,7 +5639,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6203,24 +5647,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6229,13 +5671,11 @@ msgstr ""
 msgid "Post"
 msgstr "Registrar"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6276,7 +5716,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Postscript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6314,20 +5753,16 @@ msgstr ""
 msgid "Price"
 msgstr "Precio"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6363,8 +5798,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6374,7 +5807,6 @@ msgstr ""
 msgid "Print"
 msgstr "Vista Preliminar"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6391,7 +5823,7 @@ msgstr ""
 msgid "Printed"
 msgstr "Impreso"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Impresora"
 
@@ -6435,17 +5867,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6474,7 +5904,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6493,7 +5922,6 @@ msgstr "Traducciones de descripción de proyecto"
 msgid "Project Number"
 msgstr "Número de proyecto"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6502,9 +5930,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Proyectos"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6514,7 +5939,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6532,22 +5956,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Orden de compra"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "Número de Orden de Compra"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Ordenes de compra"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6562,14 +5980,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Orden de compra"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6600,7 +6014,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Cant."
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6614,8 +6027,6 @@ msgstr "¡La cantidad excede al inventario disponible!"
 msgid "Quarter"
 msgstr "Trimestre"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6652,9 +6063,7 @@ msgstr "¡Falta el número de la cotización!"
 msgid "Quotation deleted!"
 msgstr "¡Cotización borrada!"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6675,25 +6084,20 @@ msgstr "Sol. de Cot."
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "Número de Sol. de Cot."
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "Sols. de Cots."
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "Pto. de Reord."
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6705,7 +6109,6 @@ msgstr "Tarifa"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6728,13 +6131,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6752,7 +6151,6 @@ msgstr "Cobro"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6766,8 +6164,7 @@ msgstr "Cobros"
 msgid "Receivables"
 msgstr "Por cobrar"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Recibir"
 
@@ -6775,7 +6172,6 @@ msgstr "Recibir"
 msgid "Receive Merchandise"
 msgstr "Recibir mercancía"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6796,7 +6192,6 @@ msgstr "Conciliación"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6817,13 +6212,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6862,12 +6250,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6905,7 +6291,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6917,7 +6303,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6930,7 +6316,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6980,7 +6365,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -7000,13 +6385,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Vencimiento"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7036,7 +6418,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7045,7 +6426,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7062,7 +6442,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7112,11 +6491,11 @@ msgstr "SKU"
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7142,7 +6521,6 @@ msgstr "Ventas"
 msgid "Sales Invoice"
 msgstr "Factura de venta"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7158,20 +6536,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr "Orden de venta"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "N°de Pedido"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Ordenes de venta"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "N°de Cotización de venta"
@@ -7194,9 +6569,6 @@ msgstr "N°de Cotización de venta"
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7220,13 +6592,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7246,7 +6615,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7256,7 +6625,6 @@ msgstr "Guardar"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7315,11 +6683,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "Guardar como nuevo"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7342,10 +6709,8 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Pantalla"
 
@@ -7365,7 +6730,6 @@ msgstr "Pantalla"
 msgid "Search"
 msgstr "Buscar"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7374,7 +6738,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7427,11 +6790,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7443,11 +6806,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7459,7 +6822,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7467,7 +6830,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7523,7 +6885,6 @@ msgstr "¡Seleccione txt, postscript o PDF!"
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7532,9 +6893,6 @@ msgstr ""
 msgid "Sell"
 msgstr "Vender"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7588,13 +6946,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Sep"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "Septiembre"
 
@@ -7615,9 +6971,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "Núm. de serie"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7647,7 +7000,6 @@ msgstr ""
 msgid "Services"
 msgstr "Servicio"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 #, fuzzy
 msgid "Session Timeout (e.g. \"90 minutes\")"
@@ -7661,7 +7013,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7681,10 +7033,10 @@ msgstr "diecisiete"
 msgid "Seventy"
 msgstr "setenta"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Enviar"
 
@@ -7711,10 +7063,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7775,10 +7123,6 @@ msgstr "¡Falta la fecha de envío!"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7820,7 +7164,6 @@ msgstr "Fecha de envío"
 msgid "Short"
 msgstr "Corto"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7861,7 +7204,6 @@ msgstr "sesenta"
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7874,12 +7216,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7906,7 +7242,6 @@ msgstr "Referencia"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7928,21 +7263,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Estándar"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "Standard Industrial Codes"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7973,8 +7297,6 @@ msgstr ""
 msgid "Startdate"
 msgstr "Fecha inicial"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8011,13 +7333,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Estado de cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Saldo bancario"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8048,7 +7368,7 @@ msgstr "Inventariar ensamblaje"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Hoja de estilos"
 
@@ -8073,7 +7393,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8116,7 +7435,6 @@ msgstr "Resumen"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8149,12 +7467,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8166,9 +7478,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8187,8 +7496,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8199,17 +7506,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8353,7 +7657,6 @@ msgstr ""
 msgid "Template"
 msgstr "Plantillas HTML"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8362,7 +7665,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8415,7 +7717,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8427,7 +7729,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8478,24 +7780,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8518,14 +7817,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8569,7 +7864,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8599,19 +7893,10 @@ msgstr ""
 msgid "To"
 msgstr "A"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8648,7 +7933,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8673,16 +7957,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8725,7 +8000,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8733,7 +8008,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8754,7 +8028,6 @@ msgstr "Asiento"
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8770,14 +8043,12 @@ msgstr "¡Falta la fecha del movimiento!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8816,7 +8087,6 @@ msgstr "Traducciones"
 msgid "Translations saved!"
 msgstr "¡Traducciones guardadas!"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Balanza de comprobación"
@@ -8825,7 +8095,6 @@ msgstr "Balanza de comprobación"
 msgid "Trillion"
 msgstr "billón"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8882,10 +8151,6 @@ msgstr "veintidós"
 msgid "Two"
 msgstr "dos"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8920,39 +8185,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8971,43 +8230,37 @@ msgstr "Unidad"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9015,23 +8268,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9048,7 +8296,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9076,21 +8323,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9099,7 +8341,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9117,24 +8358,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9144,7 +8380,6 @@ msgstr "Usuario"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9165,7 +8400,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9191,8 +8425,6 @@ msgstr "Válido hasta"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9202,11 +8434,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9222,7 +8450,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Proveedor"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9236,7 +8463,6 @@ msgstr "Historia de proveedor"
 msgid "Vendor Invoice"
 msgstr "Factura de compra"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9246,9 +8472,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9278,9 +8501,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "¡Falta el proveedor!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9288,8 +8509,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "¡Proveedor no registrado!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9304,7 +8523,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9317,7 +8535,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9340,7 +8557,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Almacenes"
@@ -9349,11 +8565,26 @@ msgstr "Almacenes"
 msgid "Warning!"
 msgstr "¡Advertencia!"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9363,7 +8594,6 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9380,13 +8610,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Peso"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Unidad de Peso"
@@ -9403,7 +8631,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9421,11 +8648,11 @@ msgstr "Orden de Trabajo"
 msgid "Work order"
 msgstr "Orden de Trabajo"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9468,15 +8695,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Si"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9503,7 +8725,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9567,17 +8789,12 @@ msgstr "días"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9594,7 +8811,7 @@ msgstr ""
 msgid "done"
 msgstr "listo"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9622,8 +8839,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9632,22 +8847,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9672,7 +8883,6 @@ msgstr ""
 msgid "sent"
 msgstr "enviado"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9697,8 +8907,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/es_PA.po
+++ b/locale/po/es_PA.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Spanish (Panama) (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,27 +15,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -48,12 +43,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -99,7 +90,6 @@ msgstr "Cuentas por Pagar"
 msgid "AP Aging"
 msgstr "Vencimiento de Cuentas por Pagar"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -108,7 +98,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -123,7 +112,6 @@ msgstr "Cuentas por Pagar pendientes"
 msgid "AP Transaction"
 msgstr "Movimiento de Cuentas por Pagar"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Movimientos de Cuentas por Pagar"
@@ -136,9 +124,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -157,7 +143,6 @@ msgstr "Cuentas por Cobrar"
 msgid "AR Aging"
 msgstr "Vencimiento Cuentas por Cobrar"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -166,7 +151,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -181,7 +165,6 @@ msgstr "Cuentas por Cobrar pendientes"
 msgid "AR Transaction"
 msgstr "Movimiento de Cuentas por Cobrar"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Movimientos de Cuentas por Cobrar"
@@ -194,9 +177,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -205,8 +186,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Movimiento de Cuentas por Cobrar"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -216,16 +195,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -251,38 +225,20 @@ msgstr ""
 msgid "Account"
 msgstr "Cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -303,23 +259,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Número de Cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -359,17 +310,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -381,7 +330,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -409,12 +358,10 @@ msgstr "Activo"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -437,11 +384,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr "Agregar Ensamblaje"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -566,7 +513,6 @@ msgstr "Agregar Orden de Venta"
 msgid "Add Service"
 msgstr "Agregar Servicio"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -633,7 +579,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Actualizar"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -658,7 +603,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -668,12 +612,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -693,8 +636,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -747,7 +689,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -756,11 +697,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -794,14 +730,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Importe"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -810,27 +742,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Importe Adeudado"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -848,14 +774,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -874,17 +800,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -893,13 +816,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -908,7 +824,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -917,14 +832,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -936,19 +849,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Abr"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "Abril"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -964,7 +874,6 @@ msgstr "¿Seguro que desea borrar la Cotización?"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -983,19 +892,17 @@ msgstr "Ensamblajes re-inventariados!"
 msgid "Asset"
 msgstr "Activo"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1008,29 +915,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1046,7 +950,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1144,8 +1047,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Ago"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Agosto"
 
@@ -1157,7 +1059,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1171,7 +1072,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1184,7 +1084,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1218,8 +1117,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1234,7 +1131,6 @@ msgstr "Saldo"
 msgid "Balance Sheet"
 msgstr "Balance General"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1255,7 +1151,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1266,7 +1161,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1276,18 +1170,15 @@ msgstr "Divisa"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1300,12 +1191,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1322,13 +1211,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1369,8 +1256,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1417,17 +1302,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1440,12 +1322,10 @@ msgstr ""
 msgid "Business"
 msgstr "Negocio"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "RUC"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1455,12 +1335,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1482,7 +1360,6 @@ msgstr "¡Negocio guardado!"
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1514,18 +1391,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1651,12 +1526,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Plan de Cuentas"
 
@@ -1676,7 +1550,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "Verificar existencia"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1705,7 +1578,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1717,9 +1590,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "Reconciliado"
 
@@ -1747,15 +1620,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Cerrado"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1769,8 +1640,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1785,22 +1654,18 @@ msgstr "¡Falta el Código!"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1812,39 +1677,31 @@ msgstr ""
 msgid "Company"
 msgstr "Empresa"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Razón Social"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1865,7 +1722,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "¡Confirmar!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1883,7 +1740,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Contacto"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1899,7 +1755,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1917,9 +1772,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1949,7 +1801,6 @@ msgstr ""
 msgid "Contra"
 msgstr "Cuentas del Orden"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1957,10 +1808,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1991,20 +1838,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Costo"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2020,26 +1863,20 @@ msgstr "¡No se pudo guardar!"
 msgid "Could not transfer Inventory!"
 msgstr "¡No se pudo transferir existencia!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2051,7 +1888,6 @@ msgstr ""
 msgid "Country"
 msgstr "País"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2064,7 +1900,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2072,11 +1908,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2104,8 +1940,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2113,17 +1947,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Crédito"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2148,29 +1979,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Div"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2193,18 +2014,14 @@ msgstr "Div"
 msgid "Currency"
 msgstr "Divisa"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Actual"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2214,11 +2031,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2233,7 +2046,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Cliente"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2252,9 +2064,6 @@ msgstr "¡El cliente no existe!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2274,9 +2083,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "¡Falta el Cliente!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2288,7 +2095,7 @@ msgstr "¡El cliente no existe!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2312,12 +2119,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2350,28 +2156,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2418,19 +2212,14 @@ msgstr ""
 msgid "Date"
 msgstr "Fecha"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2452,7 +2241,6 @@ msgstr "Fecha de recepción"
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2516,8 +2304,6 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2533,10 +2319,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2546,17 +2330,14 @@ msgstr ""
 msgid "Dec"
 msgstr "Dic"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Diciembre"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2566,7 +2347,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2579,47 +2359,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2632,21 +2403,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "Valores predeterminados"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2664,7 +2428,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Borrar"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2677,7 +2440,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2691,37 +2453,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Fecha de entrega"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2743,20 +2501,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2767,46 +2522,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2917,12 +2633,10 @@ msgstr "Detalle"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2935,7 +2649,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2944,7 +2657,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Descuento"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2953,28 +2665,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2982,7 +2694,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2991,7 +2702,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -2999,12 +2710,10 @@ msgstr ""
 msgid "Done"
 msgstr "Terminado"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3017,12 +2726,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3031,19 +2738,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Plano"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3059,10 +2763,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3081,7 +2781,7 @@ msgstr "¡Falta fecha de vencimiento!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3107,7 +2807,7 @@ msgstr ""
 msgid "E-mailed"
 msgstr "Enviado por e-mail"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3137,7 +2837,7 @@ msgstr "Modificar asiento de Cuentas por Cobrar"
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3281,8 +2981,6 @@ msgstr "once"
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3296,7 +2994,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Empleado"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3306,12 +3003,11 @@ msgstr "Código del empleado"
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3321,37 +3017,26 @@ msgstr "Código del empleado"
 msgid "Employees"
 msgstr "Empleados"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3375,7 +3060,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3400,12 +3084,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3415,7 +3097,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3423,7 +3105,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3449,7 +3130,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Razón Social"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3461,14 +3142,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Capital"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3482,16 +3160,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3499,7 +3176,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3512,8 +3189,6 @@ msgstr ""
 msgid "Exch"
 msgstr "Cambio"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3528,7 +3203,6 @@ msgstr "Tasa de Cambio"
 msgid "Exchange rate for payment missing!"
 msgstr "¡Falta la tasa de cambio para el pago!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3537,7 +3211,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "¡Falta la tasa de cambio!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3555,13 +3228,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Gasto/Activo"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3639,8 +3309,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Febrero"
 
@@ -3656,14 +3325,10 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3674,11 +3339,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3689,7 +3354,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3747,12 +3411,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Ganancia en Moneda Extranjera"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Pérdida en Moneda Extranjera"
@@ -3761,12 +3423,10 @@ msgstr "Pérdida en Moneda Extranjera"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3783,7 +3443,6 @@ msgstr "cuatro"
 msgid "Fourteen"
 msgstr "catorce"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3802,18 +3461,10 @@ msgstr ""
 msgid "From"
 msgstr "Desde"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3834,7 +3485,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3845,15 +3495,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3867,10 +3512,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "Plan de Cuentas Fiscal (PCF)"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3891,7 +3534,6 @@ msgstr "¡Guardado el código PCF!"
 msgid "GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3900,7 +3542,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3908,11 +3550,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3921,7 +3562,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3929,9 +3570,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3947,7 +3587,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3955,7 +3595,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3971,12 +3611,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3985,7 +3623,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4059,21 +3696,6 @@ msgstr ""
 msgid "Hundred"
 msgstr "ciento"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4104,7 +3726,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4114,13 +3735,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Imagen"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4163,7 +3782,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4197,14 +3815,10 @@ msgstr "Incluir en listas desplegables"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4212,12 +3826,10 @@ msgstr ""
 msgid "Income"
 msgstr "Ingreso"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4228,7 +3840,6 @@ msgstr "Cuadro de Resultados"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4238,7 +3849,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Cuadro de Resultados"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4258,11 +3868,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4272,30 +3881,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "Notas internas"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4305,17 +3910,14 @@ msgstr "Inventario"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4342,11 +3944,7 @@ msgstr "¡Inventario guardado!"
 msgid "Inventory transferred!"
 msgstr "¡Inventario transferido!"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4388,8 +3986,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4405,11 +4001,6 @@ msgstr "¡Falta la fecha de la factura!"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4428,7 +4019,6 @@ msgstr "Número de factura"
 msgid "Invoice Number missing!"
 msgstr "¡Falta el Número de Factura!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4458,12 +4048,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4521,8 +4109,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Ene"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Enero"
 
@@ -4551,8 +4138,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Julio"
 
@@ -4560,8 +4146,8 @@ msgstr "Julio"
 msgid "Jun"
 msgstr "Jun"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Junio"
 
@@ -4574,10 +4160,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "Plantillas LaTeX"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4599,15 +4181,12 @@ msgstr "Mano de Obra"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Idioma"
@@ -4628,7 +4207,6 @@ msgstr "¡Idiomas no definido!"
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4639,7 +4217,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4661,40 +4238,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr "Tiempo de Entrega"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4706,9 +4282,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4730,9 +4304,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4746,8 +4318,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4764,7 +4334,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4801,7 +4370,6 @@ msgstr "Mostrar Idiomas"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4827,7 +4395,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4845,7 +4412,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4866,7 +4432,7 @@ msgstr ""
 msgid "Login"
 msgstr "Entrada al sistema"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4894,45 +4460,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Marca"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4954,40 +4513,34 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Marzo"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Margen"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "Mayo"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Nota"
@@ -5004,7 +4557,6 @@ msgstr "Mensaje"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Método"
@@ -5013,7 +4565,6 @@ msgstr "Método"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5032,14 +4583,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5053,7 +4601,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5066,14 +4613,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Modelo"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5091,7 +4636,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5115,14 +4660,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5131,15 +4674,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5158,7 +4692,6 @@ msgstr "Nombre"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5209,8 +4742,6 @@ msgstr ""
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5232,12 +4763,10 @@ msgstr "diecinueve"
 msgid "Ninety"
 msgstr "noventa"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "No"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5246,7 +4775,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5254,11 +4783,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5266,7 +4795,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5275,11 +4803,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5287,21 +4815,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5320,12 +4845,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5334,12 +4857,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5377,11 +4898,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5427,23 +4943,18 @@ msgstr "¡Nada que transferir!"
 msgid "Nov"
 msgstr "Nov"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "Noviembre"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5474,7 +4985,7 @@ msgstr ""
 msgid "Number"
 msgstr "Número"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Formato Numérico"
 
@@ -5495,13 +5006,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Obsoleto"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5510,8 +5019,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Oct"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Octubre"
 
@@ -5523,9 +5031,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5575,7 +5080,6 @@ msgstr ""
 msgid "Open"
 msgstr "Abierto"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5597,9 +5101,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5645,7 +5146,6 @@ msgstr "¡Falta la fecha de la orden!"
 msgid "Order Entry"
 msgstr "Carga de Ordenes"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5667,7 +5167,6 @@ msgstr "¡Orden borrada!"
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5689,7 +5188,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5735,7 +5234,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5754,10 +5252,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5801,11 +5295,6 @@ msgstr "¡Falta el número en la lista de empaque!"
 msgid "Packing list"
 msgstr "Lista de Empaque"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5823,12 +5312,10 @@ msgstr "Pagado"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Artículo"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5838,14 +5325,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5875,14 +5354,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5898,15 +5373,12 @@ msgstr "Número de artículo"
 msgid "Parts"
 msgstr "Artículo"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5916,7 +5388,6 @@ msgstr ""
 msgid "Password"
 msgstr "Contraseña"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5929,7 +5400,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5943,7 +5413,6 @@ msgstr ""
 msgid "Payables"
 msgstr "Cuentas por Pagar"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5952,7 +5421,6 @@ msgstr "Cuentas por Pagar"
 msgid "Payment"
 msgstr "Pago"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5965,7 +5433,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5982,7 +5449,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6018,15 +5484,15 @@ msgstr "Pagos"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6045,7 +5511,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6076,108 +5541,88 @@ msgstr "Lista de Selección"
 msgid "Pick list"
 msgstr "Lista de Selección"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6193,7 +5638,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6202,24 +5646,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6228,13 +5670,11 @@ msgstr ""
 msgid "Post"
 msgstr "Registrar"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6275,7 +5715,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Postscript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6313,20 +5752,16 @@ msgstr ""
 msgid "Price"
 msgstr "Precio"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6362,8 +5797,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6373,7 +5806,6 @@ msgstr ""
 msgid "Print"
 msgstr "Imprimir"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6390,7 +5822,7 @@ msgstr ""
 msgid "Printed"
 msgstr "Impreso"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Impresora"
 
@@ -6434,17 +5866,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6473,7 +5903,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6492,7 +5921,6 @@ msgstr "Traducciones de descripción de proyecto"
 msgid "Project Number"
 msgstr "Número del Proyecto"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6501,9 +5929,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Proyectos"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6513,7 +5938,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6531,22 +5955,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Orden de Compra"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "Número de Orden de Compra"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Ordenes de Compra"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6561,14 +5979,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Orden de Compra"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6599,7 +6013,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Cant."
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6613,8 +6026,6 @@ msgstr "¡La cantidad excede al stock disponible!"
 msgid "Quarter"
 msgstr "Trimestre"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6651,9 +6062,7 @@ msgstr "¡Falta el Número de Cotización!"
 msgid "Quotation deleted!"
 msgstr "¡Cotización borrada!"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6674,25 +6083,20 @@ msgstr "Solicitud de cotización"
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "Número de Solicitud de cotización"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "Solicitudes de cotización"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "Existencia mínima"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6704,7 +6108,6 @@ msgstr "Tarifa"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6727,13 +6130,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6751,7 +6150,6 @@ msgstr "Recibo"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6765,8 +6163,7 @@ msgstr "Recibos"
 msgid "Receivables"
 msgstr "Cuentas por Cobrar"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Recibir"
 
@@ -6774,7 +6171,6 @@ msgstr "Recibir"
 msgid "Receive Merchandise"
 msgstr "Recibir mercadería"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6795,7 +6191,6 @@ msgstr "Reconciliación"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6816,13 +6211,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6861,12 +6249,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6904,7 +6290,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6916,7 +6302,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6929,7 +6315,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6979,7 +6364,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -6999,13 +6384,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Requerido para el"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7035,7 +6417,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7044,7 +6425,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7061,7 +6441,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7111,11 +6490,11 @@ msgstr "SKU"
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7141,7 +6520,6 @@ msgstr "Ventas"
 msgid "Sales Invoice"
 msgstr "Factura (venta)"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7157,20 +6535,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr "Orden de Venta"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "Número de Orden de Venta"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Ordenes de Venta"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "Número de Cotización"
@@ -7193,9 +6568,6 @@ msgstr "Número de Cotización"
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7219,13 +6591,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7245,7 +6614,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7255,7 +6624,6 @@ msgstr "Guardar"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7314,11 +6682,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "Guardar como nuevo"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7341,10 +6708,8 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Pantalla"
 
@@ -7364,7 +6729,6 @@ msgstr "Pantalla"
 msgid "Search"
 msgstr "Búsqueda"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7373,7 +6737,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7426,11 +6789,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7442,11 +6805,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7458,7 +6821,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7466,7 +6829,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7522,7 +6884,6 @@ msgstr "¡Seleccione Texto, Postscript o PDF!"
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7531,9 +6892,6 @@ msgstr ""
 msgid "Sell"
 msgstr "Vender"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7587,13 +6945,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Sep"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "Septiembre"
 
@@ -7614,9 +6970,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "Núm. de serie"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7646,7 +6999,6 @@ msgstr ""
 msgid "Services"
 msgstr "Servicio"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 #, fuzzy
 msgid "Session Timeout (e.g. \"90 minutes\")"
@@ -7660,7 +7012,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7680,10 +7032,10 @@ msgstr "diecisiete"
 msgid "Seventy"
 msgstr "setenta"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Enviar"
 
@@ -7710,10 +7062,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7774,10 +7122,6 @@ msgstr "¡Falta la fecha de envío!"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7819,7 +7163,6 @@ msgstr "Fecha de envío"
 msgid "Short"
 msgstr "Corto"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7860,7 +7203,6 @@ msgstr "sesenta"
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7873,12 +7215,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7905,7 +7241,6 @@ msgstr "Origen"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7927,21 +7262,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Estándard"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "Código Industrial Estandardizado (CIS)"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7972,8 +7296,6 @@ msgstr ""
 msgid "Startdate"
 msgstr "Fecha de inicio"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8010,13 +7332,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Estado de cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Saldo bancario"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8047,7 +7367,7 @@ msgstr "Reponer ensamblaje"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Hoja de estilos"
 
@@ -8072,7 +7392,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8115,7 +7434,6 @@ msgstr "Resúmen"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8148,12 +7466,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8165,9 +7477,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8186,8 +7495,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8198,17 +7505,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8352,7 +7656,6 @@ msgstr ""
 msgid "Template"
 msgstr "Plantillas HTML"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8361,7 +7664,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8414,7 +7716,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8426,7 +7728,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8477,24 +7779,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8517,14 +7816,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8568,7 +7863,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8598,19 +7892,10 @@ msgstr ""
 msgid "To"
 msgstr "Hasta"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8647,7 +7932,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8672,16 +7956,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8724,7 +7999,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8732,7 +8007,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8753,7 +8027,6 @@ msgstr "Asiento"
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8769,14 +8042,12 @@ msgstr "¡Falta la fecha del Asiento!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8815,7 +8086,6 @@ msgstr "Traducciones"
 msgid "Translations saved!"
 msgstr "¡Traducciones guardadas!"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Balance de Prueba"
@@ -8824,7 +8094,6 @@ msgstr "Balance de Prueba"
 msgid "Trillion"
 msgstr "billón"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8881,10 +8150,6 @@ msgstr "veintidós"
 msgid "Two"
 msgstr "dos"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8919,39 +8184,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8970,43 +8229,37 @@ msgstr "Unidad"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9014,23 +8267,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9047,7 +8295,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9075,21 +8322,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9098,7 +8340,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9116,24 +8357,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9143,7 +8379,6 @@ msgstr "Usuario"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9164,7 +8399,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9190,8 +8424,6 @@ msgstr "Válido hasta"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9201,11 +8433,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9221,7 +8449,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Proveedor"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9235,7 +8462,6 @@ msgstr "Historial del Proveedor"
 msgid "Vendor Invoice"
 msgstr "Factura de Proveedor"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9245,9 +8471,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9277,9 +8500,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "¡Falta el Proveedor!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9287,8 +8508,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "¡Proveedor no registrado!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9303,7 +8522,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9316,7 +8534,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9339,7 +8556,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Almacenes"
@@ -9348,11 +8564,26 @@ msgstr "Almacenes"
 msgid "Warning!"
 msgstr "¡Advertencia!"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9362,7 +8593,6 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9379,13 +8609,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Peso"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Unidad de peso"
@@ -9402,7 +8630,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9420,11 +8647,11 @@ msgstr "Orden de Trabajo"
 msgid "Work order"
 msgstr "Orden de Trabajo"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9467,15 +8694,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Si"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9502,7 +8724,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9566,17 +8788,12 @@ msgstr "días"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9593,7 +8810,7 @@ msgstr ""
 msgid "done"
 msgstr "Terminado"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9621,8 +8838,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9631,22 +8846,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9671,7 +8882,6 @@ msgstr ""
 msgid "sent"
 msgstr "Enviado"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9696,8 +8906,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/es_PY.po
+++ b/locale/po/es_PY.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Spanish (Paraguay) (http://www.transifex.com/ledgersmb/"
@@ -15,27 +15,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -48,12 +43,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -99,7 +90,6 @@ msgstr "Cuentas a Pagar"
 msgid "AP Aging"
 msgstr "Vencimiento de Cuentas a Pagar"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -108,7 +98,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -123,7 +112,6 @@ msgstr "Cuentas a Pagar pendientes"
 msgid "AP Transaction"
 msgstr "Movimiento de Cuentas a Pagar"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Movimientos de Cuentas a Pagar"
@@ -136,9 +124,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -157,7 +143,6 @@ msgstr "Cuentas a Cobrar"
 msgid "AR Aging"
 msgstr "Vencimiento Cuentas a Cobrar"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -166,7 +151,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -181,7 +165,6 @@ msgstr "Cuentas a Cobrar pendientes"
 msgid "AR Transaction"
 msgstr "Movimiento de Cuentas a Cobrar"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Movimientos de Cuentas a Cobrar"
@@ -194,9 +177,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -205,8 +186,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Movimiento de Cuentas a Cobrar"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -216,16 +195,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -251,38 +225,20 @@ msgstr ""
 msgid "Account"
 msgstr "Cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -303,23 +259,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Número de Cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -359,17 +310,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -381,7 +330,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -409,12 +358,10 @@ msgstr "Activo"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -437,11 +384,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr "Agregar Ensamblaje"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -566,7 +513,6 @@ msgstr "Agregar Orden de Venta"
 msgid "Add Service"
 msgstr "Agregar Servicio"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -633,7 +579,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Actualizar"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -658,7 +603,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -668,12 +612,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -693,8 +636,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -747,7 +689,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -756,11 +697,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -794,14 +730,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Importe"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -810,27 +742,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Importe Adeudado"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -848,14 +774,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -874,17 +800,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -893,13 +816,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -908,7 +824,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -917,14 +832,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -936,19 +849,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Abr"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "Abril"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -964,7 +874,6 @@ msgstr "¿Seguro que desea borrar la Cotización?"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -983,19 +892,17 @@ msgstr "Ensamblajes re-inventariados!"
 msgid "Asset"
 msgstr "Activo"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1008,29 +915,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1046,7 +950,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1144,8 +1047,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Ago"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Agosto"
 
@@ -1157,7 +1059,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1171,7 +1072,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1184,7 +1084,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1218,8 +1117,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1234,7 +1131,6 @@ msgstr "Saldo"
 msgid "Balance Sheet"
 msgstr "Balance General"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1255,7 +1151,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1266,7 +1161,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1276,18 +1170,15 @@ msgstr "Divisa"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1300,12 +1191,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1322,13 +1211,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1369,8 +1256,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1417,17 +1302,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1440,12 +1322,10 @@ msgstr ""
 msgid "Business"
 msgstr "Negocio"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "RUC"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1455,12 +1335,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1482,7 +1360,6 @@ msgstr "¡Negocio guardado!"
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1514,18 +1391,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1651,12 +1526,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Plan de Cuentas"
 
@@ -1676,7 +1550,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "Verificar existencia"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1705,7 +1578,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1717,9 +1590,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "Reconciliado"
 
@@ -1747,15 +1620,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Cerrado"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1769,8 +1640,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1785,22 +1654,18 @@ msgstr "¡Falta el Código!"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1812,39 +1677,31 @@ msgstr ""
 msgid "Company"
 msgstr "Empresa"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Razón Social"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1865,7 +1722,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "¡Confirmar!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1883,7 +1740,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Contacto"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1899,7 +1755,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1917,9 +1772,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1949,7 +1801,6 @@ msgstr ""
 msgid "Contra"
 msgstr "Cuentas del Orden"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1957,10 +1808,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1991,20 +1838,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Costo"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2020,26 +1863,20 @@ msgstr "¡No se pudo guardar!"
 msgid "Could not transfer Inventory!"
 msgstr "¡No se pudo transferir existencia!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2051,7 +1888,6 @@ msgstr ""
 msgid "Country"
 msgstr "País"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2064,7 +1900,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2072,11 +1908,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2104,8 +1940,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2113,17 +1947,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Crédito"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2148,29 +1979,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Div"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2193,18 +2014,14 @@ msgstr "Div"
 msgid "Currency"
 msgstr "Divisa"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Actual"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2214,11 +2031,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2233,7 +2046,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Cliente"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2252,9 +2064,6 @@ msgstr "¡El cliente no existe!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2274,9 +2083,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "¡Falta el Cliente!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2288,7 +2095,7 @@ msgstr "¡El cliente no existe!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2312,12 +2119,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2350,28 +2156,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2418,19 +2212,14 @@ msgstr ""
 msgid "Date"
 msgstr "Fecha"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2452,7 +2241,6 @@ msgstr "Fecha de recepción"
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2516,8 +2304,6 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2533,10 +2319,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2546,17 +2330,14 @@ msgstr ""
 msgid "Dec"
 msgstr "Dic"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Diciembre"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2566,7 +2347,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2579,47 +2359,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2632,21 +2403,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "Valores predeterminados"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2664,7 +2428,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Borrar"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2677,7 +2440,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2691,37 +2453,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Fecha de entrega"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2743,20 +2501,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2767,46 +2522,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2917,12 +2633,10 @@ msgstr "Detalle"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2935,7 +2649,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2944,7 +2657,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Descuento"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2953,28 +2665,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2982,7 +2694,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2991,7 +2702,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -2999,12 +2710,10 @@ msgstr ""
 msgid "Done"
 msgstr "Terminado"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3017,12 +2726,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3031,19 +2738,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Plano"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3059,10 +2763,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3081,7 +2781,7 @@ msgstr "¡Falta fecha de vencimiento!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3107,7 +2807,7 @@ msgstr ""
 msgid "E-mailed"
 msgstr "Enviado por e-mail"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3137,7 +2837,7 @@ msgstr "Modificar asiento de Cuentas a Cobrar"
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3281,8 +2981,6 @@ msgstr "once"
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3296,7 +2994,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Empleado"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3306,12 +3003,11 @@ msgstr "Código del empleado"
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3321,37 +3017,26 @@ msgstr "Código del empleado"
 msgid "Employees"
 msgstr "Empleados"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3375,7 +3060,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3400,12 +3084,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3415,7 +3097,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3423,7 +3105,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3449,7 +3130,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Razón Social"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3461,14 +3142,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Patrimonio"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3482,16 +3160,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3499,7 +3176,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3512,8 +3189,6 @@ msgstr ""
 msgid "Exch"
 msgstr "Cambio"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3528,7 +3203,6 @@ msgstr "Tasa de Cambio"
 msgid "Exchange rate for payment missing!"
 msgstr "¡Falta la tasa de cambio para el pago!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3537,7 +3211,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "¡Falta la tasa de cambio!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3555,13 +3228,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Egreso/Activo"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3639,8 +3309,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Febrero"
 
@@ -3656,14 +3325,10 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3674,11 +3339,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3689,7 +3354,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3747,12 +3411,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Ganancia en Moneda Extranjera"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Pérdida en Moneda Extranjera"
@@ -3761,12 +3423,10 @@ msgstr "Pérdida en Moneda Extranjera"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3783,7 +3443,6 @@ msgstr "cuatro"
 msgid "Fourteen"
 msgstr "catorce"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3802,18 +3461,10 @@ msgstr ""
 msgid "From"
 msgstr "Desde"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3834,7 +3485,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3845,15 +3495,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3867,10 +3512,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "Plan de Cuentas Fiscal (PCF)"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3891,7 +3534,6 @@ msgstr "¡Guardado el código PCF!"
 msgid "GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3900,7 +3542,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3908,11 +3550,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3921,7 +3562,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3929,9 +3570,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3947,7 +3587,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3955,7 +3595,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3971,12 +3611,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3985,7 +3623,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4059,21 +3696,6 @@ msgstr ""
 msgid "Hundred"
 msgstr "ciento"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4104,7 +3726,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4114,13 +3735,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Imagen"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4163,7 +3782,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4197,14 +3815,10 @@ msgstr "Incluir en listas desplegables"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4212,12 +3826,10 @@ msgstr ""
 msgid "Income"
 msgstr "Ingreso"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4228,7 +3840,6 @@ msgstr "Cuadro de Resultados"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4238,7 +3849,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Cuadro de Resultados"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4258,11 +3868,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4272,30 +3881,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "Notas internas"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4305,17 +3910,14 @@ msgstr "Existencia"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4342,11 +3944,7 @@ msgstr "¡Existencias guardadas!"
 msgid "Inventory transferred!"
 msgstr "¡Existencias transferidas!"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4388,8 +3986,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4405,11 +4001,6 @@ msgstr "¡Falta la fecha de la factura!"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4428,7 +4019,6 @@ msgstr "Número de factura"
 msgid "Invoice Number missing!"
 msgstr "¡Falta el Número de Factura!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4458,12 +4048,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4521,8 +4109,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Ene"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Enero"
 
@@ -4551,8 +4138,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Julio"
 
@@ -4560,8 +4146,8 @@ msgstr "Julio"
 msgid "Jun"
 msgstr "Jun"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Junio"
 
@@ -4574,10 +4160,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "Plantillas LaTeX"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4599,15 +4181,12 @@ msgstr "Mano de Obra"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Idioma"
@@ -4628,7 +4207,6 @@ msgstr "¡Idiomas no definido!"
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4639,7 +4217,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4661,40 +4238,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr "Tiempo de Entrega"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4706,9 +4282,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4730,9 +4304,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4746,8 +4318,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4764,7 +4334,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4801,7 +4370,6 @@ msgstr "Mostrar Idiomas"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4827,7 +4395,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4845,7 +4412,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4866,7 +4432,7 @@ msgstr ""
 msgid "Login"
 msgstr "Entrada al sistema"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4894,45 +4460,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Marca"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4954,40 +4513,34 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Marzo"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Margen"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "Mayo"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Nota"
@@ -5004,7 +4557,6 @@ msgstr "Mensaje"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Método"
@@ -5013,7 +4565,6 @@ msgstr "Método"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5032,14 +4583,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5053,7 +4601,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5066,14 +4613,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Modelo"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5091,7 +4636,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5115,14 +4660,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5131,15 +4674,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5158,7 +4692,6 @@ msgstr "Nombre"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5209,8 +4742,6 @@ msgstr ""
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5232,12 +4763,10 @@ msgstr "diecinueve"
 msgid "Ninety"
 msgstr "noventa"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "No"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5246,7 +4775,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5254,11 +4783,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5266,7 +4795,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5275,11 +4803,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5287,21 +4815,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5320,12 +4845,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5334,12 +4857,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5377,11 +4898,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5427,23 +4943,18 @@ msgstr "¡Nada que transferir!"
 msgid "Nov"
 msgstr "Nov"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "Noviembre"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5474,7 +4985,7 @@ msgstr ""
 msgid "Number"
 msgstr "Número"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Formato Numérico"
 
@@ -5495,13 +5006,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Obsoleto"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5510,8 +5019,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Oct"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Octubre"
 
@@ -5523,9 +5031,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5575,7 +5080,6 @@ msgstr ""
 msgid "Open"
 msgstr "Abierto"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5597,9 +5101,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5645,7 +5146,6 @@ msgstr "¡Falta la fecha de la orden!"
 msgid "Order Entry"
 msgstr "Carga de Ordenes"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5667,7 +5167,6 @@ msgstr "¡Orden borrada!"
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5689,7 +5188,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5735,7 +5234,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5754,10 +5252,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5801,11 +5295,6 @@ msgstr "¡Falta el número en la lista de empaque!"
 msgid "Packing list"
 msgstr "Lista de Empaque"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5823,12 +5312,10 @@ msgstr "Pagado"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Artículo"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5838,14 +5325,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5875,14 +5354,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5898,15 +5373,12 @@ msgstr "Número de artículo"
 msgid "Parts"
 msgstr "Artículo"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5916,7 +5388,6 @@ msgstr ""
 msgid "Password"
 msgstr "Contraseña"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5929,7 +5400,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5943,7 +5413,6 @@ msgstr ""
 msgid "Payables"
 msgstr "Cuentas a Pagar"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5952,7 +5421,6 @@ msgstr "Cuentas a Pagar"
 msgid "Payment"
 msgstr "Pago"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5965,7 +5433,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5982,7 +5449,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6018,15 +5484,15 @@ msgstr "Pagos"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6045,7 +5511,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6076,108 +5541,88 @@ msgstr "Lista de Selección"
 msgid "Pick list"
 msgstr "Lista de Selección"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6193,7 +5638,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6202,24 +5646,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6228,13 +5670,11 @@ msgstr ""
 msgid "Post"
 msgstr "Registrar"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6275,7 +5715,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Postscript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6313,20 +5752,16 @@ msgstr ""
 msgid "Price"
 msgstr "Precio"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6362,8 +5797,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6373,7 +5806,6 @@ msgstr ""
 msgid "Print"
 msgstr "Imprimir"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6390,7 +5822,7 @@ msgstr ""
 msgid "Printed"
 msgstr "Impreso"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Impresora"
 
@@ -6434,17 +5866,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6473,7 +5903,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6492,7 +5921,6 @@ msgstr "Traducciones de descripción de proyecto"
 msgid "Project Number"
 msgstr "Número del Proyecto"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6501,9 +5929,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Proyectos"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6513,7 +5938,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6531,22 +5955,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Orden de Compra"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "Número de Orden de Compra"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Ordenes de Compra"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6561,14 +5979,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Orden de Compra"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6599,7 +6013,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Cant."
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6613,8 +6026,6 @@ msgstr "¡La cantidad excede al stock disponible!"
 msgid "Quarter"
 msgstr "Trimestre"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6651,9 +6062,7 @@ msgstr "¡Falta el Número de Cotización!"
 msgid "Quotation deleted!"
 msgstr "¡Cotización borrada!"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6674,25 +6083,20 @@ msgstr "Solicitud de cotización"
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "Número de Solicitud de cotización"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "Solicitudes de cotización"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "Existencia mínima"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6704,7 +6108,6 @@ msgstr "Tarifa"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6727,13 +6130,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6751,7 +6150,6 @@ msgstr "Recibo"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6765,8 +6163,7 @@ msgstr "Recibos"
 msgid "Receivables"
 msgstr "Cuentas a Cobrar"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Recibir"
 
@@ -6774,7 +6171,6 @@ msgstr "Recibir"
 msgid "Receive Merchandise"
 msgstr "Recibir mercadería"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6795,7 +6191,6 @@ msgstr "Reconciliación"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6816,13 +6211,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6861,12 +6249,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6904,7 +6290,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6916,7 +6302,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6929,7 +6315,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6979,7 +6364,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -6999,13 +6384,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Requerido para el"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7035,7 +6417,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7044,7 +6425,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7061,7 +6441,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7111,11 +6490,11 @@ msgstr "SKU"
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7141,7 +6520,6 @@ msgstr "Ventas"
 msgid "Sales Invoice"
 msgstr "Factura (venta)"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7157,20 +6535,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr "Orden de Venta"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "Número de Orden de Venta"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Ordenes de Venta"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "Número de Cotización"
@@ -7193,9 +6568,6 @@ msgstr "Número de Cotización"
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7219,13 +6591,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7245,7 +6614,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7255,7 +6624,6 @@ msgstr "Guardar"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7314,11 +6682,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "Guardar como nuevo"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7341,10 +6708,8 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Pantalla"
 
@@ -7364,7 +6729,6 @@ msgstr "Pantalla"
 msgid "Search"
 msgstr "Búsqueda"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7373,7 +6737,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7426,11 +6789,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7442,11 +6805,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7458,7 +6821,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7466,7 +6829,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7522,7 +6884,6 @@ msgstr "¡Seleccione Texto, Postscript o PDF!"
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7531,9 +6892,6 @@ msgstr ""
 msgid "Sell"
 msgstr "Vender"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7587,13 +6945,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Sep"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "Septiembre"
 
@@ -7614,9 +6970,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "Núm. de serie"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7646,7 +6999,6 @@ msgstr ""
 msgid "Services"
 msgstr "Servicio"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 #, fuzzy
 msgid "Session Timeout (e.g. \"90 minutes\")"
@@ -7660,7 +7012,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7680,10 +7032,10 @@ msgstr "diecisiete"
 msgid "Seventy"
 msgstr "setenta"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Enviar"
 
@@ -7710,10 +7062,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7774,10 +7122,6 @@ msgstr "¡Falta la fecha de envío!"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7819,7 +7163,6 @@ msgstr "Fecha de envío"
 msgid "Short"
 msgstr "Corto"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7860,7 +7203,6 @@ msgstr "sesenta"
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7873,12 +7215,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7905,7 +7241,6 @@ msgstr "Origen"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7927,21 +7262,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Estándard"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "Código Industrial Estandardizado (CIS)"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7972,8 +7296,6 @@ msgstr ""
 msgid "Startdate"
 msgstr "Fecha de inicio"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8010,13 +7332,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Estado de cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Saldo bancario"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8047,7 +7367,7 @@ msgstr "Reponer ensamblaje"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Hoja de estilos"
 
@@ -8072,7 +7392,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8115,7 +7434,6 @@ msgstr "Resúmen"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8148,12 +7466,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8165,9 +7477,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8186,8 +7495,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8198,17 +7505,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8352,7 +7656,6 @@ msgstr ""
 msgid "Template"
 msgstr "Plantillas HTML"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8361,7 +7664,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8414,7 +7716,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8426,7 +7728,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8477,24 +7779,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8517,14 +7816,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8568,7 +7863,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8598,19 +7892,10 @@ msgstr ""
 msgid "To"
 msgstr "Hasta"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8647,7 +7932,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8672,16 +7956,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8724,7 +7999,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8732,7 +8007,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8753,7 +8027,6 @@ msgstr "Asiento"
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8769,14 +8042,12 @@ msgstr "¡Falta la fecha del Asiento!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8815,7 +8086,6 @@ msgstr "Traducciones"
 msgid "Translations saved!"
 msgstr "¡Traducciones guardadas!"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Balance de Sumas y Saldos"
@@ -8824,7 +8094,6 @@ msgstr "Balance de Sumas y Saldos"
 msgid "Trillion"
 msgstr "billón"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8881,10 +8150,6 @@ msgstr "veintidós"
 msgid "Two"
 msgstr "dos"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8919,39 +8184,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8970,43 +8229,37 @@ msgstr "Unidad"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9014,23 +8267,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9047,7 +8295,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9075,21 +8322,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9098,7 +8340,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9116,24 +8357,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9143,7 +8379,6 @@ msgstr "Usuario"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9164,7 +8399,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9190,8 +8424,6 @@ msgstr "Válido hasta"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9201,11 +8433,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9221,7 +8449,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Proveedor"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9235,7 +8462,6 @@ msgstr "Historial del Proveedor"
 msgid "Vendor Invoice"
 msgstr "Factura de Proveedor"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9245,9 +8471,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9277,9 +8500,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "¡Falta el Proveedor!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9287,8 +8508,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "¡Proveedor no registrado!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9303,7 +8522,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9316,7 +8534,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9339,7 +8556,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Almacenes"
@@ -9348,11 +8564,26 @@ msgstr "Almacenes"
 msgid "Warning!"
 msgstr "¡Advertencia!"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9362,7 +8593,6 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9379,13 +8609,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Peso"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Unidad de peso"
@@ -9402,7 +8630,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9420,11 +8647,11 @@ msgstr "Orden de Trabajo"
 msgid "Work order"
 msgstr "Orden de Trabajo"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9467,15 +8694,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Si"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9502,7 +8724,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9566,17 +8788,12 @@ msgstr "días"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9593,7 +8810,7 @@ msgstr ""
 msgid "done"
 msgstr "Terminado"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9621,8 +8838,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9631,22 +8846,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9671,7 +8882,6 @@ msgstr ""
 msgid "sent"
 msgstr "Enviado"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9696,8 +8906,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/es_SV.po
+++ b/locale/po/es_SV.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Spanish (El Salvador) (http://www.transifex.com/ledgersmb/"
@@ -15,27 +15,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -48,12 +43,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -99,7 +90,6 @@ msgstr "Ctas X Pagar"
 msgid "AP Aging"
 msgstr "Antiguedad de Saldos - CxP"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -108,7 +98,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -123,7 +112,6 @@ msgstr "CxP Extraordinarias"
 msgid "AP Transaction"
 msgstr "Transaccion - CxP"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Transacciones - Cuentas por Pagar"
@@ -136,9 +124,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -157,7 +143,6 @@ msgstr "Ctas X Cobrar"
 msgid "AR Aging"
 msgstr "Antiguedad de Saldos - CxC "
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -166,7 +151,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -181,7 +165,6 @@ msgstr "CxC Extraordinarias"
 msgid "AR Transaction"
 msgstr "Transaccion - CxC"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Transacciones - CxC"
@@ -194,9 +177,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -205,8 +186,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Transaccion - CxC"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -216,16 +195,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -251,38 +225,20 @@ msgstr ""
 msgid "Account"
 msgstr "Cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -303,23 +259,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Número de Cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -359,17 +310,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -381,7 +330,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -409,12 +358,10 @@ msgstr "Activa"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -437,11 +384,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr "Agregar Ensamble"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -566,7 +513,6 @@ msgstr "Agregar Nota de Remisión"
 msgid "Add Service"
 msgstr "Agregar Servicio"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -633,7 +579,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Actualizar"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -658,7 +603,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -668,12 +612,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -693,8 +636,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -747,7 +689,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -756,11 +697,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -794,14 +730,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Total"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -810,27 +742,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Monto Vencido"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -848,14 +774,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -874,17 +800,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -893,13 +816,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -908,7 +824,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -917,14 +832,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -936,19 +849,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Abr"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "Abril"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -964,7 +874,6 @@ msgstr ""
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -983,19 +892,17 @@ msgstr "Conjuntos re-inventariados"
 msgid "Asset"
 msgstr "Activo"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1008,29 +915,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1046,7 +950,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1144,8 +1047,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Ago"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Agosto"
 
@@ -1157,7 +1059,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1171,7 +1072,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1184,7 +1084,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1218,8 +1117,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1234,7 +1131,6 @@ msgstr "Balance"
 msgid "Balance Sheet"
 msgstr "Hoja de Balance"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1255,7 +1151,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1266,7 +1161,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1276,18 +1170,15 @@ msgstr "Moneda"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1300,12 +1191,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1322,13 +1211,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1369,8 +1256,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1416,17 +1301,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1439,12 +1321,10 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Numero de Negocio"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1454,12 +1334,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1481,7 +1359,6 @@ msgstr ""
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1513,18 +1390,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1650,12 +1525,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Catálogo Contable"
 
@@ -1675,7 +1549,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1704,7 +1577,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1716,9 +1589,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr ""
 
@@ -1746,15 +1619,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Cerrado"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1768,8 +1639,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1784,22 +1653,18 @@ msgstr ""
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1811,39 +1676,31 @@ msgstr ""
 msgid "Company"
 msgstr "Compañía"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1864,7 +1721,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Confirmar!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1882,7 +1739,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Contacto"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1898,7 +1754,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1916,9 +1771,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1948,7 +1800,6 @@ msgstr ""
 msgid "Contra"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1956,10 +1807,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1990,20 +1837,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2019,26 +1862,20 @@ msgstr ""
 msgid "Could not transfer Inventory!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2050,7 +1887,6 @@ msgstr ""
 msgid "Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2063,7 +1899,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2071,11 +1907,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2103,8 +1939,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2112,17 +1946,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Crédito"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2147,29 +1978,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Mon."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2192,18 +2013,14 @@ msgstr "Mon."
 msgid "Currency"
 msgstr "Moneda"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Actual"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2213,11 +2030,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2232,7 +2045,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Cliente"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2251,9 +2063,6 @@ msgstr "Cliente no existe en archivo!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2273,9 +2082,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "Falta cliente!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2287,7 +2094,7 @@ msgstr "Cliente no existe en archivo!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2311,12 +2118,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2349,28 +2155,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2417,19 +2211,14 @@ msgstr ""
 msgid "Date"
 msgstr "Fecha"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2451,7 +2240,6 @@ msgstr ""
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2515,8 +2303,6 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2532,10 +2318,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2545,17 +2329,14 @@ msgstr ""
 msgid "Dec"
 msgstr "Dic"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Diciembre"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2565,7 +2346,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2578,47 +2358,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2631,21 +2402,14 @@ msgstr ""
 msgid "Defaults"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2663,7 +2427,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Borrar"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2676,7 +2439,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2690,37 +2452,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Fecha de Entrega"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2742,20 +2500,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2766,46 +2521,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2916,12 +2632,10 @@ msgstr "Detalle"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2934,7 +2648,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2943,7 +2656,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Descuento"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2952,28 +2664,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2981,7 +2693,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2990,7 +2701,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -2998,12 +2709,10 @@ msgstr ""
 msgid "Done"
 msgstr "Listo"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3016,12 +2725,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3030,19 +2737,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Retiro"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3058,10 +2762,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3080,7 +2780,7 @@ msgstr "Falta Fecha de Vencimiento!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3106,7 +2806,7 @@ msgstr ""
 msgid "E-mailed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3136,7 +2836,7 @@ msgstr ""
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3280,8 +2980,6 @@ msgstr "once"
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3295,7 +2993,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Empleado"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3305,12 +3002,11 @@ msgstr ""
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 msgid "Employee wage screen"
 msgstr ""
@@ -3319,37 +3015,26 @@ msgstr ""
 msgid "Employees"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3373,7 +3058,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3398,12 +3082,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3413,7 +3095,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3421,7 +3103,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3446,7 +3127,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3458,14 +3139,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Capital"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3479,16 +3157,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3496,7 +3173,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3509,8 +3186,6 @@ msgstr ""
 msgid "Exch"
 msgstr "Interc."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3525,7 +3200,6 @@ msgstr "Tasa de Intercambio"
 msgid "Exchange rate for payment missing!"
 msgstr "No se encuentra pago por cambio de moneda"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3534,7 +3208,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "No se encuentra cambio de moneda"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3552,13 +3225,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Egreso/Activo"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3636,8 +3306,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Febrero"
 
@@ -3653,14 +3322,10 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3671,11 +3336,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3686,7 +3351,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3744,12 +3408,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Ganancia en Moneda Extranjera"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Pérdida en Moneda Extranjera"
@@ -3758,12 +3420,10 @@ msgstr "Pérdida en Moneda Extranjera"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3780,7 +3440,6 @@ msgstr "cuatro"
 msgid "Fourteen"
 msgstr "catorce"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3799,18 +3458,10 @@ msgstr ""
 msgid "From"
 msgstr "Desde"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3831,7 +3482,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3842,15 +3492,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3864,10 +3509,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "Código GIFI"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3888,7 +3531,6 @@ msgstr "GIFI guardado!"
 msgid "GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3897,7 +3539,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3905,11 +3547,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3918,7 +3559,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3926,9 +3567,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3944,7 +3584,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3952,7 +3592,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3968,12 +3608,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3982,7 +3620,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4056,21 +3693,6 @@ msgstr ""
 msgid "Hundred"
 msgstr "ciento"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4101,7 +3723,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4111,13 +3732,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Imagen"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4160,7 +3779,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4194,14 +3812,10 @@ msgstr "Incluya en menús desplegables"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4209,12 +3823,10 @@ msgstr ""
 msgid "Income"
 msgstr "Ingreso"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4225,7 +3837,6 @@ msgstr "Estado de Cuentas"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4235,7 +3846,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Estado de Cuentas"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4255,11 +3865,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4269,30 +3878,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4302,17 +3907,14 @@ msgstr "Inventario"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4340,11 +3942,7 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4386,8 +3984,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4403,11 +3999,6 @@ msgstr "Falta la Fecha de la Factura!"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4426,7 +4017,6 @@ msgstr "Número de Factura"
 msgid "Invoice Number missing!"
 msgstr "Falta el Número de Factura!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4456,12 +4046,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4519,8 +4107,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Ene"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Enero"
 
@@ -4549,8 +4136,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Julio"
 
@@ -4558,8 +4144,8 @@ msgstr "Julio"
 msgid "Jun"
 msgstr "Jun"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Junio"
 
@@ -4572,10 +4158,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "Plantillas de LaTeX"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4597,15 +4179,12 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr ""
@@ -4626,7 +4205,6 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4637,7 +4215,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4659,40 +4236,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4704,9 +4280,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4728,9 +4302,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4744,8 +4316,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4762,7 +4332,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4799,7 +4368,6 @@ msgstr ""
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4825,7 +4393,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4843,7 +4410,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4864,7 +4430,7 @@ msgstr ""
 msgid "Login"
 msgstr "Nombre de Acceso"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4892,45 +4458,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Marca"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4952,40 +4511,34 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Marzo"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "May"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr ""
@@ -5002,7 +4555,6 @@ msgstr "Mensaje"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr ""
@@ -5011,7 +4563,6 @@ msgstr ""
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5030,14 +4581,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5051,7 +4599,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5064,14 +4611,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Modelo"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5089,7 +4634,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5113,14 +4658,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5129,15 +4672,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5156,7 +4690,6 @@ msgstr "Nombre"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5207,8 +4740,6 @@ msgstr ""
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5230,12 +4761,10 @@ msgstr "diecinueve"
 msgid "Ninety"
 msgstr "noventa"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "No"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5244,7 +4773,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5252,11 +4781,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5264,7 +4793,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5273,11 +4801,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5285,21 +4813,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5318,12 +4843,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5332,12 +4855,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5375,11 +4896,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5425,23 +4941,18 @@ msgstr ""
 msgid "Nov"
 msgstr "Nov"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "Noviembre"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5472,7 +4983,7 @@ msgstr ""
 msgid "Number"
 msgstr "Número"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Formato de Numero"
 
@@ -5493,13 +5004,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Obsoleto"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5508,8 +5017,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Oct"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Octubre"
 
@@ -5521,9 +5029,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5573,7 +5078,6 @@ msgstr ""
 msgid "Open"
 msgstr "Abierto"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5595,9 +5099,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5643,7 +5144,6 @@ msgstr "No se encuentra la fecha de orden!"
 msgid "Order Entry"
 msgstr "Orden de Entrada"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5665,7 +5165,6 @@ msgstr "Orden borrada!"
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5687,7 +5186,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5732,7 +5231,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5751,10 +5249,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5798,11 +5292,6 @@ msgstr "!Falta nzmero en lista de empaque!"
 msgid "Packing list"
 msgstr "Lista de Empaque"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5820,12 +5309,10 @@ msgstr "Total Pagado"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Partes"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5835,14 +5322,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5872,14 +5351,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5895,15 +5370,12 @@ msgstr ""
 msgid "Parts"
 msgstr "Partes"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5913,7 +5385,6 @@ msgstr ""
 msgid "Password"
 msgstr "Contraseña"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5926,7 +5397,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5940,7 +5410,6 @@ msgstr ""
 msgid "Payables"
 msgstr "Por Pagar"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5949,7 +5418,6 @@ msgstr "Por Pagar"
 msgid "Payment"
 msgstr "Pago"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5962,7 +5430,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5979,7 +5446,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6015,15 +5481,15 @@ msgstr "Pagos"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6042,7 +5508,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6072,108 +5537,88 @@ msgstr ""
 msgid "Pick list"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6189,7 +5634,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6198,24 +5642,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6224,13 +5666,11 @@ msgstr ""
 msgid "Post"
 msgstr "Registrar"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6271,7 +5711,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Postscript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6309,20 +5748,16 @@ msgstr ""
 msgid "Price"
 msgstr "Precio"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6358,8 +5793,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6369,7 +5802,6 @@ msgstr ""
 msgid "Print"
 msgstr "Imprimir"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6386,7 +5818,7 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Impresora"
 
@@ -6430,17 +5862,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6469,7 +5899,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6488,7 +5917,6 @@ msgstr ""
 msgid "Project Number"
 msgstr "Número de Proyecto"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6497,9 +5925,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Proyectos"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6509,7 +5934,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6527,22 +5951,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Orden de Compra"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Ordenes de Compra"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6557,14 +5975,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Orden de Compra"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6595,7 +6009,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Cant."
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6609,8 +6022,6 @@ msgstr ""
 msgid "Quarter"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6647,9 +6058,7 @@ msgstr ""
 msgid "Quotation deleted!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6670,25 +6079,20 @@ msgstr ""
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "ROP"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6700,7 +6104,6 @@ msgstr "Tarifa"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6723,13 +6126,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6747,7 +6146,6 @@ msgstr "Recibo"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6761,8 +6159,7 @@ msgstr "Ingresos"
 msgid "Receivables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr ""
 
@@ -6770,7 +6167,6 @@ msgstr ""
 msgid "Receive Merchandise"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6791,7 +6187,6 @@ msgstr "Conciliación"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6812,13 +6207,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6857,12 +6245,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6900,7 +6286,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6912,7 +6298,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6925,7 +6311,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6974,7 +6359,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -6994,13 +6379,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Requerido por"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7030,7 +6412,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7039,7 +6420,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7056,7 +6436,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7106,11 +6485,11 @@ msgstr ""
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7136,7 +6515,6 @@ msgstr "Ventas"
 msgid "Sales Invoice"
 msgstr "Factura de Venta"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7152,20 +6530,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr "Orden de venta"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Ordenes de venta"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr ""
@@ -7187,9 +6562,6 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7213,13 +6585,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7239,7 +6608,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7249,7 +6618,6 @@ msgstr "Salvar"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7308,11 +6676,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "Guardar como nuevo"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7335,10 +6702,8 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Pantalla"
 
@@ -7358,7 +6723,6 @@ msgstr "Pantalla"
 msgid "Search"
 msgstr "Buscar"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7367,7 +6731,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7420,11 +6783,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7436,11 +6799,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7452,7 +6815,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7460,7 +6823,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7516,7 +6878,6 @@ msgstr ""
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7525,9 +6886,6 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7581,13 +6939,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Sep"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "Septiembre"
 
@@ -7608,9 +6964,6 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7640,7 +6993,6 @@ msgstr ""
 msgid "Services"
 msgstr "Servicio"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 msgid "Session Timeout (e.g. \"90 minutes\")"
 msgstr ""
@@ -7653,7 +7005,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7673,10 +7025,10 @@ msgstr "diecisiete"
 msgid "Seventy"
 msgstr "setenta"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Envíe"
 
@@ -7703,10 +7055,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7767,10 +7115,6 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7811,7 +7155,6 @@ msgstr ""
 msgid "Short"
 msgstr "Corto"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7852,7 +7195,6 @@ msgstr "sesenta"
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7865,12 +7207,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7897,7 +7233,6 @@ msgstr "Fuente"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7919,21 +7254,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Estandar"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7964,8 +7288,6 @@ msgstr ""
 msgid "Startdate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8002,13 +7324,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Estado de Cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Balance Estado de Cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8038,7 +7358,7 @@ msgstr "Inventariar Ensamblaje?"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Estilo de hoja"
 
@@ -8063,7 +7383,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8106,7 +7425,6 @@ msgstr "Resumen"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8139,12 +7457,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8156,9 +7468,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8177,8 +7486,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8189,17 +7496,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8343,7 +7647,6 @@ msgstr ""
 msgid "Template"
 msgstr "Plantillas HTML"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8352,7 +7655,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8405,7 +7707,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8417,7 +7719,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8468,24 +7770,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8508,14 +7807,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8559,7 +7854,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8589,19 +7883,10 @@ msgstr ""
 msgid "To"
 msgstr "Hasta "
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8638,7 +7923,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8663,16 +7947,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8715,7 +7990,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8723,7 +7998,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8744,7 +8018,6 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8760,14 +8033,12 @@ msgstr "Falta la fecha de la transacción!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8806,7 +8077,6 @@ msgstr ""
 msgid "Translations saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Balance De Comprobación"
@@ -8815,7 +8085,6 @@ msgstr "Balance De Comprobación"
 msgid "Trillion"
 msgstr "billón"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8872,10 +8141,6 @@ msgstr "veintidós"
 msgid "Two"
 msgstr "dos"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8910,39 +8175,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8961,43 +8220,37 @@ msgstr "Unidad"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9005,23 +8258,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9038,7 +8286,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9066,21 +8313,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9089,7 +8331,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9107,24 +8348,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9134,7 +8370,6 @@ msgstr "Usuario"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9155,7 +8390,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9181,8 +8415,6 @@ msgstr ""
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9192,11 +8424,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9212,7 +8440,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Proveedor"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9226,7 +8453,6 @@ msgstr ""
 msgid "Vendor Invoice"
 msgstr "Factura de Proveedor"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9236,9 +8462,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9268,9 +8491,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "Falta proveedor!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9278,8 +8499,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Proveedor no está en archivo!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9294,7 +8513,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9307,7 +8525,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9330,7 +8547,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr ""
@@ -9339,11 +8555,26 @@ msgstr ""
 msgid "Warning!"
 msgstr ""
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9353,7 +8584,6 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9370,13 +8600,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Peso"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Unidad de Peso"
@@ -9393,7 +8621,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9410,11 +8637,11 @@ msgstr ""
 msgid "Work order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9457,15 +8684,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Si"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9492,7 +8714,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9556,17 +8778,12 @@ msgstr "Días"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9583,7 +8800,7 @@ msgstr ""
 msgid "done"
 msgstr "Hecho"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9611,8 +8828,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9621,22 +8836,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9661,7 +8872,6 @@ msgstr ""
 msgid "sent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9686,8 +8896,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/es_VE.po
+++ b/locale/po/es_VE.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Spanish (Venezuela) (http://www.transifex.com/ledgersmb/"
@@ -15,27 +15,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -48,12 +43,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -99,7 +90,6 @@ msgstr "CxP"
 msgid "AP Aging"
 msgstr "Diario Resumido de CxP"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -108,7 +98,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -123,7 +112,6 @@ msgstr "Pendientes de CxP"
 msgid "AP Transaction"
 msgstr "Asiento de CxP"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Asientos de CxP"
@@ -136,9 +124,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -157,7 +143,6 @@ msgstr "CxC"
 msgid "AR Aging"
 msgstr "Diario Resumido de CxC"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -166,7 +151,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -181,7 +165,6 @@ msgstr "Pendientes de CxC"
 msgid "AR Transaction"
 msgstr "Asiento de CxC"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Asiento de CxC"
@@ -194,9 +177,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -205,8 +186,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Asiento de CxC"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -216,16 +195,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -251,38 +225,20 @@ msgstr ""
 msgid "Account"
 msgstr "Cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -303,23 +259,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Número de Cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -359,17 +310,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -381,7 +330,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -409,12 +358,10 @@ msgstr "Activo"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -437,11 +384,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr "Agregar Juego"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -566,7 +513,6 @@ msgstr "Agregar Pedido"
 msgid "Add Service"
 msgstr "Agregar Servicio"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -633,7 +579,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Actualizar"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -658,7 +603,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -668,12 +612,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -693,8 +636,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -747,7 +689,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -756,11 +697,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -794,14 +730,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Monto"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -810,27 +742,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Cantidad Adeudada"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -848,14 +774,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -874,17 +800,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -893,13 +816,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -908,7 +824,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -917,14 +832,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -936,19 +849,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Abr"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "Abril"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -964,7 +874,6 @@ msgstr "¿Está seguro que desea borrar la Cotización número"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -983,19 +892,17 @@ msgstr "¡Juegos realmacendados!"
 msgid "Asset"
 msgstr "Activo"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1008,29 +915,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1046,7 +950,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1144,8 +1047,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Ago"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Agosto"
 
@@ -1157,7 +1059,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1171,7 +1072,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1184,7 +1084,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr "Costo Promedio"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1218,8 +1117,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1234,7 +1131,6 @@ msgstr "Balance"
 msgid "Balance Sheet"
 msgstr "Hoja de Balance"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1255,7 +1151,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1266,7 +1161,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1276,18 +1170,15 @@ msgstr "Moneda"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1300,12 +1191,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1322,13 +1211,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1369,8 +1256,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1417,17 +1302,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1440,12 +1322,10 @@ msgstr ""
 msgid "Business"
 msgstr "Negocio"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "N° de Registro Fiscal"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1455,12 +1335,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1482,7 +1360,6 @@ msgstr "Negocio guardado!"
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1514,18 +1391,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1653,12 +1528,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Plan de Cuentas"
 
@@ -1678,7 +1552,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "Revisar Inventario"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1707,7 +1580,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1719,9 +1592,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "Debitado"
 
@@ -1749,15 +1622,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Cerrado"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1771,8 +1642,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1787,22 +1656,18 @@ msgstr "Falta Código"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1814,39 +1679,31 @@ msgstr ""
 msgid "Company"
 msgstr "Compañía"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Nombre de la Compañía"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1867,7 +1724,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "¡Favor Confirmar!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1885,7 +1742,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Contacto"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1901,7 +1757,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1919,9 +1774,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1951,7 +1803,6 @@ msgstr ""
 msgid "Contra"
 msgstr "Cuentas de Orden"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1959,10 +1810,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1993,20 +1840,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Costo"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2022,26 +1865,20 @@ msgstr "¡No se pudo guardar!"
 msgid "Could not transfer Inventory!"
 msgstr "No se pudo transferir Inventario!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2053,7 +1890,6 @@ msgstr ""
 msgid "Country"
 msgstr "País"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2066,7 +1902,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2074,11 +1910,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2106,8 +1942,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2115,17 +1949,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Crédito"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2150,29 +1981,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Mon."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2195,18 +2016,14 @@ msgstr "Mon."
 msgid "Currency"
 msgstr "Moneda"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Actual"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2216,11 +2033,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2235,7 +2048,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Cliente"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2254,9 +2066,6 @@ msgstr "¡El cliente no existe en la base datos!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2276,9 +2085,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "¡Falta el cliente!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2290,7 +2097,7 @@ msgstr "¡El cliente no existe en la base datos!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2314,12 +2121,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2352,28 +2158,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2420,19 +2214,14 @@ msgstr ""
 msgid "Date"
 msgstr "Fecha"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2454,7 +2243,6 @@ msgstr "Fecha Recibido"
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2518,8 +2306,6 @@ msgstr "Día(s)"
 msgid "Days"
 msgstr "Días"
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2535,10 +2321,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2548,17 +2332,14 @@ msgstr ""
 msgid "Dec"
 msgstr "Dic"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Diciembre"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2568,7 +2349,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2581,47 +2361,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2634,21 +2405,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "Preferencias"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2666,7 +2430,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Borrar"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2679,7 +2442,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr "Eliminar Programación"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2693,37 +2455,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Fecha de entrega"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2745,20 +2503,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2769,46 +2524,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2919,12 +2635,10 @@ msgstr "Detalle"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2937,7 +2651,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2946,7 +2659,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Descuento"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2955,28 +2667,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2984,7 +2696,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2993,7 +2704,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -3001,12 +2712,10 @@ msgstr ""
 msgid "Done"
 msgstr "Hecho"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3019,12 +2728,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3033,19 +2740,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Dibujo"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3061,10 +2765,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3083,7 +2783,7 @@ msgstr "Falta la Fecha de Vencimiento"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3109,7 +2809,7 @@ msgstr "Mensaje de E-mail"
 msgid "E-mailed"
 msgstr "Enviado por E-mail"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3139,7 +2839,7 @@ msgstr "Editar Asiento de CxC"
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3283,8 +2983,6 @@ msgstr "once"
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3298,7 +2996,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Empleado"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3308,12 +3005,11 @@ msgstr "Número de Empleado"
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3323,37 +3019,26 @@ msgstr "Número de Empleado"
 msgid "Employees"
 msgstr "Empleados"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3377,7 +3062,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3402,12 +3086,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3417,7 +3099,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3425,7 +3107,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3451,7 +3132,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Nombre de la Compañía"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3463,14 +3144,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Capital"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3484,16 +3162,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3501,7 +3178,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3514,8 +3191,6 @@ msgstr "Cada"
 msgid "Exch"
 msgstr "Cambio"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3530,7 +3205,6 @@ msgstr "Tasa de Cambio"
 msgid "Exchange rate for payment missing!"
 msgstr "¡Falta la tasa de cambio para el pago!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3539,7 +3213,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "¡Falta tasa de cambio!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3557,13 +3230,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Gastos/Activo"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3641,8 +3311,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Febrero"
 
@@ -3658,14 +3327,10 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3676,11 +3341,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3691,7 +3356,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3749,12 +3413,10 @@ msgstr ""
 msgid "For"
 msgstr "Por"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Ganancia por Diferencial Cambiario"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Pérdida por Diferencial Cambiario"
@@ -3763,12 +3425,10 @@ msgstr "Pérdida por Diferencial Cambiario"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3785,7 +3445,6 @@ msgstr "cuatro"
 msgid "Fourteen"
 msgstr "catorce"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3804,18 +3463,10 @@ msgstr ""
 msgid "From"
 msgstr "Desde"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3836,7 +3487,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr "Desde almacén"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3847,15 +3497,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3869,10 +3514,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "Código GIFI"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3893,7 +3536,6 @@ msgstr "¡Código GIFI guardado!"
 msgid "GL"
 msgstr "Libro Mayor General"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr "N. Referencia Mayor General"
@@ -3902,7 +3544,7 @@ msgstr "N. Referencia Mayor General"
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3910,11 +3552,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3923,7 +3564,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3931,9 +3572,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr "Generar"
 
@@ -3949,7 +3589,7 @@ msgstr "Generar órdenes"
 msgid "Generate Purchase Orders"
 msgstr "Generar órdenes de compra"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3957,7 +3597,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr "Generar órdenes de compra"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3973,12 +3613,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3987,7 +3625,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4061,21 +3698,6 @@ msgstr ""
 msgid "Hundred"
 msgstr "ciento"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4106,7 +3728,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4116,13 +3737,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Imagen"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4165,7 +3784,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4199,14 +3817,10 @@ msgstr "Incluir en menús desplegables"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4214,12 +3828,10 @@ msgstr ""
 msgid "Income"
 msgstr "Ingreso"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4230,7 +3842,6 @@ msgstr "Estado de Cuenta de Igresos"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4240,7 +3851,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Estado de Cuenta de Igresos"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4260,11 +3870,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4274,30 +3883,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "Anotaciones Internas"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4307,17 +3912,14 @@ msgstr "Inventario"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4345,11 +3947,7 @@ msgstr "Inventario guardado!"
 msgid "Inventory transferred!"
 msgstr "Inventario transferido!"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4391,8 +3989,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4408,11 +4004,6 @@ msgstr "¡Falta Fecha de Factura!"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4431,7 +4022,6 @@ msgstr "Número de Factura"
 msgid "Invoice Number missing!"
 msgstr "¡Falta Número de Factura!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4461,12 +4051,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4524,8 +4112,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Ene"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Enero"
 
@@ -4554,8 +4141,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Julio"
 
@@ -4563,8 +4149,8 @@ msgstr "Julio"
 msgid "Jun"
 msgstr "Jun"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Junio"
 
@@ -4577,10 +4163,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "Plantillas LaTeX"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4602,15 +4184,12 @@ msgstr "Mano de Obra/Costo Operativo"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Idioma"
@@ -4631,7 +4210,6 @@ msgstr "¡No hay idiomas definidos!"
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4642,7 +4220,6 @@ msgstr "Último Costo"
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4664,40 +4241,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr "Tiempo de Entrega"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4709,9 +4285,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4733,9 +4307,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4749,8 +4321,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4767,7 +4337,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4804,7 +4373,6 @@ msgstr "Mostrar Idiomas"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4830,7 +4398,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4848,7 +4415,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4869,7 +4435,7 @@ msgstr ""
 msgid "Login"
 msgstr "Login"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4897,45 +4463,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Fabricante"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4957,40 +4516,34 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Marzo"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Margen"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "May"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Memo"
@@ -5007,7 +4560,6 @@ msgstr "Mensaje"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Metódo"
@@ -5016,7 +4568,6 @@ msgstr "Metódo"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5035,14 +4586,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5056,7 +4604,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5069,14 +4616,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Modelo"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5094,7 +4639,7 @@ msgstr "Mes(es)"
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5118,14 +4663,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5134,15 +4677,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5161,7 +4695,6 @@ msgstr "Nombre"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5212,8 +4745,6 @@ msgstr "Siguiente fecha"
 msgid "Next Number"
 msgstr "Siguiente Número"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5235,12 +4766,10 @@ msgstr "diecinueve"
 msgid "Ninety"
 msgstr "noventa"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "No"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5249,7 +4778,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5257,11 +4786,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5269,7 +4798,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5278,11 +4806,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5290,21 +4818,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr "No hay proyectos abiertos!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5323,12 +4848,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5337,12 +4860,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr "Servicios"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5380,11 +4901,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5430,23 +4946,18 @@ msgstr "¡No hay nada que transferir!"
 msgid "Nov"
 msgstr "Nov"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "Noviembre"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5477,7 +4988,7 @@ msgstr ""
 msgid "Number"
 msgstr "Código"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Formato de Número"
 
@@ -5498,13 +5009,11 @@ msgstr "Disp."
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Obsoleto"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5513,8 +5022,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Oct"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Octubre"
 
@@ -5526,9 +5034,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5578,7 +5083,6 @@ msgstr ""
 msgid "Open"
 msgstr "Abierto"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5600,9 +5104,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5648,7 +5149,6 @@ msgstr "¡Falta fecha de la Orden!"
 msgid "Order Entry"
 msgstr "Órdenes"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5670,7 +5170,6 @@ msgstr "¡Orden borrada!"
 msgid "Order generation failed!"
 msgstr "¡No se pudo generar la orden!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5692,7 +5191,7 @@ msgstr "¡Órdenes generadas con éxito!"
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5738,7 +5237,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5757,10 +5255,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5804,11 +5298,6 @@ msgstr "¡Falta Código de Lista de Empaque!"
 msgid "Packing list"
 msgstr "Lista de Empaque"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5826,12 +5315,10 @@ msgstr "Pagado"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Parte"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5841,14 +5328,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5878,14 +5357,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5901,15 +5376,12 @@ msgstr "Número de Parte"
 msgid "Parts"
 msgstr "Parte"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5919,7 +5391,6 @@ msgstr ""
 msgid "Password"
 msgstr "Contraseña"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5932,7 +5403,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5946,7 +5416,6 @@ msgstr ""
 msgid "Payables"
 msgstr "CxP"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5955,7 +5424,6 @@ msgstr "CxP"
 msgid "Payment"
 msgstr "Pago"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5968,7 +5436,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5985,7 +5452,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6021,15 +5487,15 @@ msgstr "Pagos"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6048,7 +5514,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6079,108 +5544,88 @@ msgstr "Lista de Almacén"
 msgid "Pick list"
 msgstr "Lista de Almacén"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6196,7 +5641,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6205,24 +5649,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6231,13 +5673,11 @@ msgstr ""
 msgid "Post"
 msgstr "Registrar"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6278,7 +5718,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Postscript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6316,20 +5755,16 @@ msgstr ""
 msgid "Price"
 msgstr "Precio"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6365,8 +5800,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6376,7 +5809,6 @@ msgstr ""
 msgid "Print"
 msgstr "Imprimir"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6393,7 +5825,7 @@ msgstr "Imprimir y Guardar como Nuevo"
 msgid "Printed"
 msgstr "Impreso"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Impresora"
 
@@ -6437,17 +5869,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6476,7 +5906,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6495,7 +5924,6 @@ msgstr "Traducción de Descripción de Proyectos"
 msgid "Project Number"
 msgstr "Código de Proyecto"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6504,9 +5932,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Proyectos"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6516,7 +5941,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6534,22 +5958,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Orden de Compra"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "Número de Orden de Compra"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Órdenes de Compra"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6564,14 +5982,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Orden de Compra"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6602,7 +6016,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Cantidad"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6616,8 +6029,6 @@ msgstr "¡La Cantidad excede el disponible en en el Inventario!"
 msgid "Quarter"
 msgstr "Trimestre"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6654,9 +6065,7 @@ msgstr "¡Falta Número de Cotización!"
 msgid "Quotation deleted!"
 msgstr "¡Cotización borrada!"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6677,25 +6086,20 @@ msgstr "Solicitud de Cotización"
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "Número de Solicitud de Cotización"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "Solicitudes de Cotización"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "Existencia Mínima"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6707,7 +6111,6 @@ msgstr "Tarifa"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6730,13 +6133,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6754,7 +6153,6 @@ msgstr "Abono"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6768,8 +6166,7 @@ msgstr "Recibos"
 msgid "Receivables"
 msgstr "CxC"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Almacenar"
 
@@ -6777,7 +6174,6 @@ msgstr "Almacenar"
 msgid "Receive Merchandise"
 msgstr "Almacenar Mercancía"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6798,7 +6194,6 @@ msgstr "Conciliación"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6819,13 +6214,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Transacciones Recurrentes"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6864,12 +6252,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6907,7 +6293,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6919,7 +6305,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6932,7 +6318,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6982,7 +6367,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -7002,13 +6387,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Requerido para el"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7038,7 +6420,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7047,7 +6428,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7064,7 +6444,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7114,11 +6493,11 @@ msgstr "SKU"
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7144,7 +6523,6 @@ msgstr "Ventas"
 msgid "Sales Invoice"
 msgstr "Factura de Ventas"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "N° Factura/Transacción de CxC"
@@ -7160,20 +6538,17 @@ msgstr "N° Factura/Transacción de CxC"
 msgid "Sales Order"
 msgstr "Pedido"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "N° de Pedido"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Pedidos"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "N° de Cotización de Venta"
@@ -7196,9 +6571,6 @@ msgstr "N° de Cotización de Venta"
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7222,13 +6594,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7248,7 +6617,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7258,7 +6627,6 @@ msgstr "Guardar"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7317,11 +6685,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "Guardar como nuevo"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7344,10 +6711,8 @@ msgstr "Programar"
 msgid "Scheduled"
 msgstr "Programada"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Pantalla"
 
@@ -7367,7 +6732,6 @@ msgstr "Pantalla"
 msgid "Search"
 msgstr "Búsqueda"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7376,7 +6740,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7429,11 +6792,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7445,11 +6808,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7461,7 +6824,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7469,7 +6832,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7525,7 +6887,6 @@ msgstr "¡Seleccione txt, postscript o PDF!"
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7534,9 +6895,6 @@ msgstr ""
 msgid "Sell"
 msgstr "Vender"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7590,13 +6948,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Sep"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "Septiembre"
 
@@ -7617,9 +6973,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "Serial"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7649,7 +7002,6 @@ msgstr "Código servicio"
 msgid "Services"
 msgstr "Servicio"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 #, fuzzy
 msgid "Session Timeout (e.g. \"90 minutes\")"
@@ -7663,7 +7015,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7683,10 +7035,10 @@ msgstr "diecisiete"
 msgid "Seventy"
 msgstr "setenta"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Envío"
 
@@ -7713,10 +7065,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7777,10 +7125,6 @@ msgstr "Falta Fecha de Envío"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7822,7 +7166,6 @@ msgstr "Fecha de Envío"
 msgid "Short"
 msgstr "Corto"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7863,7 +7206,6 @@ msgstr "sesenta"
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7876,12 +7218,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7908,7 +7244,6 @@ msgstr "Cheque N°"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7930,21 +7265,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Estándard"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "Códigos Industriales Estandarizados (CIE)"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7975,8 +7299,6 @@ msgstr ""
 msgid "Startdate"
 msgstr "Fecha de Inicio"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8013,13 +7335,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Estado de Cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Balance de Cuenta"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8050,7 +7370,7 @@ msgstr "Inventariar Juego"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Hoja de Estilo"
 
@@ -8075,7 +7395,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8118,7 +7437,6 @@ msgstr "Resumen"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8151,12 +7469,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8168,9 +7480,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8189,8 +7498,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8201,17 +7508,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8355,7 +7659,6 @@ msgstr ""
 msgid "Template"
 msgstr "Plantillas HTML"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8364,7 +7667,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8417,7 +7719,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8429,7 +7731,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8480,24 +7782,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8520,14 +7819,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8571,7 +7866,6 @@ msgstr "Hoja de Tiempo"
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr "Hojas de tiempo"
@@ -8601,19 +7895,10 @@ msgstr ""
 msgid "To"
 msgstr "Hasta"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8650,7 +7935,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8675,16 +7959,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8727,7 +8002,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8735,7 +8010,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8756,7 +8030,6 @@ msgstr "Asiento"
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8772,14 +8045,12 @@ msgstr "¡Falta Fecha de Asiento"
 msgid "Transaction Dates"
 msgstr "Fecha de transacciones"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8818,7 +8089,6 @@ msgstr "Traducciones"
 msgid "Translations saved!"
 msgstr "Traducciones guardadadas"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Balance de Comprobación"
@@ -8827,7 +8097,6 @@ msgstr "Balance de Comprobación"
 msgid "Trillion"
 msgstr "billón"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8884,10 +8153,6 @@ msgstr "veintidós"
 msgid "Two"
 msgstr "dos"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8922,39 +8187,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8973,43 +8232,37 @@ msgstr "Unidad"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9017,23 +8270,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9050,7 +8298,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9078,21 +8325,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9101,7 +8343,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9119,24 +8360,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9146,7 +8382,6 @@ msgstr "Usuario"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9167,7 +8402,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9193,8 +8427,6 @@ msgstr "Válido hasta"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9204,11 +8436,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9224,7 +8452,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Proveedor"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9238,7 +8465,6 @@ msgstr "Histórico de Proveedores"
 msgid "Vendor Invoice"
 msgstr "Factura de Compra"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9248,9 +8474,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9280,9 +8503,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "¡Falta Proveedor!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9290,8 +8511,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "¡Proveedor no se encuentra en la Base de Datos!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9306,7 +8525,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9319,7 +8537,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9342,7 +8559,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Almacenes"
@@ -9351,11 +8567,26 @@ msgstr "Almacenes"
 msgid "Warning!"
 msgstr "¡Advertencia!"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9365,7 +8596,6 @@ msgstr ""
 msgid "Week"
 msgstr "Semana"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9382,13 +8612,11 @@ msgstr ""
 msgid "Weeks"
 msgstr "Semanas"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Peso"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Unidad de Peso"
@@ -9405,7 +8633,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9423,11 +8650,11 @@ msgstr "Orden de Trabajo"
 msgid "Work order"
 msgstr "Orden de Trabajo"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9470,15 +8697,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Sí"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9505,7 +8727,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9569,17 +8791,12 @@ msgstr "días"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9596,7 +8813,7 @@ msgstr ""
 msgid "done"
 msgstr "hecho"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9624,8 +8841,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9634,22 +8849,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9674,7 +8885,6 @@ msgstr ""
 msgid "sent"
 msgstr "enviado"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9699,8 +8909,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr "Error inesperado!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/et.po
+++ b/locale/po/et.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Estonian (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -16,27 +16,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr "Arveid kokku"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr "% Amort"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr "(+) Jääkväärtus"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr "(-) Kogunenud amort"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr "(=) Netoväärtus"
@@ -49,12 +44,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -100,7 +91,6 @@ msgstr "OstuReskontro"
 msgid "AP Aging"
 msgstr "OR Aegunud"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr "Ostuarve"
@@ -109,7 +99,6 @@ msgstr "Ostuarve"
 msgid "AP Invoices"
 msgstr "Ostuarved"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -124,7 +113,6 @@ msgstr "OR Laekumata"
 msgid "AP Transaction"
 msgstr "OR Tehing"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "OR Tehingud"
@@ -137,9 +125,7 @@ msgstr "Ostuvautšer"
 msgid "AP account"
 msgstr "Ostukonto"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -158,7 +144,6 @@ msgstr "MüügiReskontro"
 msgid "AR Aging"
 msgstr "MR Aegunud"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr "Müügiarve"
@@ -167,7 +152,6 @@ msgstr "Müügiarve"
 msgid "AR Invoices"
 msgstr "Müügiarved"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -182,7 +166,6 @@ msgstr "MR Laekumata"
 msgid "AR Transaction"
 msgstr "MR Tehing"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "MR Tehingud"
@@ -195,9 +178,7 @@ msgstr "Müügivautšer"
 msgid "AR account"
 msgstr "Müügikonto"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -206,8 +187,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "MR Tehing"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -217,16 +196,11 @@ msgstr "Müügi/ostu/pearaamatu summa"
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr "Ligipääs keelatud"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -252,38 +226,20 @@ msgstr "Ligipääs keelatud"
 msgid "Account"
 msgstr "Konto"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr "Konto kirjeldus"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr "Konto silt"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr "Konto nimi"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -304,23 +260,18 @@ msgstr "Konto nimi"
 msgid "Account Number"
 msgstr "Konto Number"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr "Konto number algab"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr "Konto pealkiri"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -360,17 +311,15 @@ msgstr "Kontod alates"
 msgid "Accounts To"
 msgstr "Kontod kuni"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -382,7 +331,7 @@ msgstr "Tekkepõhine"
 msgid "Accrual Basis:"
 msgstr "Tekkepõhine:"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -410,12 +359,10 @@ msgstr "Aktiiv"
 msgid "Active On"
 msgstr "Aktiivne sees"
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr "Aktiivne sessioon"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -438,11 +385,11 @@ msgstr "Lisa kontod"
 msgid "Add Assembly"
 msgstr "Lisa Komplekt"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr "Lisa vara"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr "Lisa varaklass"
 
@@ -567,7 +514,6 @@ msgstr "Lisa Müügitellimus"
 msgid "Add Service"
 msgstr "Lisa Teenus"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr "Lisa maksuvorm"
@@ -634,7 +580,6 @@ msgstr "Lisa/muuda palka"
 msgid "Add/Update"
 msgstr "Värskenda"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr "Lisatud id [_1]"
@@ -659,7 +604,6 @@ msgstr "Aadress:"
 msgid "Address: [_1]"
 msgstr "Aadress: [_1]"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -669,12 +613,11 @@ msgstr "Aadressid"
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -694,8 +637,7 @@ msgstr "Korrigeerimise üksikasjad"
 msgid "Aged"
 msgstr "Aegunud"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr "Hilinenute aruanne"
 
@@ -748,7 +690,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr "Kõik hinnad valuutas [_1]."
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr "Reserveeritud"
@@ -757,11 +698,6 @@ msgstr "Reserveeritud"
 msgid "Allow Input"
 msgstr "Luba sisestus"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -795,14 +731,10 @@ msgstr "Luba sisestus"
 msgid "Amount"
 msgstr "Summa"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -811,27 +743,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Maksmisele kuuluv summa"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -849,14 +775,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -875,17 +801,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -894,13 +817,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -909,7 +825,6 @@ msgstr ""
 msgid "Approve"
 msgstr "Kiida heaks"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -918,14 +833,12 @@ msgstr "Kiida heaks"
 msgid "Approved"
 msgstr "Heaks kiidetud"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -937,19 +850,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Apr"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "Aprill"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -965,7 +875,6 @@ msgstr "Kas oled kindel, et soovid Koteeringu Number"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -984,19 +893,17 @@ msgstr "Koosteosade laovaru täiendatud!"
 msgid "Asset"
 msgstr "Vara"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr "Vara konto"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr "Varaklass"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr "Varaklasside nimekiri"
@@ -1009,29 +916,26 @@ msgstr "Varaklass:"
 msgid "Asset Classes"
 msgstr "Varaklassid"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr "Vara amortisatsiooni aruanne"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr "Vara realiseerimise aruanne"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr "Vara nimekiri"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr "Vara osalise realiseerimise aruanne"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr "Vara silt"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1047,7 +951,6 @@ msgstr "Varad omakapitali suhe"
 msgid "Assets to Liabilities"
 msgstr "Varad kohustustesse suhe"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1145,8 +1048,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Aug"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "August"
 
@@ -1158,7 +1060,6 @@ msgstr "Autor: [_1]"
 msgid "Automatic"
 msgstr "Automaatne"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1172,7 +1073,6 @@ msgstr "Kasutatavad andmebaasid"
 msgid "Available Users"
 msgstr "Saadaval kasutajad"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1185,7 +1085,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr "Keskmised Kulud"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr "Keskmine kulu"
@@ -1219,8 +1118,6 @@ msgstr "Varunda andmebaas"
 msgid "Backup Roles"
 msgstr "Varundus rollid"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1235,7 +1132,6 @@ msgstr "Bilanss"
 msgid "Balance Sheet"
 msgstr "Bilansiaruanne"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr "Bilanss"
@@ -1256,7 +1152,6 @@ msgstr "Arveldusarve"
 msgid "Bank Account:"
 msgstr "Arveldusarve:"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1267,7 +1162,6 @@ msgstr "Arveldusarved"
 msgid "Bar Code"
 msgstr "Vöötkood"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1277,18 +1171,15 @@ msgstr "Valuuta"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1301,12 +1192,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1323,13 +1212,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1370,8 +1257,6 @@ msgstr "Maksja e-posti"
 msgid "Billion"
 msgstr "miljard"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1418,17 +1303,14 @@ msgstr ""
 msgid "Budget"
 msgstr "Eelarve"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr "Eelarve number"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr "Eelarve otsingu tulemused"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr "Eelarve lahknevuse aruanne"
@@ -1441,12 +1323,10 @@ msgstr "Eelarved"
 msgid "Business"
 msgstr "Ettevõte"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Ettevõtte Registrinumber"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1456,12 +1336,10 @@ msgstr "Ettevõtte tüüp"
 msgid "Business Type:"
 msgstr "Ettevõtte tüüp:"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1483,7 +1361,6 @@ msgstr "Ettevõte salvestatud"
 msgid "CC"
 msgstr "Koopia"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1515,18 +1392,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr "Tühistatud arvet ei saa tühistada!"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr "Tühista"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr "Tühista?"
 
@@ -1652,12 +1527,11 @@ msgstr "Muuda salasõna"
 msgid "Chargeable"
 msgstr "Maksustatav"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr "Konto ID"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Kontoplaan"
 
@@ -1677,7 +1551,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "Kontrolli Laoseisu"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1706,7 +1579,7 @@ msgstr "Linn"
 msgid "Class"
 msgstr "Klass"
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr "Laekumise kuupäev"
 
@@ -1718,9 +1591,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "Laekunud"
 
@@ -1748,15 +1621,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Suletud"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1771,8 +1642,6 @@ msgstr "Sulge andmed"
 msgid "Closing data"
 msgstr "Sulge andmed"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1787,22 +1656,18 @@ msgstr "Kood puudu!"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1814,39 +1679,31 @@ msgstr ""
 msgid "Company"
 msgstr "Firma"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr "Ettevõtte aadress"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr "Ettevõtte faks"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr "Ettevõtte andmed"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr "Ettevõtte äriregistri kood"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Firma Nimi"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr "Ettevõtte telefon"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr "Ettevõtte KM-kohuslase number"
@@ -1867,7 +1724,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Kinnita!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1885,7 +1742,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Kontakt"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1901,7 +1757,6 @@ msgstr "Kontakti info:"
 msgid "Contact Information"
 msgstr "Kontakti info"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1919,9 +1774,6 @@ msgstr "Kontaktid"
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1951,7 +1803,6 @@ msgstr "Jätka eelmist tegevust"
 msgid "Contra"
 msgstr "Ammortisatsioon"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1959,10 +1810,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1993,20 +1840,16 @@ msgstr "Kopeeri uueks"
 msgid "Copy to New Name"
 msgstr "Kopeeri uueks nimega"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Omahind"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr "Müüdud kauba kulu"
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr "Ei õnnestu laadida malli andmebaasist"
 
@@ -2022,26 +1865,20 @@ msgstr "Ei saa salvestada!"
 msgid "Could not transfer Inventory!"
 msgstr "Laoseisu ei saa ümber paigutada!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2053,7 +1890,6 @@ msgstr ""
 msgid "Country"
 msgstr "Riik"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr "Riigi nimi"
@@ -2066,7 +1902,7 @@ msgstr "Riik:"
 msgid "Create"
 msgstr "Loo"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2074,11 +1910,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr "Lisame andmebaasi?"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2106,8 +1942,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2115,17 +1949,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Kreedit"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr "Kreeditkonto"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr "Kreeditkonto number"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr "Kreeditkontod"
@@ -2150,29 +1981,19 @@ msgstr "Krediidilimiit:"
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Val."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2195,18 +2016,14 @@ msgstr "Val."
 msgid "Currency"
 msgstr "Valuuta"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Jooksev"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2216,11 +2033,7 @@ msgstr "Käesoleva aasta kasum (kahjum)"
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2235,7 +2048,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Klient"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr "Kliendi konto"
@@ -2254,9 +2066,6 @@ msgstr "Klient puudub failis!"
 msgid "Customer Name"
 msgstr "Kliendi nimi"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2276,9 +2085,7 @@ msgstr "Kliendi otsing"
 msgid "Customer missing!"
 msgstr "Klienti puudu!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2290,7 +2097,7 @@ msgstr "Klient puudub failis!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2314,12 +2121,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr "Andmed ei ole salvestatud. Palun proovige uuesti."
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr "Andmed ei ole salvestatud. Palun uuendage uuesti."
 
@@ -2352,28 +2158,16 @@ msgstr "Andmebaasi administraatori kasutajatunnused"
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr "Andmebaas eksisteerib."
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2420,19 +2214,14 @@ msgstr "Andmebaas eksisteerib."
 msgid "Date"
 msgstr "Kuupäev"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr "Kuupäeva formaat"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr "Kuupäev alates"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2454,7 +2243,6 @@ msgstr "Kättesaamise kuupäev"
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2518,8 +2306,6 @@ msgstr "Päev(a)"
 msgid "Days"
 msgstr "Päeva"
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2535,10 +2321,8 @@ msgstr "Deebitarve"
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2548,17 +2332,14 @@ msgstr ""
 msgid "Dec"
 msgstr "Dets"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Detsember"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr "Komakohad rahale"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2568,7 +2349,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2581,47 +2361,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr "Vaikimisi riik"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr "Vaikimisi keel"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2634,21 +2405,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "Vaikeväärtused"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2666,7 +2430,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Kustuta"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2679,7 +2442,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr "Kustutata Ajakava"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2694,37 +2456,33 @@ msgstr ""
 msgid "Delivery"
 msgstr "Üleandmine"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Tarnetähtaeg"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2746,20 +2504,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2770,46 +2525,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2920,12 +2636,10 @@ msgstr "Detail"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr "Keela tagasi nupp"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr "Allahindlus"
@@ -2938,7 +2652,6 @@ msgstr "Allahindlus"
 msgid "Disc %"
 msgstr "Allahindluse %"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2947,7 +2660,6 @@ msgstr "Allahindluse %"
 msgid "Discount"
 msgstr "Diskonto"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr "Allahindluse %"
@@ -2956,28 +2668,28 @@ msgstr "Allahindluse %"
 msgid "Discount:"
 msgstr "Allahindlus:"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr "Näita soetusmaksumust"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr "Realiseerimine"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr "Realiseerimise kuupäev"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr "Realiseerimise meetod"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr "Realiseerimise aruanne [_1] kuupäeval [_2]"
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr "Viga nulliga jagamisel"
 
@@ -2985,7 +2697,6 @@ msgstr "Viga nulliga jagamisel"
 msgid "Do not keep field empty [_1]"
 msgstr "Ära jära lahtrit tühjaks [_1]"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr "Dokument"
@@ -2994,7 +2705,7 @@ msgstr "Dokument"
 msgid "Document Type"
 msgstr "Dokumendi tüüp"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr "Ei tea, mida teha varukoopiaga"
 
@@ -3002,12 +2713,10 @@ msgstr "Ei tea, mida teha varukoopiaga"
 msgid "Done"
 msgstr "Valmis"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3020,12 +2729,10 @@ msgstr "Doktor"
 msgid "Draft Posted"
 msgstr "Mustand salvestatud"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr "Mustandi otsing"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr "Mustandi tüüp"
@@ -3034,19 +2741,16 @@ msgstr "Mustandi tüüp"
 msgid "Drafts"
 msgstr "Mustandid"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Joonis"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr "Rippmenüüd"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3062,10 +2766,6 @@ msgstr "Rippmenüüd"
 msgid "Due"
 msgstr "Tähtaeg"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3084,7 +2784,7 @@ msgstr "Maksetähtaeg puudub!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr "Töötaja number topelt"
 
@@ -3110,7 +2810,7 @@ msgstr "E-posti teade"
 msgid "E-mailed"
 msgstr "E-postiga saadetud"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3140,7 +2840,7 @@ msgstr "Muuda MR Tehing"
 msgid "Edit Assembly"
 msgstr "Muuda komplekti"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr "Muuda vara klassi"
 
@@ -3284,8 +2984,6 @@ msgstr ""
 msgid "Email"
 msgstr "E-posti aadress"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3299,7 +2997,6 @@ msgstr "E-posti aadress"
 msgid "Employee"
 msgstr "Töötaja"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3309,12 +3006,11 @@ msgstr "Teenistuja Number"
 msgid "Employee Search"
 msgstr "Töötaja otsing"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3324,37 +3020,26 @@ msgstr "Teenistuja Number"
 msgid "Employees"
 msgstr "Teenistujad"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3378,7 +3063,6 @@ msgstr "Lõpp kuupäev:"
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3403,12 +3087,10 @@ msgstr ""
 msgid "Enter User"
 msgstr "Sisesta kasutaja"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3418,7 +3100,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3426,7 +3108,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3452,7 +3133,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Riigi nimi"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3464,14 +3145,11 @@ msgstr "Ümbrik"
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Omandiõigus"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr "Total de Capital y Pasivos"
@@ -3485,16 +3163,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3502,7 +3179,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3515,8 +3192,6 @@ msgstr "Iga"
 msgid "Exch"
 msgstr "Kurss"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3531,7 +3206,6 @@ msgstr "Valuutakurss"
 msgid "Exchange rate for payment missing!"
 msgstr "Maksel puudub valuutakurss!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3540,7 +3214,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "Valuutakurss puudu!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr "Eeldatud"
@@ -3558,13 +3231,10 @@ msgstr "Kulukonto"
 msgid "Expense/Asset"
 msgstr "Kulu/Vara"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr "Kulud"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3642,8 +3312,7 @@ msgstr "Faks: [_1]"
 msgid "Feb"
 msgstr "Veebr"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Veebruar"
 
@@ -3659,14 +3328,10 @@ msgstr "viiskümmend"
 msgid "File"
 msgstr "Fail"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr "Fail imporditud"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3677,11 +3342,11 @@ msgstr "Faili nimi"
 msgid "File Type"
 msgstr "Faili tüüp"
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr "Faili nimi"
 
@@ -3692,7 +3357,6 @@ msgstr "Faili nimi"
 msgid "File type"
 msgstr "Faili tüüp"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr "Failid"
@@ -3750,12 +3414,10 @@ msgstr "Põhivarad"
 msgid "For"
 msgstr "Saata"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Valuutavahetuse Kasum"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Valuutavahetuse Kahjum"
@@ -3764,12 +3426,10 @@ msgstr "Valuutavahetuse Kahjum"
 msgid "Form"
 msgstr "Vorm"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr "Vormi nimi"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3786,7 +3446,6 @@ msgstr "neli"
 msgid "Fourteen"
 msgstr "neliteist"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr "Reede"
@@ -3805,18 +3464,10 @@ msgstr "Reede"
 msgid "From"
 msgstr "Alates"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3837,7 +3488,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr "Tuleb Kaubalaost"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr "Alates"
@@ -3848,15 +3498,10 @@ msgstr "Alates"
 msgid "Full"
 msgstr "Kõik"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr "Kõik õigused"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3870,10 +3515,8 @@ msgstr "Kõik õigused"
 msgid "GIFI"
 msgstr "GIFI"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr "GIFI kontod puuduvad \"gifi\" tabelis"
 
@@ -3894,7 +3537,6 @@ msgstr "GIFI salvestatud!"
 msgid "GL"
 msgstr "Pearaamat"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr "Pearaamatu Viitenumber"
@@ -3903,7 +3545,7 @@ msgstr "Pearaamatu Viitenumber"
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3911,12 +3553,11 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 #, fuzzy
 msgid "Gain/Loss"
 msgstr "Kahjum"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3925,7 +3566,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr "Pearaamatu aruanne"
 
@@ -3933,9 +3574,8 @@ msgstr "Pearaamatu aruanne"
 msgid "General Ledger Reports"
 msgstr "Pearaamatu aruanded"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr "Genereeri"
 
@@ -3951,7 +3591,7 @@ msgstr "Genereeri Tellimused"
 msgid "Generate Purchase Orders"
 msgstr "Genereeri Ostutellimused"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr "Genereeri ostutellimused müügitellimustest"
 
@@ -3959,7 +3599,7 @@ msgstr "Genereeri ostutellimused müügitellimustest"
 msgid "Generate Sales Orders"
 msgstr "Genereeri Müügitellimused"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr "Genereeri müügitellimused ostutellimustest"
 
@@ -3975,12 +3615,10 @@ msgstr "Eesnimi"
 msgid "Goods & Services"
 msgstr "Tooted ja teenused"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr "Tooted ja teenused"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr "Toodete ja teenuste ajalugu"
@@ -3989,7 +3627,6 @@ msgstr "Toodete ja teenuste ajalugu"
 msgid "Grand Total"
 msgstr "Kokku"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4063,21 +3700,6 @@ msgstr ""
 msgid "Hundred"
 msgstr "sada"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4108,7 +3730,6 @@ msgstr "IRC"
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4118,13 +3739,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Pilt"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4167,7 +3786,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4201,14 +3819,10 @@ msgstr "Kaasa rippmenüüdesse"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4216,12 +3830,10 @@ msgstr ""
 msgid "Income"
 msgstr "Tulu"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4232,7 +3844,6 @@ msgstr "Kasumiaruanne"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4242,7 +3853,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Kasumiaruanne"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4262,11 +3872,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr "Andmebaasi sisene viga"
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4276,30 +3885,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "Sisemärkused"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4309,17 +3914,14 @@ msgstr "Laoseis"
 msgid "Inventory Activity"
 msgstr "Lao liikumised"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4345,11 +3947,7 @@ msgstr "Laoseis salvestatud!"
 msgid "Inventory transferred!"
 msgstr "Laoseis üle kantud!"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4391,8 +3989,6 @@ msgstr "Arve loonud"
 msgid "Invoice Created Date missing!"
 msgstr "Arve koostamise kuupäev puudub!"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4408,11 +4004,6 @@ msgstr "Kaubaarvel Kuupäev puudu!"
 msgid "Invoice No."
 msgstr "Arve nr"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4431,7 +4022,6 @@ msgstr "Kaubaarve Number"
 msgid "Invoice Number missing!"
 msgstr "Kaubaarve Number puudu!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4461,12 +4051,10 @@ msgstr "Maksetähtaeg"
 msgid "Invoice not found"
 msgstr "Arvet ei leitud"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4524,8 +4112,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Jaan"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Jaanuar"
 
@@ -4554,8 +4141,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Juul"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Juuli"
 
@@ -4563,8 +4149,8 @@ msgstr "Juuli"
 msgid "Jun"
 msgstr "Juun"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Juuni"
 
@@ -4577,10 +4163,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "LaTeX Dokumendipõhjad"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4602,15 +4184,12 @@ msgstr "Tööjõud/Kulud"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Keel"
@@ -4631,7 +4210,6 @@ msgstr "Keeled pole defineeritud!"
 msgid "Last"
 msgstr "Viimane"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4642,7 +4220,6 @@ msgstr "Viimane Maksumus"
 msgid "Last Name"
 msgstr "Perekonnanimi"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr "Viimati uuendatud"
@@ -4664,41 +4241,40 @@ msgstr "Tarneaeg"
 msgid "Leadtime"
 msgstr "Tellimuse täitmisaeg"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr "LedgerSMB 1.2 db leitud."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr "LedgerSMB 1.3 db leitud."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr "LedgerSMB 1.4 db leitud."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr "LedgerSMB 1.5 db leitud."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 #, fuzzy
 msgid "LedgerSMB 1.8 db found."
 msgstr "LedgerSMB 1.2 db leitud."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 #, fuzzy
 msgid "LedgerSMB 1.9 db found."
 msgstr "LedgerSMB 1.2 db leitud."
@@ -4711,9 +4287,7 @@ msgstr "LedgerSMB andmebaasi statistika"
 msgid "LedgerSMB [_1]"
 msgstr "LedgerSMB [_1]"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4735,9 +4309,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4751,8 +4323,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr "Kirjapäis"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4769,7 +4339,6 @@ msgstr "Ettevõtte äriregistri kood"
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4806,7 +4375,6 @@ msgstr "Keelte Nimekiri"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4832,7 +4400,6 @@ msgstr "Kasutajate nimekiri"
 msgid "List Warehouse"
 msgstr "Ladude nimekiri"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr "Ettevõtete tüüpide nimekiri"
@@ -4850,7 +4417,6 @@ msgstr "Asukoht"
 msgid "Locations"
 msgstr "Asukohad"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4871,7 +4437,7 @@ msgstr "Sisse logimine. Palun oodake."
 msgid "Login"
 msgstr "Logi sisse"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr "Login välja?"
 
@@ -4899,45 +4465,38 @@ msgstr "MSN"
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Tootja"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr "Tee töötaja number unikaalseks"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr "Tee arve number unikaalseks"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr "Kasutajate haldamine"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4959,40 +4518,34 @@ msgstr "Manuaalne"
 msgid "Mar"
 msgstr "Mär"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Märts"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Kate"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr "Hüppikmenüü max valikute arv"
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "Mai"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Memo"
@@ -5009,7 +4562,6 @@ msgstr "Sõnum"
 msgid "Message: "
 msgstr "Teade: "
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Meetod"
@@ -5018,7 +4570,6 @@ msgstr "Meetod"
 msgid "Method Default"
 msgstr "Vaikimisi meetod"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5037,14 +4588,11 @@ msgstr "Keskmine nimi"
 msgid "Million"
 msgstr "miljon"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5058,7 +4606,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr "Seaded"
@@ -5071,14 +4618,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Mudel"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr "Esmaspäev"
@@ -5096,7 +4641,7 @@ msgstr "Kuu(d)"
 msgid "Months"
 msgstr "kuud"
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5121,14 +4666,12 @@ msgstr "Mitu kuupäeva"
 msgid "Multiple dates"
 msgstr "Mitu kuupäeva"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5137,15 +4680,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5164,7 +4698,6 @@ msgstr "Nimi"
 msgid "Name:"
 msgstr "Nimi:"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5215,8 +4748,6 @@ msgstr "Järgmine Kuupäev"
 msgid "Next Number"
 msgstr "Järgmine Number"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5238,12 +4769,10 @@ msgstr "üheksateist"
 msgid "Ninety"
 msgstr "üheksakümmend"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Ei"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5252,7 +4781,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr "Kontol puudub id [_1]"
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5260,11 +4789,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5272,7 +4801,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5281,11 +4809,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5293,21 +4821,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr "Puuduvad avatud Projektid!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr "Maksuvormi pole valitud"
@@ -5326,12 +4851,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5340,12 +4863,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr "Mitte jälgitavad Kaubaartiklid"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5383,11 +4904,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5433,23 +4949,18 @@ msgstr "Pole midagi ümber paigutada!"
 msgid "Nov"
 msgstr "Nov"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "November"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5480,7 +4991,7 @@ msgstr ""
 msgid "Number"
 msgstr "Number"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Numbri Formaat"
 
@@ -5501,13 +5012,11 @@ msgstr "Ülekulud"
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Aegunud"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5516,8 +5025,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Okt"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Oktoober"
 
@@ -5529,9 +5037,6 @@ msgstr ""
 msgid "Old Password"
 msgstr "Kehtiv salasõna"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5581,7 +5086,6 @@ msgstr "Ainult töötajatele"
 msgid "Open"
 msgstr "Avatud"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5603,9 +5107,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5651,7 +5152,6 @@ msgstr "Tellimuse Kuupäev puudub!"
 msgid "Order Entry"
 msgstr "Tellimuse Sisestus"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5673,7 +5173,6 @@ msgstr "Tellimus kustutatud!"
 msgid "Order generation failed!"
 msgstr "Arve genereerimine ebaõnnestus!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr "Tellimus/Arve"
@@ -5695,7 +5194,7 @@ msgstr "Arved genereeritud"
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5741,7 +5240,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5760,10 +5258,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr "Ostutellimus"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5807,11 +5301,6 @@ msgstr "Saateelehe Number puudu!"
 msgid "Packing list"
 msgstr "Saateleht"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5829,12 +5318,10 @@ msgstr "Makstud"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Detail"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5844,14 +5331,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5881,14 +5360,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5904,15 +5379,12 @@ msgstr "Detailinumber"
 msgid "Parts"
 msgstr "Detail"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5922,7 +5394,6 @@ msgstr ""
 msgid "Password"
 msgstr "Parool"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5935,7 +5406,6 @@ msgstr "Salasõnad peavad kattuma."
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5949,7 +5419,6 @@ msgstr ""
 msgid "Payables"
 msgstr "Kreditoorne võlgnevus"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5958,7 +5427,6 @@ msgstr "Kreditoorne võlgnevus"
 msgid "Payment"
 msgstr "Makse"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5971,7 +5439,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5988,7 +5455,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6024,15 +5490,15 @@ msgstr "Maksed"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6051,7 +5517,6 @@ msgstr "Perioodi valimine"
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6082,108 +5547,88 @@ msgstr "Veose Saateleht"
 msgid "Pick list"
 msgstr "Veose Saateleht"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr "Veendu, et kõigil töötajatel oleksid numbrid"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6199,7 +5644,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr "Palun vali sobiv päis"
@@ -6208,24 +5652,22 @@ msgstr "Palun vali sobiv päis"
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6234,13 +5676,11 @@ msgstr ""
 msgid "Post"
 msgstr "Postita"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6281,7 +5721,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Postscript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6319,20 +5758,16 @@ msgstr ""
 msgid "Price"
 msgstr "Hind"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr "Hinnagrupp"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr "Hinnagrupid"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6368,8 +5803,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr "Peamine telefon"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6379,7 +5812,6 @@ msgstr "Peamine telefon"
 msgid "Print"
 msgstr "Trüki"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6396,7 +5828,7 @@ msgstr "Trüki ja Salvesta uuena"
 msgid "Printed"
 msgstr "Trükitud"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Printer"
 
@@ -6440,17 +5872,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6479,7 +5909,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6498,7 +5927,6 @@ msgstr "Projekti Kirjelduse Selgitus"
 msgid "Project Number"
 msgstr "Projekti Number"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6507,9 +5935,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Projektid"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6519,7 +5944,6 @@ msgstr "Ostu kuupäev"
 msgid "Purchase Date:"
 msgstr "Ostu kuupäev:"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6537,22 +5961,16 @@ msgstr "Ostu ajalugu"
 msgid "Purchase Order"
 msgstr "Hanketellimus"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "Hanketellimuse Number"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Hanketellimused"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6567,14 +5985,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Hanketellimus"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr "Ostetud"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6605,7 +6019,6 @@ msgstr "Ostetud"
 msgid "Qty"
 msgstr "Kogus"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr "Kogus"
@@ -6619,8 +6032,6 @@ msgstr "Kogus ületab laos olevad ühikud!"
 msgid "Quarter"
 msgstr "Kvartal"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6657,9 +6068,7 @@ msgstr "Koteeringu Number puudub!"
 msgid "Quotation deleted!"
 msgstr "Koteering kustutatud!"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6680,25 +6089,20 @@ msgstr "Hinnapakkumuse Taotlus"
 msgid "RFQ #"
 msgstr "Müügipakkumise taotluse nr"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "Hinnapakkumuse Taotluse NR."
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "Hinnapakkumuse Taotlused"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "Pakendis tk."
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6710,7 +6114,6 @@ msgstr "Tariif"
 msgid "Rate (%)"
 msgstr "Määr (%)"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6733,13 +6136,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6757,7 +6156,6 @@ msgstr "Kviitung"
 msgid "Receipt Date"
 msgstr "Laekumise kuupäev"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6771,8 +6169,7 @@ msgstr "Laekumid"
 msgid "Receivables"
 msgstr "Debitoorne võlgnevus"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Vastuvõtt"
 
@@ -6780,7 +6177,6 @@ msgstr "Vastuvõtt"
 msgid "Receive Merchandise"
 msgstr "Kauba Vastuvõtt"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr "Vastu võetud"
@@ -6801,7 +6197,6 @@ msgstr "Kooskõlastamine"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6822,13 +6217,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Korduvad Tehingud"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6867,12 +6255,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr "Hülga"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6910,7 +6296,7 @@ msgstr ""
 msgid "Report Name"
 msgstr "Aruande nimi"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6922,7 +6308,7 @@ msgstr ""
 msgid "Report Type"
 msgstr "Aruande tüüp"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6935,7 +6321,6 @@ msgstr ""
 msgid "Report type"
 msgstr "Aruande tüüp"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6985,7 +6370,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -7005,13 +6390,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Tarnetähtaeg"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7041,7 +6423,6 @@ msgstr "Mine tagasi logimis lehele"
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7050,7 +6431,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7067,7 +6447,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7117,11 +6496,11 @@ msgstr "Asenduskaup"
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr "SQL-Ledger 3.0 andmebaas tuvastatud"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr "SQL-Ledger andmebaas tuvastatud"
 
@@ -7147,7 +6526,6 @@ msgstr "Müük"
 msgid "Sales Invoice"
 msgstr "Müügiarve"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Müügiarve/MR Tehingu Number"
@@ -7163,20 +6541,17 @@ msgstr "Müügiarve/MR Tehingu Number"
 msgid "Sales Order"
 msgstr "Müügitellimus"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "Müügiarve Number"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Müügitellimused"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "Müügipakkumuse Number"
@@ -7199,9 +6574,6 @@ msgstr "Tervitus"
 msgid "Sales:"
 msgstr "Müük:"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7225,13 +6597,10 @@ msgstr "Tervitus"
 msgid "Salvage Value:"
 msgstr "Jääkväärtus:"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr "Laup"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7251,7 +6620,7 @@ msgstr "Laup"
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7261,7 +6630,6 @@ msgstr "Salvesta"
 msgid "Save As New"
 msgstr "Salvesta uuena"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7320,11 +6688,10 @@ msgstr "Salvesta uuena"
 msgid "Save as new"
 msgstr "Salvesta uuena"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr "Salvestatud id [_1]"
@@ -7347,10 +6714,8 @@ msgstr "Ajakava"
 msgid "Scheduled"
 msgstr "Planeeritud"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Ekraan"
 
@@ -7370,7 +6735,6 @@ msgstr "Ekraan"
 msgid "Search"
 msgstr "Otsi"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7379,7 +6743,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7432,11 +6795,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7448,11 +6811,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7464,7 +6827,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7472,7 +6835,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr "Turvaseaded"
@@ -7528,7 +6890,6 @@ msgstr "Valida .txt, postscript või PDF!"
 msgid "Select using"
 msgstr "Kasuta valikus"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7537,9 +6898,6 @@ msgstr ""
 msgid "Sell"
 msgstr "Müüma"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7593,13 +6951,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Sept"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "September"
 
@@ -7620,9 +6976,6 @@ msgstr "Seeria #"
 msgid "Serial No."
 msgstr "Seerianr."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7652,7 +7005,6 @@ msgstr "Teenuse Kood"
 msgid "Services"
 msgstr "Teenus"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 #, fuzzy
 msgid "Session Timeout (e.g. \"90 minutes\")"
@@ -7666,7 +7018,7 @@ msgstr "Seansid"
 msgid "Setting"
 msgstr "Seaded"
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr "Seaded"
 
@@ -7686,10 +7038,10 @@ msgstr "seitseteist"
 msgid "Seventy"
 msgstr "seitsekümmend"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Saatmine"
 
@@ -7716,10 +7068,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7780,10 +7128,6 @@ msgstr "Saatmise Kuupäev puudub"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7825,7 +7169,6 @@ msgstr "Saatmise Kuupäev"
 msgid "Short"
 msgstr "Puudu"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7866,7 +7209,6 @@ msgstr "kuuskümmend"
 msgid "Skip"
 msgstr "Jäta vahele"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr "Müüdud"
@@ -7879,12 +7221,6 @@ msgstr ""
 msgid "Sort by"
 msgstr "Sorteeri"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7911,7 +7247,6 @@ msgstr "Allikas"
 msgid "Source documentation"
 msgstr "Algne dokument"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7933,21 +7268,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Standard"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "Standardiseeritud Tööstuskood"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7979,8 +7303,6 @@ msgstr "Hakka kasutama LedgerSMB tarkvara"
 msgid "Startdate"
 msgstr "Alguskuupäev"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8017,13 +7339,11 @@ msgstr "Maakond:"
 msgid "Statement"
 msgstr "Aruanne"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Bilansiaruanne"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8054,7 +7374,7 @@ msgstr "Komplekti Ladustamine"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Laaditabel"
 
@@ -8079,7 +7399,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8122,7 +7441,6 @@ msgstr "Kokkuvõte"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8155,12 +7473,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr "KOKKU"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8172,9 +7484,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8193,8 +7502,6 @@ msgstr "Maksukonto"
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8205,17 +7512,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8359,7 +7663,6 @@ msgstr "Tel: [_1]"
 msgid "Template"
 msgstr "Mallid"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8368,7 +7671,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr "Mall salvestatud!"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8421,7 +7723,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8433,7 +7735,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8486,24 +7788,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8526,14 +7825,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr "Neljapäev"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8577,7 +7872,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8607,19 +7901,10 @@ msgstr ""
 msgid "To"
 msgstr "Kuni"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8656,7 +7941,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8681,16 +7965,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8733,7 +8008,7 @@ msgstr ""
 msgid "Total"
 msgstr "Kokku"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8741,7 +8016,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr "Kokku makstud"
@@ -8762,7 +8036,6 @@ msgstr "Tehing"
 msgid "Transaction Approval"
 msgstr "Tehingu kinnitamine"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8778,14 +8051,12 @@ msgstr "Tehingu Kuupäev puudu!"
 msgid "Transaction Dates"
 msgstr "Tehingte Kuupäevad"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr "Kande tüüp"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8824,7 +8095,6 @@ msgstr "Tõlked"
 msgid "Translations saved!"
 msgstr "Tõlked salvestatud"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Proovibilanss"
@@ -8833,7 +8103,6 @@ msgstr "Proovibilanss"
 msgid "Trillion"
 msgstr "biljon"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr "Teisipäev"
@@ -8890,10 +8159,6 @@ msgstr "kakskümmend kaks"
 msgid "Two"
 msgstr "kaks"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8928,39 +8193,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8979,43 +8238,37 @@ msgstr "Ühik"
 msgid "Unit Price"
 msgstr "Ühiku hind"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr "Tundmatu"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9023,23 +8276,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9056,7 +8304,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9084,21 +8331,16 @@ msgstr ""
 msgid "Upload"
 msgstr "Lae ülesse"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr "Ülesse laetud"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9107,7 +8349,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9125,24 +8366,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr "Kasutatud"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9152,7 +8388,6 @@ msgstr "Kasutaja"
 msgid "User Name"
 msgstr "Kasutajanimi"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9173,7 +8408,6 @@ msgstr "Kasutajanimi"
 msgid "Users"
 msgstr "Kasutajad"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9199,8 +8433,6 @@ msgstr "Kehtiv kuni"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9210,11 +8442,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9230,7 +8458,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Tarnija"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr "Tarnija konto"
@@ -9244,7 +8471,6 @@ msgstr "Tarnija Ajalugu"
 msgid "Vendor Invoice"
 msgstr "Tarnija Kaubaarve"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr "Tarnija Kaubaarve/OR Number"
@@ -9254,9 +8480,6 @@ msgstr "Tarnija Kaubaarve/OR Number"
 msgid "Vendor Name"
 msgstr "Tarnija nimi"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9286,9 +8509,7 @@ msgstr "Tarnija otsing"
 msgid "Vendor missing!"
 msgstr "Tarnija puudu!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9296,8 +8517,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Tarnija pole failis!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9312,7 +8531,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr "Vautšerite nimekiri"
@@ -9325,7 +8543,6 @@ msgstr "Vautšer"
 msgid "Wages and Deductions"
 msgstr "Palgad ja kinnipidamised"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr "Palgad/kinnipidamised"
@@ -9348,7 +8565,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Kaubalaod"
@@ -9357,11 +8573,31 @@ msgstr "Kaubalaod"
 msgid "Warning!"
 msgstr "Tähelepanu!"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+#, fuzzy
+msgid "Warning: Your password will expire in [_1] days"
 msgstr "Tähelepanu! Sinu salasõna aegub [_1] jooksul"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+#, fuzzy
+msgid "Warning: Your password will expire in [_1] months"
+msgstr "Tähelepanu! Sinu salasõna aegub [_1] jooksul"
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+#, fuzzy
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr "Tähelepanu! Sinu salasõna aegub [_1] jooksul"
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+#, fuzzy
+msgid "Warning: Your password will expire in [_1] years"
+msgstr "Tähelepanu! Sinu salasõna aegub [_1] jooksul"
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+#, fuzzy
+msgid "Warning: Your password will expire today"
+msgstr "Tähelepanu! Sinu salasõna aegub [_1] jooksul"
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr "Kolmapäev"
@@ -9371,7 +8607,6 @@ msgstr "Kolmapäev"
 msgid "Week"
 msgstr "Nädal"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr "Nädal algab"
@@ -9388,13 +8623,11 @@ msgstr ""
 msgid "Weeks"
 msgstr "Nädalat"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Kaal"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Kaaluühik"
@@ -9411,7 +8644,6 @@ msgstr "Kuhu me saadaksime varundusfaili?"
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9429,11 +8661,11 @@ msgstr "Töökäsk"
 msgid "Work order"
 msgstr "Töökäsk"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr "Kas soovite migreerida andmebaasi?"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9476,16 +8708,10 @@ msgstr "Kasumi eraldamine tehtud"
 msgid "Years"
 msgstr "Aastat"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Jah"
-
-#: UI/users/preferences.html:52
-#, fuzzy
-msgid "Your password will expire in [_1]"
-msgstr "Tähelepanu! Sinu salasõna aegub [_1] jooksul"
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9512,7 +8738,7 @@ msgstr "Postiindeks:"
 msgid "Zip/Postal Code"
 msgstr "Postiindeks"
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9578,17 +8804,12 @@ msgstr "päeva"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr "kustuta"
 
@@ -9605,7 +8826,7 @@ msgstr ""
 msgid "done"
 msgstr "tehtud"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9633,8 +8854,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9643,22 +8862,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr "on vähem kui 0"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr "on tühi"
@@ -9683,7 +8898,6 @@ msgstr "tootmine"
 msgid "sent"
 msgstr "saadetud"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 #, fuzzy
 msgid "system type"
@@ -9709,8 +8923,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr "ootamatu viga!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""
@@ -9762,6 +8974,13 @@ msgstr ""
 
 #~ msgid "Version"
 #~ msgstr "Versioon"
+
+#~ msgid "Warning:  Your password will expire in [_1]"
+#~ msgstr "Tähelepanu! Sinu salasõna aegub [_1] jooksul"
+
+#, fuzzy
+#~ msgid "Your password will expire in [_1]"
+#~ msgstr "Tähelepanu! Sinu salasõna aegub [_1] jooksul"
 
 #~ msgid "cash"
 #~ msgstr "sularaha"

--- a/locale/po/fa_IR.po
+++ b/locale/po/fa_IR.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Persian (Iran) (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,27 +15,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr "فاکتور"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -48,12 +43,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -99,7 +90,6 @@ msgstr ""
 msgid "AP Aging"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -108,7 +98,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -123,7 +112,6 @@ msgstr ""
 msgid "AP Transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr ""
@@ -136,9 +124,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -156,7 +142,6 @@ msgstr ""
 msgid "AR Aging"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -165,7 +150,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -180,7 +164,6 @@ msgstr ""
 msgid "AR Transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr ""
@@ -193,9 +176,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -203,8 +184,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -214,16 +193,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -249,38 +223,20 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -301,23 +257,18 @@ msgstr ""
 msgid "Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -357,17 +308,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -379,7 +328,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -407,12 +356,10 @@ msgstr ""
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -435,11 +382,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -564,7 +511,6 @@ msgstr ""
 msgid "Add Service"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -630,7 +576,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -655,7 +600,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -665,12 +609,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -690,8 +633,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -743,7 +685,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -752,11 +693,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -790,14 +726,10 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -806,27 +738,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -844,14 +770,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -870,17 +796,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -889,13 +812,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -904,7 +820,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -913,14 +828,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -932,19 +845,16 @@ msgstr ""
 msgid "Apr"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -960,7 +870,6 @@ msgstr ""
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -978,19 +887,17 @@ msgstr ""
 msgid "Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1003,29 +910,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1041,7 +945,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1139,8 +1042,7 @@ msgstr ""
 msgid "Aug"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr ""
 
@@ -1152,7 +1054,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1166,7 +1067,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1179,7 +1079,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1213,8 +1112,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1229,7 +1126,6 @@ msgstr ""
 msgid "Balance Sheet"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1250,7 +1146,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1261,7 +1156,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 msgid "Base Currency"
 msgstr ""
@@ -1270,18 +1164,15 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1294,12 +1185,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1316,13 +1205,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1363,8 +1250,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1410,17 +1295,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1433,12 +1315,10 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1448,12 +1328,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1475,7 +1353,6 @@ msgstr ""
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1507,18 +1384,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1644,12 +1519,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr ""
 
@@ -1669,7 +1543,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1698,7 +1571,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1710,9 +1583,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr ""
 
@@ -1740,15 +1613,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 msgid "Closing Balance"
 msgstr ""
@@ -1761,8 +1632,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1777,22 +1646,18 @@ msgstr ""
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1804,39 +1669,31 @@ msgstr ""
 msgid "Company"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1857,7 +1714,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1875,7 +1732,6 @@ msgstr ""
 msgid "Contact"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1891,7 +1747,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1909,9 +1764,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1941,7 +1793,6 @@ msgstr ""
 msgid "Contra"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1949,10 +1800,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1983,20 +1830,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2012,26 +1855,20 @@ msgstr ""
 msgid "Could not transfer Inventory!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2043,7 +1880,6 @@ msgstr ""
 msgid "Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2056,7 +1892,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2064,11 +1900,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2096,8 +1932,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2105,17 +1939,14 @@ msgstr ""
 msgid "Credit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2140,29 +1971,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2185,18 +2006,14 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2206,11 +2023,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2225,7 +2038,6 @@ msgstr ""
 msgid "Customer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2244,9 +2056,6 @@ msgstr "فاکتور"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2266,9 +2075,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2280,7 +2087,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2304,12 +2111,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2342,28 +2148,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2410,19 +2204,14 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2444,7 +2233,6 @@ msgstr ""
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2508,8 +2296,6 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2525,10 +2311,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2538,17 +2322,14 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2558,7 +2339,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2571,47 +2351,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2624,21 +2395,14 @@ msgstr ""
 msgid "Defaults"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2656,7 +2420,6 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2669,7 +2432,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2683,37 +2445,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2735,20 +2493,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2759,46 +2514,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2909,12 +2625,10 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2927,7 +2641,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2936,7 +2649,6 @@ msgstr ""
 msgid "Discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2945,28 +2657,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2974,7 +2686,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2983,7 +2694,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -2991,12 +2702,10 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3009,12 +2718,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3023,19 +2730,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3051,10 +2755,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3073,7 +2773,7 @@ msgstr ""
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3099,7 +2799,7 @@ msgstr ""
 msgid "E-mailed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3129,7 +2829,7 @@ msgstr ""
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3273,8 +2973,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3288,7 +2986,6 @@ msgstr ""
 msgid "Employee"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3298,12 +2995,11 @@ msgstr ""
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 msgid "Employee wage screen"
 msgstr ""
@@ -3312,37 +3008,26 @@ msgstr ""
 msgid "Employees"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3366,7 +3051,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3391,12 +3075,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3406,7 +3088,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3414,7 +3096,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3439,7 +3120,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3451,14 +3132,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3472,16 +3150,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3489,7 +3166,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3502,8 +3179,6 @@ msgstr ""
 msgid "Exch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3518,7 +3193,6 @@ msgstr ""
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3527,7 +3201,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3545,13 +3218,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3629,8 +3299,7 @@ msgstr ""
 msgid "Feb"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr ""
 
@@ -3646,14 +3315,10 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3664,11 +3329,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3679,7 +3344,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3737,12 +3401,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr ""
@@ -3751,12 +3413,10 @@ msgstr ""
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3773,7 +3433,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3792,18 +3451,10 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3824,7 +3475,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3835,15 +3485,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3857,10 +3502,8 @@ msgstr ""
 msgid "GIFI"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3881,7 +3524,6 @@ msgstr ""
 msgid "GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3890,7 +3532,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3898,11 +3540,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3911,7 +3552,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3919,9 +3560,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3937,7 +3577,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3945,7 +3585,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3961,12 +3601,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3975,7 +3613,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4049,21 +3686,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4094,7 +3716,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4104,13 +3725,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4153,7 +3772,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4187,14 +3805,10 @@ msgstr ""
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4202,12 +3816,10 @@ msgstr ""
 msgid "Income"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4218,7 +3830,6 @@ msgstr ""
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4227,7 +3838,6 @@ msgstr ""
 msgid "Income statement"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4247,11 +3857,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4261,30 +3870,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4294,17 +3899,14 @@ msgstr ""
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4330,11 +3932,7 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4376,8 +3974,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4393,11 +3989,6 @@ msgstr ""
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4416,7 +4007,6 @@ msgstr ""
 msgid "Invoice Number missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4446,12 +4036,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4509,8 +4097,7 @@ msgstr ""
 msgid "Jan"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr ""
 
@@ -4539,8 +4126,7 @@ msgstr ""
 msgid "Jul"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr ""
 
@@ -4548,8 +4134,8 @@ msgstr ""
 msgid "Jun"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr ""
 
@@ -4562,10 +4148,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4587,15 +4169,12 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr ""
@@ -4616,7 +4195,6 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4627,7 +4205,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4649,40 +4226,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4694,9 +4270,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4718,9 +4292,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4734,8 +4306,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4752,7 +4322,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4789,7 +4358,6 @@ msgstr ""
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4815,7 +4383,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4833,7 +4400,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4854,7 +4420,7 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4882,45 +4448,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4942,40 +4501,34 @@ msgstr ""
 msgid "Mar"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr ""
@@ -4992,7 +4545,6 @@ msgstr ""
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr ""
@@ -5001,7 +4553,6 @@ msgstr ""
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5020,14 +4571,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5041,7 +4589,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5054,14 +4601,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5079,7 +4624,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5103,14 +4648,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5119,15 +4662,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5146,7 +4680,6 @@ msgstr ""
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5197,8 +4730,6 @@ msgstr ""
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5220,12 +4751,10 @@ msgstr ""
 msgid "Ninety"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5234,7 +4763,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5242,11 +4771,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5254,7 +4783,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5263,11 +4791,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5275,21 +4803,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5308,12 +4833,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5322,12 +4845,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5365,11 +4886,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5415,23 +4931,18 @@ msgstr ""
 msgid "Nov"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5462,7 +4973,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr ""
 
@@ -5483,13 +4994,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5498,8 +5007,7 @@ msgstr ""
 msgid "Oct"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr ""
 
@@ -5511,9 +5019,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5563,7 +5068,6 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 msgid "Opening Balance"
 msgstr ""
@@ -5584,9 +5088,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5632,7 +5133,6 @@ msgstr ""
 msgid "Order Entry"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5654,7 +5154,6 @@ msgstr ""
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5676,7 +5175,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5721,7 +5220,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5740,10 +5238,6 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5786,11 +5280,6 @@ msgstr ""
 msgid "Packing list"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5808,12 +5297,10 @@ msgstr ""
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5823,14 +5310,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5860,14 +5339,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5882,15 +5357,12 @@ msgstr ""
 msgid "Parts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5900,7 +5372,6 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5913,7 +5384,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5927,7 +5397,6 @@ msgstr ""
 msgid "Payables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5936,7 +5405,6 @@ msgstr ""
 msgid "Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5949,7 +5417,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5966,7 +5433,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 msgid "Payment batch"
 msgstr ""
@@ -6001,15 +5467,15 @@ msgstr ""
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6028,7 +5494,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6058,108 +5523,88 @@ msgstr ""
 msgid "Pick list"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6175,7 +5620,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6184,24 +5628,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6210,13 +5652,11 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6257,7 +5697,6 @@ msgstr ""
 msgid "Postscript"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6294,20 +5733,16 @@ msgstr ""
 msgid "Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6343,8 +5778,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6354,7 +5787,6 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6371,7 +5803,7 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr ""
 
@@ -6415,17 +5847,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6454,7 +5884,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6473,7 +5902,6 @@ msgstr ""
 msgid "Project Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6482,9 +5910,6 @@ msgstr ""
 msgid "Projects"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6494,7 +5919,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6512,22 +5936,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6541,14 +5959,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6579,7 +5993,6 @@ msgstr ""
 msgid "Qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6593,8 +6006,6 @@ msgstr ""
 msgid "Quarter"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6631,9 +6042,7 @@ msgstr ""
 msgid "Quotation deleted!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6654,25 +6063,20 @@ msgstr ""
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6684,7 +6088,6 @@ msgstr ""
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 msgid "Rate Type"
 msgstr ""
@@ -6705,13 +6108,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6729,7 +6128,6 @@ msgstr ""
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6743,8 +6141,7 @@ msgstr ""
 msgid "Receivables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr ""
 
@@ -6752,7 +6149,6 @@ msgstr ""
 msgid "Receive Merchandise"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6773,7 +6169,6 @@ msgstr ""
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6794,13 +6189,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6839,12 +6227,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6882,7 +6268,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6894,7 +6280,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6907,7 +6293,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6956,7 +6341,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -6976,13 +6361,10 @@ msgstr ""
 msgid "Required by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7012,7 +6394,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7021,7 +6402,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7038,7 +6418,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7088,11 +6467,11 @@ msgstr ""
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7118,7 +6497,6 @@ msgstr ""
 msgid "Sales Invoice"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7134,20 +6512,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr ""
@@ -7168,9 +6543,6 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7194,13 +6566,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7220,7 +6589,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7230,7 +6599,6 @@ msgstr ""
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7289,11 +6657,10 @@ msgstr ""
 msgid "Save as new"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7316,10 +6683,8 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr ""
 
@@ -7339,7 +6704,6 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7348,7 +6712,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7401,11 +6764,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7417,11 +6780,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7433,7 +6796,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7441,7 +6804,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7497,7 +6859,6 @@ msgstr ""
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7506,9 +6867,6 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7562,13 +6920,11 @@ msgstr ""
 msgid "Sep"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr ""
 
@@ -7589,9 +6945,6 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7620,7 +6973,6 @@ msgstr ""
 msgid "Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 msgid "Session Timeout (e.g. \"90 minutes\")"
 msgstr ""
@@ -7633,7 +6985,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7653,10 +7005,10 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr ""
 
@@ -7683,10 +7035,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7747,10 +7095,6 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7791,7 +7135,6 @@ msgstr ""
 msgid "Short"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7832,7 +7175,6 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7845,12 +7187,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7877,7 +7213,6 @@ msgstr ""
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7899,21 +7234,10 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7944,8 +7268,6 @@ msgstr ""
 msgid "Startdate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -7982,13 +7304,11 @@ msgstr ""
 msgid "Statement"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8018,7 +7338,7 @@ msgstr ""
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr ""
 
@@ -8043,7 +7363,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8086,7 +7405,6 @@ msgstr ""
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8119,12 +7437,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8136,9 +7448,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8157,8 +7466,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8169,17 +7476,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8322,7 +7626,6 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8331,7 +7634,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8384,7 +7686,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8396,7 +7698,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8447,24 +7749,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8487,14 +7786,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8538,7 +7833,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8568,19 +7862,10 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8617,7 +7902,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8642,16 +7926,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8694,7 +7969,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8702,7 +7977,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8723,7 +7997,6 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8739,14 +8012,12 @@ msgstr ""
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8785,7 +8056,6 @@ msgstr ""
 msgid "Translations saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr ""
@@ -8794,7 +8064,6 @@ msgstr ""
 msgid "Trillion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8851,10 +8120,6 @@ msgstr ""
 msgid "Two"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8889,39 +8154,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8940,43 +8199,37 @@ msgstr ""
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -8984,23 +8237,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9017,7 +8265,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9045,21 +8292,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9068,7 +8310,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9086,24 +8327,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9113,7 +8349,6 @@ msgstr ""
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9134,7 +8369,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9160,8 +8394,6 @@ msgstr ""
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9171,11 +8403,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9191,7 +8419,6 @@ msgstr ""
 msgid "Vendor"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9205,7 +8432,6 @@ msgstr ""
 msgid "Vendor Invoice"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9215,9 +8441,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9247,9 +8470,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9257,8 +8478,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 msgid "Vendor/Customer"
@@ -9272,7 +8491,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9285,7 +8503,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9308,7 +8525,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr ""
@@ -9317,11 +8533,26 @@ msgstr ""
 msgid "Warning!"
 msgstr ""
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9331,7 +8562,6 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9348,13 +8578,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr ""
@@ -9371,7 +8599,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9388,11 +8615,11 @@ msgstr ""
 msgid "Work order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9435,14 +8662,9 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
-msgstr ""
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
 msgstr ""
 
 #: t/data/04-complex_template.html:388
@@ -9470,7 +8692,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9534,17 +8756,12 @@ msgstr ""
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9561,7 +8778,7 @@ msgstr ""
 msgid "done"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9589,8 +8806,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9599,22 +8814,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9639,7 +8850,6 @@ msgstr ""
 msgid "sent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9664,8 +8874,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/fi.po
+++ b/locale/po/fi.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Finnish (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -17,27 +17,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -50,12 +45,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -101,7 +92,6 @@ msgstr "Ostoreskontra"
 msgid "AP Aging"
 msgstr "Vanhenevat ostolaskut"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -110,7 +100,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -125,7 +114,6 @@ msgstr "Ei maksetut ostolaskut"
 msgid "AP Transaction"
 msgstr "Ostotapahtuma"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Ostotapahtumat"
@@ -138,9 +126,7 @@ msgstr ""
 msgid "AP account"
 msgstr "Ostoreskontratili"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -159,7 +145,6 @@ msgstr "Myyntireskontra"
 msgid "AR Aging"
 msgstr "Vanhenevat myyntilaskut"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -168,7 +153,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -183,7 +167,6 @@ msgstr "Ei maksetut myyntilaskut"
 msgid "AR Transaction"
 msgstr "Myyntitapahtuma"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Myyntitapahtumat"
@@ -196,9 +179,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -207,8 +188,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Myyntitapahtuma"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -218,16 +197,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -253,38 +227,20 @@ msgstr ""
 msgid "Account"
 msgstr "Tili"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -305,23 +261,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Tilinumero"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -361,17 +312,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -383,7 +332,7 @@ msgstr "Varaukset"
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -411,12 +360,10 @@ msgstr "Avoin"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -439,11 +386,11 @@ msgstr "Lisää tilejä"
 msgid "Add Assembly"
 msgstr "Lisää tuote"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -568,7 +515,6 @@ msgstr "Lisää tilausvahvistus"
 msgid "Add Service"
 msgstr "Lisää palvelu"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -635,7 +581,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Päivitä"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -660,7 +605,6 @@ msgstr "Osoite:"
 msgid "Address: [_1]"
 msgstr "Osoite: [_1]"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -670,12 +614,11 @@ msgstr "Osoitteet"
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -695,8 +638,7 @@ msgstr ""
 msgid "Aged"
 msgstr "Vanhat"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -749,7 +691,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr "Allokoitu"
@@ -758,11 +699,6 @@ msgstr "Allokoitu"
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -796,14 +732,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Summa"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -812,27 +744,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Erääntyvä summa"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -850,14 +776,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -876,17 +802,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -895,13 +818,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -910,7 +826,6 @@ msgstr ""
 msgid "Approve"
 msgstr "Hyväksy"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -919,14 +834,12 @@ msgstr "Hyväksy"
 msgid "Approved"
 msgstr "Hyväksytty"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr "Hyväksyjä"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -938,19 +851,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Huh"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "Huhtikuu"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -966,7 +876,6 @@ msgstr "Haluatko poistaa tarjouksen numero"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -985,19 +894,17 @@ msgstr "Tuotteet viety varastoon"
 msgid "Asset"
 msgstr "Vastaavaa"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1010,29 +917,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1048,7 +952,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1146,8 +1049,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Elo"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Elokuu"
 
@@ -1159,7 +1061,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1173,7 +1074,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1186,7 +1086,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr "Keskikustannus"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1220,8 +1119,6 @@ msgstr "Varmuuskopioi tietokanta"
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1236,7 +1133,6 @@ msgstr "Tase"
 msgid "Balance Sheet"
 msgstr "Taselaskelma"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr "Tase"
@@ -1257,7 +1153,6 @@ msgstr "Pankkitili"
 msgid "Bank Account:"
 msgstr "Pankkitili:"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1268,7 +1163,6 @@ msgstr "Pankkitilit"
 msgid "Bar Code"
 msgstr "Viivakoodi"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1278,18 +1172,15 @@ msgstr "Valuutta"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1302,12 +1193,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1324,13 +1213,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1371,8 +1258,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1419,17 +1304,14 @@ msgstr ""
 msgid "Budget"
 msgstr "Budjetti"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1442,12 +1324,10 @@ msgstr "Budjetit"
 msgid "Business"
 msgstr "Yritys"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Y-numero"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1457,12 +1337,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1484,7 +1362,6 @@ msgstr "Yritys tallennettu"
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1516,18 +1393,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr "Peruuta"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr "Peruuta?"
 
@@ -1653,12 +1528,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr "Laskutettavissa"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Tilikartta"
 
@@ -1678,7 +1552,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "Sekkivarasto"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1707,7 +1580,7 @@ msgstr "Kaupunki:"
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1719,9 +1592,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "Tyhjennetty"
 
@@ -1749,15 +1622,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Suljettu"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1771,8 +1642,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1787,22 +1656,18 @@ msgstr "Koodi puuttuu!"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1814,39 +1679,31 @@ msgstr ""
 msgid "Company"
 msgstr "Yritys"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr "Yrityksen osoite"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr "Yrityksen fax"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr "Yrityksen tiedot"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr "Kaupparekisterinumero"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Yrityksen nimi"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr "Yrityksen puhelinnumero"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr "Alv-numero"
@@ -1867,7 +1724,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Vahvista!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1885,7 +1742,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Yhteyshenkilö"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1901,7 +1757,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1919,9 +1774,6 @@ msgstr "Kontaktit"
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1951,7 +1803,6 @@ msgstr ""
 msgid "Contra"
 msgstr "Kontra"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1959,10 +1810,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1993,20 +1840,16 @@ msgstr "Kopioi uudeksi"
 msgid "Copy to New Name"
 msgstr "Kopioi uudelle nimelle"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Kustannus"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2022,26 +1865,20 @@ msgstr "Tallentaminen ei onnistu"
 msgid "Could not transfer Inventory!"
 msgstr "Varaston siirto ei onnistu"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2053,7 +1890,6 @@ msgstr ""
 msgid "Country"
 msgstr "Maa"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr "Maan nimi"
@@ -2066,7 +1902,7 @@ msgstr "Maa:"
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2074,11 +1910,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr "Luo tietokanta?"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2106,8 +1942,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2115,17 +1949,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Kredit"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2150,29 +1981,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Valuutta"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2195,18 +2016,14 @@ msgstr "Valuutta"
 msgid "Currency"
 msgstr "Valuutta"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Nykyinen"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2216,11 +2033,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2235,7 +2048,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Asiakas"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2254,9 +2066,6 @@ msgstr "Asiakas ei järjestelmässä!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2276,9 +2085,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "Asiakas puuttuu!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2290,7 +2097,7 @@ msgstr "Asiakas ei järjestelmässä!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2314,12 +2121,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2352,28 +2158,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2420,19 +2214,14 @@ msgstr ""
 msgid "Date"
 msgstr "Päiväys"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2454,7 +2243,6 @@ msgstr "Vastaanotettu"
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2518,8 +2306,6 @@ msgstr "Päivä(t)"
 msgid "Days"
 msgstr "Päivät"
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2535,10 +2321,8 @@ msgstr "Lasku"
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2548,17 +2332,14 @@ msgstr ""
 msgid "Dec"
 msgstr "Jou"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Joulukuu"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2568,7 +2349,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2581,47 +2361,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2634,21 +2405,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "Oletukset"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2666,7 +2430,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Poista"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2679,7 +2442,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr "Poista aikataulu"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2693,37 +2455,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Toimituspäivä"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2745,20 +2503,17 @@ msgstr "Poisto"
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2769,46 +2524,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2919,12 +2635,10 @@ msgstr "Yksityiskohdat"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2937,7 +2651,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2946,7 +2659,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Alennus"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2955,28 +2667,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2984,7 +2696,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2993,7 +2704,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -3001,12 +2712,10 @@ msgstr ""
 msgid "Done"
 msgstr "Suoritettu"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3019,12 +2728,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3033,19 +2740,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Piirros"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3061,10 +2765,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3083,7 +2783,7 @@ msgstr "Eräpäivä puuttuu!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3109,7 +2809,7 @@ msgstr "Sähkpostiviesti"
 msgid "E-mailed"
 msgstr "Sähköpostitettu"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3139,7 +2839,7 @@ msgstr "Muokkaa myyntitapahtumaa"
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3283,8 +2983,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3298,7 +2996,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Työntekijä"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3308,12 +3005,11 @@ msgstr "Työntekijän numero"
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3323,37 +3019,26 @@ msgstr "Työntekijän numero"
 msgid "Employees"
 msgstr "Työntekijät"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3377,7 +3062,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3402,12 +3086,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3417,7 +3099,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3425,7 +3107,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3451,7 +3132,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Maan nimi"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3463,14 +3144,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Oma pääoma"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3484,16 +3162,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3501,7 +3178,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3514,8 +3191,6 @@ msgstr "Jokainen"
 msgid "Exch"
 msgstr "Vaihtokurssi"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3530,7 +3205,6 @@ msgstr "Vaihtokurssi"
 msgid "Exchange rate for payment missing!"
 msgstr "Maksun vaihtokurssi puuttuu"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3539,7 +3213,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "Vaihtokurssi puuttuu"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3557,13 +3230,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Meno/Vastaavaa"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr "Menot"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3641,8 +3311,7 @@ msgstr "Faksi: [_1]"
 msgid "Feb"
 msgstr "Hel"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Helmikuu"
 
@@ -3658,14 +3327,10 @@ msgstr ""
 msgid "File"
 msgstr "Tiedosto"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3676,11 +3341,11 @@ msgstr "Tiedoston nimi"
 msgid "File Type"
 msgstr "Tiedoston tyyppi"
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr "Tiedoston nimi"
 
@@ -3691,7 +3356,6 @@ msgstr "Tiedoston nimi"
 msgid "File type"
 msgstr "Tiedoston tyyppi"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr "Tiedostot"
@@ -3749,12 +3413,10 @@ msgstr "Käyttöomaisuus"
 msgid "For"
 msgstr " "
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Vaihtokurssivoitto"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Vaihtokurssitappio"
@@ -3763,12 +3425,10 @@ msgstr "Vaihtokurssitappio"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3785,7 +3445,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3804,18 +3463,10 @@ msgstr ""
 msgid "From"
 msgstr "Alkaen"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3836,7 +3487,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr "Varastosta"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3847,15 +3497,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr "Täydet oikeudet"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3869,10 +3514,8 @@ msgstr "Täydet oikeudet"
 msgid "GIFI"
 msgstr "GIFI"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3893,7 +3536,6 @@ msgstr "GIFI tallennettu!"
 msgid "GL"
 msgstr "Pääkirja"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr "Pääkirjan viitenumero"
@@ -3902,7 +3544,7 @@ msgstr "Pääkirjan viitenumero"
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3910,11 +3552,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3923,7 +3564,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3931,9 +3572,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr "Luo"
 
@@ -3949,7 +3589,7 @@ msgstr "Luo tilaukset"
 msgid "Generate Purchase Orders"
 msgstr "Luo ostotilaukset"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3957,7 +3597,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr "Luo myyntitilaukset"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3973,12 +3613,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3987,7 +3625,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4061,21 +3698,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4106,7 +3728,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4116,13 +3737,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Kuva"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4165,7 +3784,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4199,14 +3817,10 @@ msgstr "Sisällytä pudotusvalikoihin"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4214,12 +3828,10 @@ msgstr ""
 msgid "Income"
 msgstr "Tulo"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4230,7 +3842,6 @@ msgstr "Tulolaskelma"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4240,7 +3851,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Tulolaskelma"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4260,11 +3870,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4274,30 +3883,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "Sisäiset viestit"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4307,17 +3912,14 @@ msgstr "Varasto"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4343,11 +3945,7 @@ msgstr "Varasto tallennettu!"
 msgid "Inventory transferred!"
 msgstr "Varasto siirretty!"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4389,8 +3987,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4406,11 +4002,6 @@ msgstr "Laskun päiväys puuttuu!"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4429,7 +4020,6 @@ msgstr "Laskun numero"
 msgid "Invoice Number missing!"
 msgstr "Laskun numero puuttuu!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4459,12 +4049,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4522,8 +4110,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Tam"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Tammikuu"
 
@@ -4552,8 +4139,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Hei"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Heinäkuu"
 
@@ -4561,8 +4147,8 @@ msgstr "Heinäkuu"
 msgid "Jun"
 msgstr "Kes"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Kesäkuu"
 
@@ -4575,10 +4161,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "LaTeX mallit"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4600,15 +4182,12 @@ msgstr "Työ/overhead"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Kieli"
@@ -4629,7 +4208,6 @@ msgstr "Kielet ei ole määritelty"
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4640,7 +4218,6 @@ msgstr "Viimeksi toteutunut kustannus"
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4662,40 +4239,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr "Ennakkoaika"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4707,9 +4283,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4731,9 +4305,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4747,8 +4319,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4765,7 +4335,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4802,7 +4371,6 @@ msgstr "Listaa kielet"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4828,7 +4396,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4846,7 +4413,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4867,7 +4433,7 @@ msgstr ""
 msgid "Login"
 msgstr "Nimi"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4895,45 +4461,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Valmistaja"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4955,40 +4514,34 @@ msgstr ""
 msgid "Mar"
 msgstr "Maa"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Maaliskuu"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Hintalisäys"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "Tou"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Muistio"
@@ -5005,7 +4558,6 @@ msgstr "Viesti"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Tapa"
@@ -5014,7 +4566,6 @@ msgstr "Tapa"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5033,14 +4584,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5054,7 +4602,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5067,14 +4614,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Tuotenimi"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5092,7 +4637,7 @@ msgstr "Kuukausi(det)"
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5116,14 +4661,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5132,15 +4675,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5159,7 +4693,6 @@ msgstr "Nimi"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5210,8 +4743,6 @@ msgstr "Seuraava pvm"
 msgid "Next Number"
 msgstr "Seuraava numero"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5233,12 +4764,10 @@ msgstr ""
 msgid "Ninety"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Ei"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5247,7 +4776,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5255,11 +4784,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5267,7 +4796,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5276,11 +4804,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5288,21 +4816,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr "Projekteja ei auki"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5321,12 +4846,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5335,12 +4858,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr "Ei seurattavia tuotteita"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5378,11 +4899,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5428,23 +4944,18 @@ msgstr "Ei siirrettävää!"
 msgid "Nov"
 msgstr "Mar"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "Marraskuu"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5475,7 +4986,7 @@ msgstr ""
 msgid "Number"
 msgstr "Numero"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Numeron muoto"
 
@@ -5496,13 +5007,11 @@ msgstr "Oh"
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Vanhentunut"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5511,8 +5020,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Lok"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Lokakuu"
 
@@ -5524,9 +5032,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5576,7 +5081,6 @@ msgstr ""
 msgid "Open"
 msgstr "Avoinna"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5598,9 +5102,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5646,7 +5147,6 @@ msgstr "Tilauspäivämäärä puuttuu!"
 msgid "Order Entry"
 msgstr "Tilauksen kirjaus"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5668,7 +5168,6 @@ msgstr "Tilaus poistettu!"
 msgid "Order generation failed!"
 msgstr "Tilausten luonti ei onnistunut"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5690,7 +5189,7 @@ msgstr "Tilaukset luotu"
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5736,7 +5235,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5755,10 +5253,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5802,11 +5296,6 @@ msgstr "Pakkauslistan numero puuttuu!"
 msgid "Packing list"
 msgstr "Pakkauslista"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5824,12 +5313,10 @@ msgstr "Maksettu"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Tarvike"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5839,14 +5326,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5876,14 +5355,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5899,15 +5374,12 @@ msgstr "Tarvikenumero"
 msgid "Parts"
 msgstr "Tarvike"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5917,7 +5389,6 @@ msgstr ""
 msgid "Password"
 msgstr "Salasana"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5930,7 +5401,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5944,7 +5414,6 @@ msgstr ""
 msgid "Payables"
 msgstr "Erääntyvät"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5953,7 +5422,6 @@ msgstr "Erääntyvät"
 msgid "Payment"
 msgstr "Maksu"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5966,7 +5434,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5983,7 +5450,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6019,15 +5485,15 @@ msgstr "Maksut"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6046,7 +5512,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6077,108 +5542,88 @@ msgstr "Keräyslista"
 msgid "Pick list"
 msgstr "Keräyslista"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6194,7 +5639,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6203,24 +5647,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6229,13 +5671,11 @@ msgstr ""
 msgid "Post"
 msgstr "Kirjaa"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6276,7 +5716,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Postscript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6314,20 +5753,16 @@ msgstr ""
 msgid "Price"
 msgstr "Hinta"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6363,8 +5798,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6374,7 +5807,6 @@ msgstr ""
 msgid "Print"
 msgstr "Tulosta"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6391,7 +5823,7 @@ msgstr "Tulosta ja tallenna uutena"
 msgid "Printed"
 msgstr "Tulostettu"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Tulostin"
 
@@ -6435,17 +5867,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6474,7 +5904,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6493,7 +5922,6 @@ msgstr "Projektikuvauskäännökset"
 msgid "Project Number"
 msgstr "Projektin numero"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6502,9 +5930,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Projektit"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6514,7 +5939,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6532,22 +5956,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Ostotilaus"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "Ostotilausnumero"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Ostotilaukset"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6562,14 +5980,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Ostotilaus"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6600,7 +6014,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Määrä"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6614,8 +6027,6 @@ msgstr "Määrä ylittää varaston"
 msgid "Quarter"
 msgstr "Neljännes"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6652,9 +6063,7 @@ msgstr "Tarjousnumero puuttuu"
 msgid "Quotation deleted!"
 msgstr "Tarjous poistettu"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6675,25 +6084,20 @@ msgstr "Tarjouspyyntö"
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "Tarjouspyynnön numero"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "Tarjouspyynnöt"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "Uudelleentilauspiste"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6705,7 +6109,6 @@ msgstr "Kurssi"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6728,13 +6131,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6752,7 +6151,6 @@ msgstr "Kuitti"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6766,8 +6164,7 @@ msgstr "Kuitit"
 msgid "Receivables"
 msgstr "Saatavat"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Vastaanota"
 
@@ -6775,7 +6172,6 @@ msgstr "Vastaanota"
 msgid "Receive Merchandise"
 msgstr "Vastaanota tuotteet"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6796,7 +6192,6 @@ msgstr "Sovitus"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6817,13 +6212,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Toistuvat siirrit"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6862,12 +6250,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6905,7 +6291,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6917,7 +6303,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6930,7 +6316,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6980,7 +6365,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -7000,13 +6385,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Toimituspäivä"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7036,7 +6418,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7045,7 +6426,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7062,7 +6442,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7112,11 +6491,11 @@ msgstr "Varastoyksikkö"
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7142,7 +6521,6 @@ msgstr "Myynnit"
 msgid "Sales Invoice"
 msgstr "Myyntilasku"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Myyntilaskun/viennin numero"
@@ -7158,20 +6536,17 @@ msgstr "Myyntilaskun/viennin numero"
 msgid "Sales Order"
 msgstr "Tilausvahvistus"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "Tilausvahvistuksen numero"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Tilausvahvistukset"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "Myynnntitarjousnumero"
@@ -7194,9 +6569,6 @@ msgstr "Myynnntitarjousnumero"
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7220,13 +6592,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7246,7 +6615,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7256,7 +6625,6 @@ msgstr "Tallenna"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7315,11 +6683,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "Tallenna uutena"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7342,10 +6709,8 @@ msgstr "Aikataulu"
 msgid "Scheduled"
 msgstr "Aikataulutettu"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Näyttö"
 
@@ -7365,7 +6730,6 @@ msgstr "Näyttö"
 msgid "Search"
 msgstr "Etsi"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7374,7 +6738,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7427,11 +6790,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7443,11 +6806,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7459,7 +6822,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7467,7 +6830,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7523,7 +6885,6 @@ msgstr "Valitse tekstitiedosto, postscript tai PDF!"
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7532,9 +6893,6 @@ msgstr ""
 msgid "Sell"
 msgstr "Myynti"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7588,13 +6946,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Syy"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "Syyskuu"
 
@@ -7615,9 +6971,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "Sarjan:o"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7647,7 +7000,6 @@ msgstr "Palvelukoodi"
 msgid "Services"
 msgstr "Palvelu"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 #, fuzzy
 msgid "Session Timeout (e.g. \"90 minutes\")"
@@ -7661,7 +7013,7 @@ msgstr ""
 msgid "Setting"
 msgstr "Asetus"
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr "Asetukset"
 
@@ -7681,10 +7033,10 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Toimita"
 
@@ -7711,10 +7063,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7775,10 +7123,6 @@ msgstr "Toimituspvm puuttuu"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7820,7 +7164,6 @@ msgstr "Toimituspvm"
 msgid "Short"
 msgstr "Lyhytaikaiset"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7861,7 +7204,6 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7874,12 +7216,6 @@ msgstr ""
 msgid "Sort by"
 msgstr "Järjestä mukaan"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7906,7 +7242,6 @@ msgstr "Lähde"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7928,21 +7263,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Vakio"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "Teollisuusluokitteet"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7973,8 +7297,6 @@ msgstr ""
 msgid "Startdate"
 msgstr "Aloituspäivä"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8011,13 +7333,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Tiliote"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Tiliotteen tase"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8048,7 +7368,7 @@ msgstr "Varastoi tuote"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Tyylitiedosto"
 
@@ -8073,7 +7393,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8116,7 +7435,6 @@ msgstr "Kooste"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8149,12 +7467,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8166,9 +7478,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8187,8 +7496,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8199,17 +7506,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8353,7 +7657,6 @@ msgstr ""
 msgid "Template"
 msgstr "HTML-mallit"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8362,7 +7665,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8415,7 +7717,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8427,7 +7729,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8478,24 +7780,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8518,14 +7817,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8569,7 +7864,6 @@ msgstr "Aikakortti"
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr "Aikakortit"
@@ -8599,19 +7893,10 @@ msgstr ""
 msgid "To"
 msgstr "Hetkeen"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8648,7 +7933,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8673,16 +7957,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8725,7 +8000,7 @@ msgstr ""
 msgid "Total"
 msgstr "Yhteensä"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8733,7 +8008,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8754,7 +8028,6 @@ msgstr "Vienti"
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8770,14 +8043,12 @@ msgstr "Viennin päiväys puuttuu!"
 msgid "Transaction Dates"
 msgstr "Vientipvm"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8816,7 +8087,6 @@ msgstr "Käännökset"
 msgid "Translations saved!"
 msgstr "Käännökset tallennettu"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Saldolista"
@@ -8825,7 +8095,6 @@ msgstr "Saldolista"
 msgid "Trillion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8882,10 +8151,6 @@ msgstr ""
 msgid "Two"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8920,39 +8185,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8971,43 +8230,37 @@ msgstr "Yksikkö"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9015,23 +8268,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9048,7 +8296,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9076,21 +8323,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9099,7 +8341,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9117,24 +8358,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9144,7 +8380,6 @@ msgstr "Käyttäjä"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9165,7 +8400,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9191,8 +8425,6 @@ msgstr "Voimassa asti"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9202,11 +8434,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9222,7 +8450,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Toimittaja"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9236,7 +8463,6 @@ msgstr "Toimittajahistoria"
 msgid "Vendor Invoice"
 msgstr "Ostolasku"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr "Ostolasku/Ostoreskontra vientinumero"
@@ -9246,9 +8472,6 @@ msgstr "Ostolasku/Ostoreskontra vientinumero"
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9278,9 +8501,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "Toimittaja puuttuu!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9288,8 +8509,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Toimittajaa ei järjestelmässä!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9304,7 +8523,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9317,7 +8535,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9340,7 +8557,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Varastot"
@@ -9349,11 +8565,26 @@ msgstr "Varastot"
 msgid "Warning!"
 msgstr "Varoitus!"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9363,7 +8594,6 @@ msgstr ""
 msgid "Week"
 msgstr "Viikko"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9380,13 +8610,11 @@ msgstr ""
 msgid "Weeks"
 msgstr "Viikot"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Paino"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Painoyksikkö"
@@ -9403,7 +8631,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9421,11 +8648,11 @@ msgstr "Työmääräin"
 msgid "Work order"
 msgstr "Työmääräin"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9468,15 +8695,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Kyllä"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9503,7 +8725,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9567,17 +8789,12 @@ msgstr "päivää"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9594,7 +8811,7 @@ msgstr ""
 msgid "done"
 msgstr "valmis"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9622,8 +8839,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9632,22 +8847,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9672,7 +8883,6 @@ msgstr ""
 msgid "sent"
 msgstr "lähetetty"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 #, fuzzy
 msgid "system type"
@@ -9698,8 +8908,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr "odottamaton virhe"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/fr.po
+++ b/locale/po/fr.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: French (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -15,27 +15,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -48,12 +43,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -99,7 +90,6 @@ msgstr "Dépenses"
 msgid "AP Aging"
 msgstr "Dépenses exigibles"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -108,7 +98,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -123,7 +112,6 @@ msgstr "Dépenses en retard"
 msgid "AP Transaction"
 msgstr "Écriture dépenses"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Mouvements - Dépenses"
@@ -136,9 +124,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -157,7 +143,6 @@ msgstr "Recettes"
 msgid "AR Aging"
 msgstr "Recettes exigibles"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -166,7 +151,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -181,7 +165,6 @@ msgstr "Recettes en retard"
 msgid "AR Transaction"
 msgstr "Écriture recettes"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Mouvements - Recettes"
@@ -194,9 +177,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -205,8 +186,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Écriture recettes"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -216,16 +195,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -251,38 +225,20 @@ msgstr ""
 msgid "Account"
 msgstr "Compte"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -303,23 +259,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Numéro de compte"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -359,17 +310,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -381,7 +330,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -409,12 +358,10 @@ msgstr "Actif"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -437,11 +384,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr "Ajouter produit"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -566,7 +513,6 @@ msgstr "Établir commande de vente"
 msgid "Add Service"
 msgstr "Ajouter prestation"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -633,7 +579,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Mettre à jour"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -658,7 +603,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -668,12 +612,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -693,8 +636,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -747,7 +689,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -756,11 +697,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -794,14 +730,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Montant"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -810,27 +742,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Montant dû"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -848,14 +774,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -874,17 +800,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -893,13 +816,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -908,7 +824,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -917,14 +832,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -936,19 +849,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Avril"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "Avril"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -964,7 +874,6 @@ msgstr "Êtes vous sûr de vouloir supprimer le devis n°"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -983,19 +892,17 @@ msgstr "Renvoyer produits vers stock!"
 msgid "Asset"
 msgstr "Actif"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1008,29 +915,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1046,7 +950,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1144,8 +1047,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Août"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Août"
 
@@ -1157,7 +1059,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1171,7 +1072,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1184,7 +1084,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1218,8 +1117,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1234,7 +1131,6 @@ msgstr "Solde"
 msgid "Balance Sheet"
 msgstr "Bilan"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1255,7 +1151,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1266,7 +1161,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1276,18 +1170,15 @@ msgstr "Devise"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1300,12 +1191,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1322,13 +1211,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1369,8 +1256,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1417,17 +1302,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1440,12 +1322,10 @@ msgstr ""
 msgid "Business"
 msgstr "Type d'affaire"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Numéro d'enregistrement société"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1455,12 +1335,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1482,7 +1360,6 @@ msgstr "Type d'affaire enregistré!"
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1514,18 +1391,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1651,12 +1526,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Plan Comptable"
 
@@ -1676,7 +1550,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "Listing chèques"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1705,7 +1578,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1717,9 +1590,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "Lettré"
 
@@ -1747,15 +1620,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Clôturé"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1769,8 +1640,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1785,22 +1654,18 @@ msgstr "Code manquant!"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1812,39 +1677,31 @@ msgstr ""
 msgid "Company"
 msgstr "Société"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Nom de société"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1865,7 +1722,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Confirmer!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1883,7 +1740,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Contact"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1899,7 +1755,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1917,9 +1772,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1949,7 +1801,6 @@ msgstr ""
 msgid "Contra"
 msgstr "Contrepartie"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1957,10 +1808,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1991,20 +1838,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Coût"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2020,26 +1863,20 @@ msgstr "Enregistrement impossible!"
 msgid "Could not transfer Inventory!"
 msgstr "Impossible de transférer l'inventaire!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2051,7 +1888,6 @@ msgstr ""
 msgid "Country"
 msgstr "Pays"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2064,7 +1900,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2072,11 +1908,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2104,8 +1940,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2113,17 +1947,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Crédit"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2148,29 +1979,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Dev."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2193,18 +2014,14 @@ msgstr "Dev."
 msgid "Currency"
 msgstr "Devise"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "En cours"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2214,11 +2031,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2233,7 +2046,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Client"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2252,9 +2064,6 @@ msgstr "Client absent du fichier!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2274,9 +2083,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "Client manquant!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2288,7 +2095,7 @@ msgstr "Client absent du fichier!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2312,12 +2119,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2350,28 +2156,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2418,19 +2212,14 @@ msgstr ""
 msgid "Date"
 msgstr "Date"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2452,7 +2241,6 @@ msgstr "Date de réception"
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2516,8 +2304,6 @@ msgstr ""
 msgid "Days"
 msgstr "Jours"
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2533,10 +2319,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2546,17 +2330,14 @@ msgstr ""
 msgid "Dec"
 msgstr "Déc."
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Décembre"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2566,7 +2347,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2579,47 +2359,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2632,21 +2403,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "Valeurs par défaut"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2664,7 +2428,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Supprimer"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2677,7 +2440,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr "Effacer transaction planifiée"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2691,37 +2453,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Date de livraison"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2743,20 +2501,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2767,46 +2522,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2917,12 +2633,10 @@ msgstr "Détail"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2935,7 +2649,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2944,7 +2657,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Remise"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2953,28 +2665,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2982,7 +2694,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2991,7 +2702,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -2999,12 +2710,10 @@ msgstr ""
 msgid "Done"
 msgstr "Fait!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3017,12 +2726,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3031,19 +2738,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Dessin"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3059,10 +2763,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3081,7 +2781,7 @@ msgstr "Date d'échéance manquante!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3107,7 +2807,7 @@ msgstr "Message e-mail"
 msgid "E-mailed"
 msgstr "E-mail envoyé"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3137,7 +2837,7 @@ msgstr "Modifier une recette"
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3281,8 +2981,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3296,7 +2994,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Employé"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3306,12 +3003,11 @@ msgstr "Numéro d'employé"
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3321,37 +3017,26 @@ msgstr "Numéro d'employé"
 msgid "Employees"
 msgstr "Employés"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3375,7 +3060,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3400,12 +3084,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3415,7 +3097,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3423,7 +3105,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3449,7 +3130,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Nom de société"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3461,14 +3142,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Capital"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3482,16 +3160,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3499,7 +3176,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3512,8 +3189,6 @@ msgstr "Chaque"
 msgid "Exch"
 msgstr "Change"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3528,7 +3203,6 @@ msgstr "Taux de change"
 msgid "Exchange rate for payment missing!"
 msgstr "Taux de change manquant pour le paiement!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3537,7 +3211,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "Taux de change manquant!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3555,13 +3228,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Dépenses/actif"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3639,8 +3309,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Fév."
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Février"
 
@@ -3656,14 +3325,10 @@ msgstr "Cinquante"
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3674,11 +3339,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3689,7 +3354,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3747,12 +3411,10 @@ msgstr ""
 msgid "For"
 msgstr "Pour"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Produit conversion devises"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Perte conversion devises"
@@ -3761,12 +3423,10 @@ msgstr "Perte conversion devises"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3783,7 +3443,6 @@ msgstr "Quatre"
 msgid "Fourteen"
 msgstr "Quatorze"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3802,18 +3461,10 @@ msgstr ""
 msgid "From"
 msgstr "De"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3834,7 +3485,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3845,15 +3495,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3867,10 +3512,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "Code d'identification comptable ou fiscale"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3891,7 +3534,6 @@ msgstr "Code d'identification comptable ou fiscale enregistré!"
 msgid "GL"
 msgstr "Grand-livre"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3900,7 +3542,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3908,11 +3550,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3921,7 +3562,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3929,9 +3570,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3947,7 +3587,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3955,7 +3595,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3971,12 +3611,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3985,7 +3623,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4059,21 +3696,6 @@ msgstr ""
 msgid "Hundred"
 msgstr "Cent"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4104,7 +3726,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4114,13 +3735,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Image"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4163,7 +3782,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4197,14 +3815,10 @@ msgstr "Inclure dans les menus déroulants"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4212,12 +3826,10 @@ msgstr ""
 msgid "Income"
 msgstr "Recettes"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4228,7 +3840,6 @@ msgstr "Compte de résultat"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4238,7 +3849,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Compte de résultat"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4258,11 +3868,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4272,30 +3881,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "Notes internes"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4305,17 +3910,14 @@ msgstr "Inventaire"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4342,11 +3944,7 @@ msgstr "Inventaire enregistré!"
 msgid "Inventory transferred!"
 msgstr "Inventaire transféré!"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4388,8 +3986,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4405,11 +4001,6 @@ msgstr "Date de facture manquante!"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4428,7 +4019,6 @@ msgstr "Numéro de facture"
 msgid "Invoice Number missing!"
 msgstr "Numéro de facture manquant!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4458,12 +4048,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4521,8 +4109,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Jan."
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Janvier"
 
@@ -4551,8 +4138,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Juill."
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Juillet"
 
@@ -4560,8 +4146,8 @@ msgstr "Juillet"
 msgid "Jun"
 msgstr "Juin"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Juin"
 
@@ -4574,10 +4160,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "Squelettes LaTeX"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4599,15 +4181,12 @@ msgstr "Coût de production"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Langue"
@@ -4628,7 +4207,6 @@ msgstr "Langues non définis!"
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4639,7 +4217,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4661,40 +4238,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr "Délai"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4706,9 +4282,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4730,9 +4304,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4746,8 +4318,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4764,7 +4334,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4801,7 +4370,6 @@ msgstr "Liste des langues"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4827,7 +4395,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4845,7 +4412,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4866,7 +4432,7 @@ msgstr ""
 msgid "Login"
 msgstr "Login"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4894,45 +4460,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Marque"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4954,40 +4513,34 @@ msgstr ""
 msgid "Mar"
 msgstr "Mars"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Mars"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Majoration"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "Mai"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Mémo"
@@ -5004,7 +4557,6 @@ msgstr "Message"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Méthode"
@@ -5013,7 +4565,6 @@ msgstr "Méthode"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5032,14 +4583,11 @@ msgstr ""
 msgid "Million"
 msgstr "Million"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5053,7 +4601,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5066,14 +4613,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Modèle"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5091,7 +4636,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5115,14 +4660,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5131,15 +4674,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5158,7 +4692,6 @@ msgstr "Nom"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5209,8 +4742,6 @@ msgstr "Prochaine date"
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5232,12 +4763,10 @@ msgstr "Dix-neuf"
 msgid "Ninety"
 msgstr "Quatre-vignt-dix"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Non"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5246,7 +4775,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5254,11 +4783,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5266,7 +4795,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5275,11 +4803,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5287,21 +4815,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5320,12 +4845,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5334,12 +4857,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5377,11 +4898,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5427,23 +4943,18 @@ msgstr "Rien à transférer!"
 msgid "Nov"
 msgstr "Nov."
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "Novembre"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5474,7 +4985,7 @@ msgstr ""
 msgid "Number"
 msgstr "Numéro"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Format des numéros"
 
@@ -5495,13 +5006,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Obsolète"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5510,8 +5019,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Oct."
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Octobre"
 
@@ -5523,9 +5031,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5575,7 +5080,6 @@ msgstr ""
 msgid "Open"
 msgstr "Ouvert"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5597,9 +5101,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5645,7 +5146,6 @@ msgstr "Date de commande manquante!"
 msgid "Order Entry"
 msgstr "Commandes"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5667,7 +5167,6 @@ msgstr "Commande supprimée!"
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5689,7 +5188,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5735,7 +5234,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5754,10 +5252,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5801,11 +5295,6 @@ msgstr "Le numéro de la liste d'envoi est manquant!"
 msgid "Packing list"
 msgstr "Liste d'envoi"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5823,12 +5312,10 @@ msgstr "Total payé"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Marchandise"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5838,14 +5325,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5875,14 +5354,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5898,15 +5373,12 @@ msgstr "Numéro de marchandise"
 msgid "Parts"
 msgstr "Marchandise"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5916,7 +5388,6 @@ msgstr ""
 msgid "Password"
 msgstr "Mot de passe"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5929,7 +5400,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5943,7 +5413,6 @@ msgstr ""
 msgid "Payables"
 msgstr "À payer"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5952,7 +5421,6 @@ msgstr "À payer"
 msgid "Payment"
 msgstr "Paiement"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5965,7 +5433,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5982,7 +5449,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6018,15 +5484,15 @@ msgstr "Paiements"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6045,7 +5511,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6076,108 +5541,88 @@ msgstr "Liste de sélection"
 msgid "Pick list"
 msgstr "Liste de sélection"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6193,7 +5638,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6202,24 +5646,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6228,13 +5670,11 @@ msgstr ""
 msgid "Post"
 msgstr "Enregistrer"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6275,7 +5715,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Postcript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6313,20 +5752,16 @@ msgstr ""
 msgid "Price"
 msgstr "Prix"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6362,8 +5797,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6373,7 +5806,6 @@ msgstr ""
 msgid "Print"
 msgstr "Imprimer"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6390,7 +5822,7 @@ msgstr ""
 msgid "Printed"
 msgstr "Imprimé"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Imprimante"
 
@@ -6434,17 +5866,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6473,7 +5903,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6492,7 +5921,6 @@ msgstr "Traductions description de projet"
 msgid "Project Number"
 msgstr "Numéro de projet"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6501,9 +5929,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Projets"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6513,7 +5938,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6531,22 +5955,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Commande d'achat"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "Numéro de commande"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Commandes d'achat"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6561,14 +5979,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Commande d'achat"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6599,7 +6013,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Qté"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6613,8 +6026,6 @@ msgstr "La quantité dépasse le nombre d'unités en stock"
 msgid "Quarter"
 msgstr "Trimestre"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6651,9 +6062,7 @@ msgstr "Numéro de devis manquant!"
 msgid "Quotation deleted!"
 msgstr "Devis effacé!"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6674,25 +6083,20 @@ msgstr "Demande de devis"
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "Numéro de demande de devis"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "Demandes de devis"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "Seuil réapprovisionnement"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6704,7 +6108,6 @@ msgstr "Taux"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6727,13 +6130,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6751,7 +6150,6 @@ msgstr "Reçu"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6765,8 +6163,7 @@ msgstr "Reçus"
 msgid "Receivables"
 msgstr "À recevoir"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Réception"
 
@@ -6774,7 +6171,6 @@ msgstr "Réception"
 msgid "Receive Merchandise"
 msgstr "Réception marchandise"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6795,7 +6191,6 @@ msgstr "Rapprochement"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6816,13 +6211,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Transactions périodiques"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6861,12 +6249,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6904,7 +6290,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6916,7 +6302,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6929,7 +6315,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6979,7 +6364,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -6999,13 +6384,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Requis pour"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7035,7 +6417,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7044,7 +6425,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7061,7 +6441,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7111,11 +6490,11 @@ msgstr "SKU"
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7141,7 +6520,6 @@ msgstr "Ventes"
 msgid "Sales Invoice"
 msgstr "Facture de vente"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7157,20 +6535,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr "Commande de vente"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "Numéro de commande de vente"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Commandes de vente"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "Numéro de devis de vente"
@@ -7193,9 +6568,6 @@ msgstr "Numéro de devis de vente"
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7219,13 +6591,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7245,7 +6614,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7255,7 +6624,6 @@ msgstr "Enregistrer"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7314,11 +6682,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "Enregistrer comme nouveau"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7341,10 +6708,8 @@ msgstr "Planification"
 msgid "Scheduled"
 msgstr "Planifié"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Écran"
 
@@ -7364,7 +6729,6 @@ msgstr "Écran"
 msgid "Search"
 msgstr "Recherche"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7373,7 +6737,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7426,11 +6789,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7442,11 +6805,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7458,7 +6821,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7466,7 +6829,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7522,7 +6884,6 @@ msgstr "Sélectionner Txt, Postscript ou PDF!"
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7531,9 +6892,6 @@ msgstr ""
 msgid "Sell"
 msgstr "Vente"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7587,13 +6945,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Sept."
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "Septembre"
 
@@ -7614,9 +6970,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "N° série"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7646,7 +6999,6 @@ msgstr ""
 msgid "Services"
 msgstr "Prestation de service"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 #, fuzzy
 msgid "Session Timeout (e.g. \"90 minutes\")"
@@ -7660,7 +7012,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7680,10 +7032,10 @@ msgstr "Dix-sept"
 msgid "Seventy"
 msgstr "Soixante-dix"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Expédier"
 
@@ -7710,10 +7062,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7774,10 +7122,6 @@ msgstr "Date d'expédition manquante!"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7819,7 +7163,6 @@ msgstr "Date d'expédition"
 msgid "Short"
 msgstr "Court"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7860,7 +7203,6 @@ msgstr "Soixante"
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7873,12 +7215,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7905,7 +7241,6 @@ msgstr "Source"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7927,21 +7262,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Standard"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "Code secteur économique"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7972,8 +7296,6 @@ msgstr ""
 msgid "Startdate"
 msgstr "Date de début"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8010,13 +7332,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Relevé"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Solde relevé de compte"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8047,7 +7367,7 @@ msgstr "Stock de produits"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Feuille de style"
 
@@ -8072,7 +7392,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8115,7 +7434,6 @@ msgstr "Résumé"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8148,12 +7466,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8165,9 +7477,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8186,8 +7495,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8198,17 +7505,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8352,7 +7656,6 @@ msgstr ""
 msgid "Template"
 msgstr "Squelettes HTML"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8361,7 +7664,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8414,7 +7716,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8426,7 +7728,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8477,24 +7779,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8517,14 +7816,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8568,7 +7863,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8598,19 +7892,10 @@ msgstr ""
 msgid "To"
 msgstr "À"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8647,7 +7932,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8672,16 +7956,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8724,7 +7999,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8732,7 +8007,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8753,7 +8027,6 @@ msgstr "Écriture"
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8769,14 +8042,12 @@ msgstr "Date d'écriture manquante!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8815,7 +8086,6 @@ msgstr "Traductions"
 msgid "Translations saved!"
 msgstr "Traductions enregistrées"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Balance Globale"
@@ -8824,7 +8094,6 @@ msgstr "Balance Globale"
 msgid "Trillion"
 msgstr "Billion"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8881,10 +8150,6 @@ msgstr ""
 msgid "Two"
 msgstr "Deux"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8919,39 +8184,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8970,43 +8229,37 @@ msgstr "Unité"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9014,23 +8267,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9047,7 +8295,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9075,21 +8322,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9098,7 +8340,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9116,24 +8357,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9143,7 +8379,6 @@ msgstr "Utilisateur"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9164,7 +8399,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9190,8 +8424,6 @@ msgstr "Valable jusqu'au"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9201,11 +8433,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9221,7 +8449,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Fournisseur"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9235,7 +8462,6 @@ msgstr "Historique fournisseurs"
 msgid "Vendor Invoice"
 msgstr "Facture d'achat"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9245,9 +8471,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9277,9 +8500,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "Fournisseur manquant!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9287,8 +8508,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Fournisseur absent du fichier!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9303,7 +8522,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9316,7 +8534,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9339,7 +8556,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Entrepôts"
@@ -9348,11 +8564,26 @@ msgstr "Entrepôts"
 msgid "Warning!"
 msgstr "Attention!"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9362,7 +8593,6 @@ msgstr ""
 msgid "Week"
 msgstr "Semaine"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9379,13 +8609,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Poids"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Unité de poids"
@@ -9402,7 +8630,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9420,11 +8647,11 @@ msgstr "Fiche de traitement"
 msgid "Work order"
 msgstr "Fiche de traitement"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9467,15 +8694,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Oui"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9502,7 +8724,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9566,17 +8788,12 @@ msgstr "jours"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9593,7 +8810,7 @@ msgstr ""
 msgid "done"
 msgstr "fait"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9621,8 +8838,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9631,22 +8846,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9671,7 +8882,6 @@ msgstr ""
 msgid "sent"
 msgstr "envoyé"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9696,8 +8906,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/fr_BE.po
+++ b/locale/po/fr_BE.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: French (Belgium) (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,27 +15,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -48,12 +43,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -99,7 +90,6 @@ msgstr "Dépenses"
 msgid "AP Aging"
 msgstr "Dépenses exigibles"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -108,7 +98,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -123,7 +112,6 @@ msgstr "Dépenses en retard"
 msgid "AP Transaction"
 msgstr "Écriture dépenses"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Mouvements - Dépenses"
@@ -136,9 +124,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -157,7 +143,6 @@ msgstr "Recettes"
 msgid "AR Aging"
 msgstr "Recettes exigibles"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -166,7 +151,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -181,7 +165,6 @@ msgstr "Recettes en retard"
 msgid "AR Transaction"
 msgstr "Écriture recettes"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Mouvements - Recettes"
@@ -194,9 +177,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -205,8 +186,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Écriture recettes"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -216,16 +195,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -251,38 +225,20 @@ msgstr ""
 msgid "Account"
 msgstr "Compte"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -303,23 +259,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Numéro de compte"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -359,17 +310,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -381,7 +330,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -409,12 +358,10 @@ msgstr "Actif"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -437,11 +384,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr "Ajouter produit"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -566,7 +513,6 @@ msgstr "Établir commande de vente"
 msgid "Add Service"
 msgstr "Ajouter prestation"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -633,7 +579,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Mettre à jour"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -658,7 +603,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -668,12 +612,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -693,8 +636,7 @@ msgstr ""
 msgid "Aged"
 msgstr "Âgé"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -747,7 +689,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr "Attribué"
@@ -756,11 +697,6 @@ msgstr "Attribué"
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -794,14 +730,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Montant"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -810,27 +742,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Montant dû"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -848,14 +774,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -874,17 +800,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -893,13 +816,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -908,7 +824,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -917,14 +832,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -936,19 +849,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Avril"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "Avril"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -964,7 +874,6 @@ msgstr "Êtes vous sûr de vouloir supprimer le devis n°"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -983,19 +892,17 @@ msgstr "Renvoyer produits vers stock!"
 msgid "Asset"
 msgstr "Actif"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1008,29 +915,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1046,7 +950,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1144,8 +1047,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Août"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Août"
 
@@ -1157,7 +1059,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1171,7 +1072,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1184,7 +1084,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr "Coût moyen"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1218,8 +1117,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1234,7 +1131,6 @@ msgstr "Solde"
 msgid "Balance Sheet"
 msgstr "Bilan"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1255,7 +1151,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1266,7 +1161,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1276,18 +1170,15 @@ msgstr "Devise"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1300,12 +1191,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1322,13 +1211,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1369,8 +1256,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1417,17 +1302,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1440,12 +1322,10 @@ msgstr ""
 msgid "Business"
 msgstr "Type d'affaire"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Numéro d'enregistrement société"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1455,12 +1335,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1482,7 +1360,6 @@ msgstr "Type d'affaire enregistré!"
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1514,18 +1391,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1653,12 +1528,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr "À facturer"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Plan Comptable"
 
@@ -1678,7 +1552,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "Listing chèques"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1707,7 +1580,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1719,9 +1592,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "Lettré"
 
@@ -1749,15 +1622,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Clôturé"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1771,8 +1642,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1787,22 +1656,18 @@ msgstr "Code manquant!"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1814,39 +1679,31 @@ msgstr ""
 msgid "Company"
 msgstr "Société"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Nom de société"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1867,7 +1724,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Confirmer!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1885,7 +1742,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Contact"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1901,7 +1757,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1919,9 +1774,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1951,7 +1803,6 @@ msgstr ""
 msgid "Contra"
 msgstr "Contrepartie"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1959,10 +1810,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1993,20 +1840,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Coût"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2022,26 +1865,20 @@ msgstr "Enregistrement impossible!"
 msgid "Could not transfer Inventory!"
 msgstr "Impossible de transférer l'inventaire!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2053,7 +1890,6 @@ msgstr ""
 msgid "Country"
 msgstr "Pays"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2066,7 +1902,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2074,11 +1910,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2106,8 +1942,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2115,17 +1949,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Crédit"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2150,29 +1981,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Dev."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2195,18 +2016,14 @@ msgstr "Dev."
 msgid "Currency"
 msgstr "Devise"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "En cours"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2216,11 +2033,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2235,7 +2048,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Client"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2254,9 +2066,6 @@ msgstr "Client absent du fichier!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2276,9 +2085,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "Client manquant!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2290,7 +2097,7 @@ msgstr "Client absent du fichier!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2314,12 +2121,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2352,28 +2158,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2420,19 +2214,14 @@ msgstr ""
 msgid "Date"
 msgstr "Date"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2454,7 +2243,6 @@ msgstr "Date de réception"
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2518,8 +2306,6 @@ msgstr "Jour(s)"
 msgid "Days"
 msgstr "Jours"
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2535,10 +2321,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2548,17 +2332,14 @@ msgstr ""
 msgid "Dec"
 msgstr "Déc."
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Décembre"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2568,7 +2349,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2581,47 +2361,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2634,21 +2405,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "Valeurs par défaut"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2666,7 +2430,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Supprimer"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2679,7 +2442,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr "Effacer transaction planifiée"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2693,37 +2455,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Date de livraison"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2745,20 +2503,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2769,46 +2524,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2919,12 +2635,10 @@ msgstr "Détail"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2937,7 +2651,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2946,7 +2659,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Remise"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2955,28 +2667,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2984,7 +2696,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2993,7 +2704,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -3001,12 +2712,10 @@ msgstr ""
 msgid "Done"
 msgstr "Fait!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3019,12 +2728,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3033,19 +2740,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Dessin"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3061,10 +2765,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3083,7 +2783,7 @@ msgstr "Date d'échéance manquante!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3109,7 +2809,7 @@ msgstr "Message e-mail"
 msgid "E-mailed"
 msgstr "E-mail envoyé"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3139,7 +2839,7 @@ msgstr "Modifier une recette"
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3283,8 +2983,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3298,7 +2996,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Employé"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3308,12 +3005,11 @@ msgstr "Numéro d'employé"
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3323,37 +3019,26 @@ msgstr "Numéro d'employé"
 msgid "Employees"
 msgstr "Employés"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3377,7 +3062,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3402,12 +3086,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3417,7 +3099,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3425,7 +3107,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3451,7 +3132,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Nom de société"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3463,14 +3144,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Capital"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3484,16 +3162,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3501,7 +3178,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3514,8 +3191,6 @@ msgstr "Chaque"
 msgid "Exch"
 msgstr "Change"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3530,7 +3205,6 @@ msgstr "Taux de change"
 msgid "Exchange rate for payment missing!"
 msgstr "Taux de change manquant pour le paiement!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3539,7 +3213,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "Taux de change manquant!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3557,13 +3230,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Dépenses/actif"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3641,8 +3311,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Fév."
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Février"
 
@@ -3658,14 +3327,10 @@ msgstr "Cinquante"
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3676,11 +3341,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3691,7 +3356,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3749,12 +3413,10 @@ msgstr ""
 msgid "For"
 msgstr "Pour"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Produit conversion devises"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Perte conversion devises"
@@ -3763,12 +3425,10 @@ msgstr "Perte conversion devises"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3785,7 +3445,6 @@ msgstr "Quatre"
 msgid "Fourteen"
 msgstr "Quatorze"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3804,18 +3463,10 @@ msgstr ""
 msgid "From"
 msgstr "De"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3836,7 +3487,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr "Du entrepôt"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3847,15 +3497,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3869,10 +3514,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "Code d'identification comptable ou fiscale"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3893,7 +3536,6 @@ msgstr "Code d'identification comptable ou fiscale enregistré!"
 msgid "GL"
 msgstr "Grand-livre"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr "Numéro de réf. Grand-livre"
@@ -3902,7 +3544,7 @@ msgstr "Numéro de réf. Grand-livre"
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3910,11 +3552,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3923,7 +3564,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3931,9 +3572,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr "Générer"
 
@@ -3949,7 +3589,7 @@ msgstr "Générer commandes"
 msgid "Generate Purchase Orders"
 msgstr "Générer commandes d'achat"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3957,7 +3597,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr "Générer commandes de ventes"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3973,12 +3613,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3987,7 +3625,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4061,21 +3698,6 @@ msgstr ""
 msgid "Hundred"
 msgstr "Cent"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4106,7 +3728,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4116,13 +3737,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Image"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4165,7 +3784,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4199,14 +3817,10 @@ msgstr "Inclure dans les menus déroulants"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4214,12 +3828,10 @@ msgstr ""
 msgid "Income"
 msgstr "Recettes"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4230,7 +3842,6 @@ msgstr "Compte de résultat"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4240,7 +3851,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Compte de résultat"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4260,11 +3870,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4274,30 +3883,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "Notes internes"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4307,17 +3912,14 @@ msgstr "Inventaire"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4344,11 +3946,7 @@ msgstr "Inventaire enregistré!"
 msgid "Inventory transferred!"
 msgstr "Inventaire transféré!"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4390,8 +3988,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4407,11 +4003,6 @@ msgstr "Date de facture manquante!"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4430,7 +4021,6 @@ msgstr "Numéro de facture"
 msgid "Invoice Number missing!"
 msgstr "Numéro de facture manquant!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4460,12 +4050,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4523,8 +4111,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Jan."
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Janvier"
 
@@ -4553,8 +4140,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Juill."
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Juillet"
 
@@ -4562,8 +4148,8 @@ msgstr "Juillet"
 msgid "Jun"
 msgstr "Juin"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Juin"
 
@@ -4576,10 +4162,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "Squelettes LaTeX"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4601,15 +4183,12 @@ msgstr "Coût de production"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Langue"
@@ -4630,7 +4209,6 @@ msgstr "Langues non définis!"
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4641,7 +4219,6 @@ msgstr "Dernier prix"
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4663,40 +4240,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr "Délai"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4708,9 +4284,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4732,9 +4306,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4748,8 +4320,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4766,7 +4336,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4803,7 +4372,6 @@ msgstr "Liste des langues"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4829,7 +4397,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4847,7 +4414,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4868,7 +4434,7 @@ msgstr ""
 msgid "Login"
 msgstr "Login"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4896,45 +4462,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Marque"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4956,40 +4515,34 @@ msgstr ""
 msgid "Mar"
 msgstr "Mars"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Mars"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Majoration"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "Mai"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Mémo"
@@ -5006,7 +4559,6 @@ msgstr "Message"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Méthode"
@@ -5015,7 +4567,6 @@ msgstr "Méthode"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5034,14 +4585,11 @@ msgstr ""
 msgid "Million"
 msgstr "Million"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5055,7 +4603,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5068,14 +4615,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Modèle"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5093,7 +4638,7 @@ msgstr "Mois"
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5117,14 +4662,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5133,15 +4676,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5160,7 +4694,6 @@ msgstr "Nom"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5211,8 +4744,6 @@ msgstr "Prochaine date"
 msgid "Next Number"
 msgstr "Prochain numéro"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5234,12 +4765,10 @@ msgstr "Dix-neuf"
 msgid "Ninety"
 msgstr "Nonante"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Non"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5248,7 +4777,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5256,11 +4785,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5268,7 +4797,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5277,11 +4805,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5289,21 +4817,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr "Aucun projet ouvert!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5322,12 +4847,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5336,12 +4859,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr "Objets non-référencés"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5379,11 +4900,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5429,23 +4945,18 @@ msgstr "Rien à transférer!"
 msgid "Nov"
 msgstr "Nov."
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "Novembre"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5476,7 +4987,7 @@ msgstr ""
 msgid "Number"
 msgstr "Numéro"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Format des numéros"
 
@@ -5497,13 +5008,11 @@ msgstr "OH"
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Obsolète"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5512,8 +5021,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Oct."
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Octobre"
 
@@ -5525,9 +5033,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5577,7 +5082,6 @@ msgstr ""
 msgid "Open"
 msgstr "Ouvert"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5599,9 +5103,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5647,7 +5148,6 @@ msgstr "Date de commande manquante!"
 msgid "Order Entry"
 msgstr "Commandes"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5669,7 +5169,6 @@ msgstr "Commande supprimée!"
 msgid "Order generation failed!"
 msgstr "Génération commande échouée!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5691,7 +5190,7 @@ msgstr "Commandes générées!"
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5737,7 +5236,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5756,10 +5254,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5803,11 +5297,6 @@ msgstr "Le numéro de la liste d'envoi est manquant!"
 msgid "Packing list"
 msgstr "Liste d'envoi"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5825,12 +5314,10 @@ msgstr "Total payé"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Marchandise"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5840,14 +5327,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5877,14 +5356,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5900,15 +5375,12 @@ msgstr "Numéro de marchandise"
 msgid "Parts"
 msgstr "Marchandise"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5918,7 +5390,6 @@ msgstr ""
 msgid "Password"
 msgstr "Mot de passe"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5931,7 +5402,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5945,7 +5415,6 @@ msgstr ""
 msgid "Payables"
 msgstr "À payer"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5954,7 +5423,6 @@ msgstr "À payer"
 msgid "Payment"
 msgstr "Paiement"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5967,7 +5435,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5984,7 +5451,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6020,15 +5486,15 @@ msgstr "Paiements"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6047,7 +5513,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6078,108 +5543,88 @@ msgstr "Liste de sélection"
 msgid "Pick list"
 msgstr "Liste de sélection"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6195,7 +5640,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6204,24 +5648,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6230,13 +5672,11 @@ msgstr ""
 msgid "Post"
 msgstr "Enregistrer"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6277,7 +5717,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Postcript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6315,20 +5754,16 @@ msgstr ""
 msgid "Price"
 msgstr "Prix"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6364,8 +5799,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6375,7 +5808,6 @@ msgstr ""
 msgid "Print"
 msgstr "Imprimer"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6392,7 +5824,7 @@ msgstr "Imprimer et enregister comme nouveau"
 msgid "Printed"
 msgstr "Imprimé"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Imprimante"
 
@@ -6436,17 +5868,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6475,7 +5905,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6494,7 +5923,6 @@ msgstr "Traductions description de projet"
 msgid "Project Number"
 msgstr "Numéro de projet"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6503,9 +5931,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Projets"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6515,7 +5940,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6533,22 +5957,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Commande d'achat"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "Numéro de commande"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Commandes d'achat"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6563,14 +5981,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Commande d'achat"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6601,7 +6015,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Qté"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6615,8 +6028,6 @@ msgstr "La quantité dépasse le nombre d'unités en stock"
 msgid "Quarter"
 msgstr "Trimestre"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6653,9 +6064,7 @@ msgstr "Numéro de devis manquant!"
 msgid "Quotation deleted!"
 msgstr "Devis effacé!"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6676,25 +6085,20 @@ msgstr "Demande de devis"
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "Numéro de demande de devis"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "Demandes de devis"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "Seuil réapprovisionnement"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6706,7 +6110,6 @@ msgstr "Taux"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6729,13 +6132,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6753,7 +6152,6 @@ msgstr "Reçu"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6767,8 +6165,7 @@ msgstr "Reçus"
 msgid "Receivables"
 msgstr "À recevoir"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Réception"
 
@@ -6776,7 +6173,6 @@ msgstr "Réception"
 msgid "Receive Merchandise"
 msgstr "Réception marchandise"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6797,7 +6193,6 @@ msgstr "Rapprochement"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6818,13 +6213,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Transactions périodiques"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6863,12 +6251,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6906,7 +6292,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6918,7 +6304,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6931,7 +6317,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6981,7 +6366,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -7001,13 +6386,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Requis pour"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7037,7 +6419,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7046,7 +6427,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7063,7 +6443,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7113,11 +6492,11 @@ msgstr "SKU"
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7143,7 +6522,6 @@ msgstr "Ventes"
 msgid "Sales Invoice"
 msgstr "Facture de vente"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Numéro facture de vente/écriture recette"
@@ -7159,20 +6537,17 @@ msgstr "Numéro facture de vente/écriture recette"
 msgid "Sales Order"
 msgstr "Commande de vente"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "Numéro de commande de vente"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Commandes de vente"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "Numéro de devis de vente"
@@ -7195,9 +6570,6 @@ msgstr "Numéro de devis de vente"
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7221,13 +6593,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7247,7 +6616,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7257,7 +6626,6 @@ msgstr "Enregistrer"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7316,11 +6684,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "Enregistrer comme nouveau"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7343,10 +6710,8 @@ msgstr "Planification"
 msgid "Scheduled"
 msgstr "Planifié"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Écran"
 
@@ -7366,7 +6731,6 @@ msgstr "Écran"
 msgid "Search"
 msgstr "Recherche"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7375,7 +6739,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7428,11 +6791,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7444,11 +6807,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7460,7 +6823,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7468,7 +6831,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7524,7 +6886,6 @@ msgstr "Sélectionner Txt, Postscript ou PDF!"
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7533,9 +6894,6 @@ msgstr ""
 msgid "Sell"
 msgstr "Vente"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7589,13 +6947,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Sept."
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "Septembre"
 
@@ -7616,9 +6972,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "N° série"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7648,7 +7001,6 @@ msgstr "Compte de prestation"
 msgid "Services"
 msgstr "Prestation de service"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 #, fuzzy
 msgid "Session Timeout (e.g. \"90 minutes\")"
@@ -7662,7 +7014,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7682,10 +7034,10 @@ msgstr "Dix-sept"
 msgid "Seventy"
 msgstr "Septante"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Expédier"
 
@@ -7712,10 +7064,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7776,10 +7124,6 @@ msgstr "Date d'expédition manquante!"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7821,7 +7165,6 @@ msgstr "Date d'expédition"
 msgid "Short"
 msgstr "Court"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7862,7 +7205,6 @@ msgstr "Soixante"
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7875,12 +7217,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7907,7 +7243,6 @@ msgstr "Source"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7929,21 +7264,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Standard"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "Code secteur économique"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7974,8 +7298,6 @@ msgstr ""
 msgid "Startdate"
 msgstr "Date de début"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8012,13 +7334,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Relevé"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Solde relevé de compte"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8049,7 +7369,7 @@ msgstr "Stock de produits"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Feuille de style"
 
@@ -8074,7 +7394,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8117,7 +7436,6 @@ msgstr "Résumé"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8150,12 +7468,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8167,9 +7479,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8188,8 +7497,6 @@ msgstr "Compte de taxe"
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8200,17 +7507,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8354,7 +7658,6 @@ msgstr ""
 msgid "Template"
 msgstr "Squelettes HTML"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8363,7 +7666,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8416,7 +7718,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8428,7 +7730,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8479,24 +7781,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8519,14 +7818,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8570,7 +7865,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8600,19 +7894,10 @@ msgstr ""
 msgid "To"
 msgstr "Jusqu'au"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8649,7 +7934,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8674,16 +7958,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8726,7 +8001,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8734,7 +8009,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8755,7 +8029,6 @@ msgstr "Écriture"
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8771,14 +8044,12 @@ msgstr "Date d'écriture manquante!"
 msgid "Transaction Dates"
 msgstr "Dates de transactions"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8817,7 +8088,6 @@ msgstr "Traductions"
 msgid "Translations saved!"
 msgstr "Traductions enregistrées"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Balance Globale"
@@ -8826,7 +8096,6 @@ msgstr "Balance Globale"
 msgid "Trillion"
 msgstr "Billion"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8883,10 +8152,6 @@ msgstr ""
 msgid "Two"
 msgstr "Deux"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8921,39 +8186,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8972,43 +8231,37 @@ msgstr "Unité"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9016,23 +8269,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9049,7 +8297,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9077,21 +8324,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9100,7 +8342,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9118,24 +8359,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9145,7 +8381,6 @@ msgstr "Utilisateur"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9166,7 +8401,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9192,8 +8426,6 @@ msgstr "Valable jusqu'au"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9203,11 +8435,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9223,7 +8451,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Fournisseur"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9237,7 +8464,6 @@ msgstr "Historique fournisseurs"
 msgid "Vendor Invoice"
 msgstr "Facture d'achat"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr "Numéro facture d'achat/écriture achat"
@@ -9247,9 +8473,6 @@ msgstr "Numéro facture d'achat/écriture achat"
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9279,9 +8502,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "Fournisseur manquant!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9289,8 +8510,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Fournisseur absent du fichier!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9305,7 +8524,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9318,7 +8536,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9341,7 +8558,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Entrepôts"
@@ -9350,11 +8566,26 @@ msgstr "Entrepôts"
 msgid "Warning!"
 msgstr "Attention!"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9364,7 +8595,6 @@ msgstr ""
 msgid "Week"
 msgstr "Semaine"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9381,13 +8611,11 @@ msgstr ""
 msgid "Weeks"
 msgstr "Semaines"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Poids"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Unité de poids"
@@ -9404,7 +8632,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9422,11 +8649,11 @@ msgstr "Fiche de traitement"
 msgid "Work order"
 msgstr "Fiche de traitement"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9469,15 +8696,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Oui"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9504,7 +8726,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9568,17 +8790,12 @@ msgstr "jours"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9595,7 +8812,7 @@ msgstr ""
 msgid "done"
 msgstr "fait"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9623,8 +8840,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9633,22 +8848,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9673,7 +8884,6 @@ msgstr ""
 msgid "sent"
 msgstr "envoyé"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9698,8 +8908,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr "Erreur inattendue!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/fr_CA.po
+++ b/locale/po/fr_CA.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: French (Canada) (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -16,27 +16,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr "# Factures"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -49,12 +44,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -100,7 +91,6 @@ msgstr "Dépenses"
 msgid "AP Aging"
 msgstr "Dépenses exigibles"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -109,7 +99,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -124,7 +113,6 @@ msgstr "Dépenses en retard"
 msgid "AP Transaction"
 msgstr "Écriture dépenses"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Mouvements - Dépenses"
@@ -137,9 +125,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -158,7 +144,6 @@ msgstr "Recettes"
 msgid "AR Aging"
 msgstr "Recettes exigibles"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -167,7 +152,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -182,7 +166,6 @@ msgstr "Recettes en retard"
 msgid "AR Transaction"
 msgstr "Écriture recettes"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Mouvements - Recettes"
@@ -195,9 +178,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -206,8 +187,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Écriture recettes"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -217,16 +196,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr "Accès refusé"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -252,38 +226,20 @@ msgstr "Accès refusé"
 msgid "Account"
 msgstr "Compte"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -304,23 +260,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Numéro de compte"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -360,17 +311,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -382,7 +331,7 @@ msgstr "Accumulation"
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -410,12 +359,10 @@ msgstr "Actif"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr "Sessions actives"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -438,11 +385,11 @@ msgstr "Ajouter comptes"
 msgid "Add Assembly"
 msgstr "Ajouter produit"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -567,7 +514,6 @@ msgstr "Établir commande de vente"
 msgid "Add Service"
 msgstr "Ajouter prestation"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -634,7 +580,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Mettre à jour"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -659,7 +604,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -669,12 +613,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -694,8 +637,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -748,7 +690,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -757,11 +698,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -795,14 +731,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Montant"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -811,27 +743,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Montant dû"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -849,14 +775,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -875,17 +801,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -894,13 +817,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -909,7 +825,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -918,14 +833,12 @@ msgstr ""
 msgid "Approved"
 msgstr "Approuvé"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr "Approuvé par"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -937,19 +850,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Avril"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "Avril"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -965,7 +875,6 @@ msgstr "Êtes vous sûr de vouloir supprimer le devis n°"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -984,19 +893,17 @@ msgstr "Renvoyer produits vers stock!"
 msgid "Asset"
 msgstr "Actif"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr "Compte d'actif"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr "Classe d'actif"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1009,29 +916,26 @@ msgstr "Classe d'actif:"
 msgid "Asset Classes"
 msgstr "Classes d'actif"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1047,7 +951,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1145,8 +1048,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Août"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Août"
 
@@ -1158,7 +1060,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1172,7 +1073,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1185,7 +1085,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1219,8 +1118,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1235,7 +1132,6 @@ msgstr "Solde"
 msgid "Balance Sheet"
 msgstr "Bilan"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1256,7 +1152,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1267,7 +1162,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1277,18 +1171,15 @@ msgstr "Devise"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1301,12 +1192,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1323,13 +1212,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1370,8 +1257,6 @@ msgstr ""
 msgid "Billion"
 msgstr "Milliard"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1418,17 +1303,14 @@ msgstr ""
 msgid "Budget"
 msgstr "Budget"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1441,12 +1323,10 @@ msgstr ""
 msgid "Business"
 msgstr "Type d'affaire"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Numéro d'enregistrement société"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1456,12 +1336,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1483,7 +1361,6 @@ msgstr "Type d'affaire enregistré!"
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1515,18 +1392,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1654,12 +1529,11 @@ msgstr "Modifier mot de passe"
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Plan Comptable"
 
@@ -1679,7 +1553,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "Listing chèques"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr "Préfixe"
@@ -1708,7 +1581,7 @@ msgstr "Ville"
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1720,9 +1593,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "Encaissé"
 
@@ -1750,15 +1623,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Clôturé"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1772,8 +1643,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1788,22 +1657,18 @@ msgstr "Code manquant!"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1815,39 +1680,31 @@ msgstr ""
 msgid "Company"
 msgstr "Société"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr "Adresse"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr "Télécopieur"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr "Information"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Nom de société"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr "Téléphone"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1868,7 +1725,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Confirmer!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1886,7 +1743,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Contact"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1902,7 +1758,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1920,9 +1775,6 @@ msgstr "Contacts"
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1952,7 +1804,6 @@ msgstr ""
 msgid "Contra"
 msgstr "Contrepartie"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1960,10 +1811,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1994,20 +1841,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Coût"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr "Coût des produits vendus"
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2023,26 +1866,20 @@ msgstr "Enregistrement impossible!"
 msgid "Could not transfer Inventory!"
 msgstr "Impossible de transférer l'inventaire!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr "Contrepartie"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2054,7 +1891,6 @@ msgstr ""
 msgid "Country"
 msgstr "Pays"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr "Nom du pays"
@@ -2067,7 +1903,7 @@ msgstr "Pays:"
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2075,11 +1911,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2107,8 +1943,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2116,17 +1950,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Crédit"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr "Compte de crédit"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr "Numéro de compte de crédit"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr "Comptes de crédit"
@@ -2151,29 +1982,19 @@ msgstr "Encours autorisé:"
 msgid "Credit Note"
 msgstr "Note de crédit"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Dev."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2196,18 +2017,14 @@ msgstr "Dev."
 msgid "Currency"
 msgstr "Devise"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "En cours"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2217,11 +2034,7 @@ msgstr "Bénéfice de l'exercice"
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2236,7 +2049,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Client"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr "Compte client"
@@ -2255,9 +2067,6 @@ msgstr "Client absent du fichier!"
 msgid "Customer Name"
 msgstr "Nom du client"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2277,9 +2086,7 @@ msgstr "Recherche client"
 msgid "Customer missing!"
 msgstr "Client manquant!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2291,7 +2098,7 @@ msgstr "Client absent du fichier!"
 msgid "Customer/Vendor Accounts"
 msgstr "Comptes Clients/Fournisseurs"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2315,12 +2122,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2353,28 +2159,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr "Base de données inexistante."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2421,19 +2215,14 @@ msgstr ""
 msgid "Date"
 msgstr "Date"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr "Format de date"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr "De"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2455,7 +2244,6 @@ msgstr "Date de réception"
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr "À"
@@ -2519,8 +2307,6 @@ msgstr "JOur(s)"
 msgid "Days"
 msgstr "Jours"
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2536,10 +2322,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr "Note de débit"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2549,17 +2333,14 @@ msgstr "Débits"
 msgid "Dec"
 msgstr "Déc."
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Décembre"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2569,7 +2350,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2582,47 +2362,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr "Pays par défaut"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr "CCI par défaut"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr "CC par défaut"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr "Courriel émetteur par défaut"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr "Courriel destinaire par défaut"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr "Format par défaut"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr "Langue par défaut"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2635,21 +2406,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "Valeurs par défaut"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2667,7 +2431,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Supprimer"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2680,7 +2443,6 @@ msgstr "Supprimer la langue"
 msgid "Delete Schedule"
 msgstr "Effacer transaction planifiée"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2694,37 +2456,33 @@ msgstr "Supprimer une langue effacera aussi les squelettes pour la langue [_1]"
 msgid "Delivery"
 msgstr "Livraison"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Date de livraison"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2746,20 +2504,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2770,46 +2525,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2920,12 +2636,10 @@ msgstr "Détail"
 msgid "Details"
 msgstr "Détails"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2938,7 +2652,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2947,7 +2660,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Remise"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2956,28 +2668,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2985,7 +2697,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2994,7 +2705,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -3002,12 +2713,10 @@ msgstr ""
 msgid "Done"
 msgstr "Fait!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3020,12 +2729,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3034,19 +2741,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Dessin"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3062,10 +2766,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3084,7 +2784,7 @@ msgstr "Date d'échéance manquante!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3110,7 +2810,7 @@ msgstr "Message e-mail"
 msgid "E-mailed"
 msgstr "E-mail envoyé"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3140,7 +2840,7 @@ msgstr "Modifier une recette"
 msgid "Edit Assembly"
 msgstr "Modifier produit fini / transformé"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3284,8 +2984,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3299,7 +2997,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Employé"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3309,12 +3006,11 @@ msgstr "Numéro d'employé"
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3324,37 +3020,26 @@ msgstr "Numéro d'employé"
 msgid "Employees"
 msgstr "Employés"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3378,7 +3063,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3403,12 +3087,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3418,7 +3100,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3426,7 +3108,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3452,7 +3133,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Nom du pays"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3464,14 +3145,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Capital"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3485,16 +3163,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3502,7 +3179,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3515,8 +3192,6 @@ msgstr "Chaque"
 msgid "Exch"
 msgstr "Change"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3531,7 +3206,6 @@ msgstr "Taux de change"
 msgid "Exchange rate for payment missing!"
 msgstr "Taux de change manquant pour le paiement!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3540,7 +3214,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "Taux de change manquant!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3558,13 +3231,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Dépenses/actif"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3642,8 +3312,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Fév."
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Février"
 
@@ -3659,14 +3328,10 @@ msgstr "Cinquante"
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3677,11 +3342,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3692,7 +3357,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3750,12 +3414,10 @@ msgstr ""
 msgid "For"
 msgstr "Pour"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Produit conversion devises"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Perte conversion devises"
@@ -3764,12 +3426,10 @@ msgstr "Perte conversion devises"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3786,7 +3446,6 @@ msgstr "Quatre"
 msgid "Fourteen"
 msgstr "Quatorze"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3805,18 +3464,10 @@ msgstr ""
 msgid "From"
 msgstr "De"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3837,7 +3488,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3848,15 +3498,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3870,10 +3515,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "Code d'identification comptable ou fiscale"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3894,7 +3537,6 @@ msgstr "Code d'identification comptable ou fiscale enregistré!"
 msgid "GL"
 msgstr "Grand-livre"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3903,7 +3545,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3911,11 +3553,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3924,7 +3565,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3932,9 +3573,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3950,7 +3590,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3958,7 +3598,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3974,12 +3614,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3988,7 +3626,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4062,21 +3699,6 @@ msgstr "Heures"
 msgid "Hundred"
 msgstr "Cent"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4107,7 +3729,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4117,13 +3738,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Image"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4166,7 +3785,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4200,14 +3818,10 @@ msgstr "Inclure dans les menus déroulants"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4215,12 +3829,10 @@ msgstr ""
 msgid "Income"
 msgstr "Recettes"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4231,7 +3843,6 @@ msgstr "Compte de résultat"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4241,7 +3852,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Compte de résultat"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4261,11 +3871,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4275,30 +3884,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "Notes internes"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4308,17 +3913,14 @@ msgstr "Inventaire"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4346,11 +3948,7 @@ msgstr "Inventaire enregistré!"
 msgid "Inventory transferred!"
 msgstr "Inventaire transféré!"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4392,8 +3990,6 @@ msgstr "Facture créée"
 msgid "Invoice Created Date missing!"
 msgstr "Date de création de facture manquante!"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4409,11 +4005,6 @@ msgstr "Date de facture manquante!"
 msgid "Invoice No."
 msgstr "N° de Facture"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4432,7 +4023,6 @@ msgstr "Numéro de facture"
 msgid "Invoice Number missing!"
 msgstr "Numéro de facture manquant!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4462,12 +4052,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4525,8 +4113,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Jan."
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Janvier"
 
@@ -4555,8 +4142,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Juill."
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Juillet"
 
@@ -4564,8 +4150,8 @@ msgstr "Juillet"
 msgid "Jun"
 msgstr "Juin"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Juin"
 
@@ -4578,10 +4164,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "Squelettes LaTeX"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4603,15 +4185,12 @@ msgstr "Coût de production"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Langue"
@@ -4632,7 +4211,6 @@ msgstr "Langues non définis!"
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4643,7 +4221,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4665,40 +4242,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr "Délai"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4710,9 +4286,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4734,9 +4308,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4750,8 +4322,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4768,7 +4338,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4805,7 +4374,6 @@ msgstr "Liste des langues"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4831,7 +4399,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4849,7 +4416,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4870,7 +4436,7 @@ msgstr ""
 msgid "Login"
 msgstr "Login"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4898,45 +4464,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Marque"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4958,40 +4517,34 @@ msgstr ""
 msgid "Mar"
 msgstr "Mars"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Mars"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Majoration"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "Mai"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Mémo"
@@ -5008,7 +4561,6 @@ msgstr "Message"
 msgid "Message: "
 msgstr "Message: "
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Méthode"
@@ -5017,7 +4569,6 @@ msgstr "Méthode"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5036,14 +4587,11 @@ msgstr ""
 msgid "Million"
 msgstr "Million"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5057,7 +4605,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr "Réglages divers"
@@ -5070,14 +4617,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Modèle"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5095,7 +4640,7 @@ msgstr "Mois"
 msgid "Months"
 msgstr "Mois"
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5119,14 +4664,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5135,15 +4678,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5162,7 +4696,6 @@ msgstr "Nom"
 msgid "Name:"
 msgstr "Nom:"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5213,8 +4746,6 @@ msgstr "Prochaine date"
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5236,12 +4767,10 @@ msgstr "Dix-neuf"
 msgid "Ninety"
 msgstr "Quatre-vignt-dix"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Non"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5250,7 +4779,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5258,11 +4787,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5270,7 +4799,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5279,11 +4807,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5291,21 +4819,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5324,12 +4849,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5338,12 +4861,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5381,11 +4902,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5431,23 +4947,18 @@ msgstr "Rien à transférer!"
 msgid "Nov"
 msgstr "Nov."
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "Novembre"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5478,7 +4989,7 @@ msgstr ""
 msgid "Number"
 msgstr "Numéro"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Format des numéros"
 
@@ -5499,13 +5010,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Obsolète"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5514,8 +5023,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Oct."
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Octobre"
 
@@ -5527,9 +5035,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5579,7 +5084,6 @@ msgstr ""
 msgid "Open"
 msgstr "Ouvert"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5601,9 +5105,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5649,7 +5150,6 @@ msgstr "Date de commande manquante!"
 msgid "Order Entry"
 msgstr "Commandes"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5671,7 +5171,6 @@ msgstr "Commande supprimée!"
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5693,7 +5192,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5739,7 +5238,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5758,10 +5256,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5805,11 +5299,6 @@ msgstr "Le numéro de la liste d'envoi est manquant!"
 msgid "Packing list"
 msgstr "Liste d'envoi"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5827,12 +5316,10 @@ msgstr "Total payé"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Marchandise"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5842,14 +5329,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5880,14 +5359,10 @@ msgstr "Détails"
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5903,15 +5378,12 @@ msgstr "Numéro de marchandise"
 msgid "Parts"
 msgstr "Marchandise"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5921,7 +5393,6 @@ msgstr ""
 msgid "Password"
 msgstr "Mot de passe"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5934,7 +5405,6 @@ msgstr "Mots de passes non-identiques"
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5948,7 +5418,6 @@ msgstr ""
 msgid "Payables"
 msgstr "À payer"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5957,7 +5426,6 @@ msgstr "À payer"
 msgid "Payment"
 msgstr "Paiement"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5970,7 +5438,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5987,7 +5454,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6023,15 +5489,15 @@ msgstr "Paiements"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6050,7 +5516,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6081,108 +5546,88 @@ msgstr "Liste de sélection"
 msgid "Pick list"
 msgstr "Liste de sélection"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6198,7 +5643,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6207,24 +5651,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6233,13 +5675,11 @@ msgstr ""
 msgid "Post"
 msgstr "Enregistrer"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6280,7 +5720,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Postcript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6318,20 +5757,16 @@ msgstr "Préfixe"
 msgid "Price"
 msgstr "Prix"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr "Groupe de prix"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr "Groupes de prix"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6367,8 +5802,6 @@ msgstr "Groupe de prix de [_1]"
 msgid "Primary Phone"
 msgstr "Téléphone principal"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6378,7 +5811,6 @@ msgstr "Téléphone principal"
 msgid "Print"
 msgstr "Imprimer"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6395,7 +5827,7 @@ msgstr ""
 msgid "Printed"
 msgstr "Imprimé"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Imprimante"
 
@@ -6439,17 +5871,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6478,7 +5908,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6497,7 +5926,6 @@ msgstr "Traductions description de projet"
 msgid "Project Number"
 msgstr "Numéro de projet"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6506,9 +5934,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Projets"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6518,7 +5943,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6536,22 +5960,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Commande d'achat"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "Numéro de commande"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Commandes d'achat"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6566,14 +5984,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Commande d'achat"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6604,7 +6018,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Qté"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6618,8 +6031,6 @@ msgstr "La quantité dépasse le nombre d'unités en stock"
 msgid "Quarter"
 msgstr "Trimestre"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6656,9 +6067,7 @@ msgstr "Numéro de devis manquant!"
 msgid "Quotation deleted!"
 msgstr "Devis effacé!"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6679,25 +6088,20 @@ msgstr "Demande de devis"
 msgid "RFQ #"
 msgstr "No. de demande de devis"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "Numéro de demande de devis"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "Demandes de devis"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "Seuil réapprovisionnement"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6709,7 +6113,6 @@ msgstr "Taux"
 msgid "Rate (%)"
 msgstr "Taux (%)"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6732,13 +6135,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6756,7 +6155,6 @@ msgstr "Reçu"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6770,8 +6168,7 @@ msgstr "Reçus"
 msgid "Receivables"
 msgstr "À recevoir"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Réception"
 
@@ -6779,7 +6176,6 @@ msgstr "Réception"
 msgid "Receive Merchandise"
 msgstr "Réception marchandise"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6800,7 +6196,6 @@ msgstr "Rapprochement"
 msgid "Reconciliation Report"
 msgstr "Rapport de rapprochement"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr "Rapports de rapprochement"
@@ -6821,13 +6216,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Transactions périodiques"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6866,12 +6254,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6909,7 +6295,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6921,7 +6307,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6934,7 +6320,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6984,7 +6369,7 @@ msgstr ""
 msgid "Required By"
 msgstr "Requis pour"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -7004,13 +6389,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Requis pour"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7040,7 +6422,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7049,7 +6430,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7066,7 +6446,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7116,11 +6495,11 @@ msgstr "SKU"
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7146,7 +6525,6 @@ msgstr "Ventes"
 msgid "Sales Invoice"
 msgstr "Facture de vente"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7162,20 +6540,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr "Commande de vente"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "Numéro de commande de vente"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Commandes de vente"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "Numéro de devis de vente"
@@ -7198,9 +6573,6 @@ msgstr "Numéro de devis de vente"
 msgid "Sales:"
 msgstr "Ventes:"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7224,13 +6596,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr "Sam."
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7250,7 +6619,7 @@ msgstr "Sam."
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7260,7 +6629,6 @@ msgstr "Enregistrer"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7319,11 +6687,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "Enregistrer comme nouveau"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7346,10 +6713,8 @@ msgstr "Planification"
 msgid "Scheduled"
 msgstr "Planifié"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Écran"
 
@@ -7369,7 +6734,6 @@ msgstr "Écran"
 msgid "Search"
 msgstr "Recherche"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7378,7 +6742,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7431,11 +6794,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7447,11 +6810,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7463,7 +6826,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7471,7 +6834,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr "Réglages de sécurité"
@@ -7527,7 +6889,6 @@ msgstr "Sélectionner Txt, Postscript ou PDF!"
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7536,9 +6897,6 @@ msgstr ""
 msgid "Sell"
 msgstr "Vente"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7592,13 +6950,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Sept."
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "Septembre"
 
@@ -7619,9 +6975,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "N° série"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7651,7 +7004,6 @@ msgstr ""
 msgid "Services"
 msgstr "Prestation de service"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 #, fuzzy
 msgid "Session Timeout (e.g. \"90 minutes\")"
@@ -7665,7 +7017,7 @@ msgstr "Sessions"
 msgid "Setting"
 msgstr "Réglage"
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr "Réglages"
 
@@ -7685,10 +7037,10 @@ msgstr "Dix-sept"
 msgid "Seventy"
 msgstr "Soixante-dix"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Expédier"
 
@@ -7715,10 +7067,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr "Expédier à:"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7779,10 +7127,6 @@ msgstr "Date d'expédition manquante!"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7824,7 +7168,6 @@ msgstr "Date d'expédition"
 msgid "Short"
 msgstr "Court"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7865,7 +7208,6 @@ msgstr "Soixante"
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7878,12 +7220,6 @@ msgstr ""
 msgid "Sort by"
 msgstr "Trier par"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7910,7 +7246,6 @@ msgstr "Source"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7932,21 +7267,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Standard"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "Code secteur économique"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7977,8 +7301,6 @@ msgstr ""
 msgid "Startdate"
 msgstr "Date de début"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8015,13 +7337,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Relevé"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Solde relevé de compte"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8052,7 +7372,7 @@ msgstr "Stock de produits"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Feuille de style"
 
@@ -8077,7 +7397,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8120,7 +7439,6 @@ msgstr "Résumé"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr "Dim."
@@ -8153,12 +7471,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr "TOTAL"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8170,9 +7482,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8191,8 +7500,6 @@ msgstr "Compte de taxe"
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8203,17 +7510,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8357,7 +7661,6 @@ msgstr "Tél: [_1]"
 msgid "Template"
 msgstr "Squelettes"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8366,7 +7669,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr "Squelette enregistré!"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8419,7 +7721,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8431,7 +7733,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8482,24 +7784,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8522,14 +7821,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr "Jeu."
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8573,7 +7868,6 @@ msgstr "Carte de temps"
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr "Cartes de temps"
@@ -8603,19 +7897,10 @@ msgstr ""
 msgid "To"
 msgstr "À"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8652,7 +7937,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8677,16 +7961,7 @@ msgstr ""
 msgid "Top-level"
 msgstr "Description principale"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8729,7 +8004,7 @@ msgstr "Description principale"
 msgid "Total"
 msgstr "Total"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8737,7 +8012,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8758,7 +8032,6 @@ msgstr "Écriture"
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8774,14 +8047,12 @@ msgstr "Date d'écriture manquante!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8820,7 +8091,6 @@ msgstr "Traductions"
 msgid "Translations saved!"
 msgstr "Traductions enregistrées"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Balance Globale"
@@ -8829,7 +8099,6 @@ msgstr "Balance Globale"
 msgid "Trillion"
 msgstr "Billion"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr "Mar."
@@ -8886,10 +8155,6 @@ msgstr "Vingt-deux"
 msgid "Two"
 msgstr "Deux"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8924,39 +8189,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8975,43 +8234,37 @@ msgstr "Unité"
 msgid "Unit Price"
 msgstr "Prix unitaire"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9019,23 +8272,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9052,7 +8300,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9080,21 +8327,16 @@ msgstr "Information de mise à jour"
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9103,7 +8345,6 @@ msgstr ""
 msgid "Url"
 msgstr "Url"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9121,24 +8362,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9148,7 +8384,6 @@ msgstr "Utilisateur"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9169,7 +8404,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9195,8 +8429,6 @@ msgstr "Valable jusqu'au"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9206,11 +8438,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9226,7 +8454,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Fournisseur"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9240,7 +8467,6 @@ msgstr "Historique fournisseurs"
 msgid "Vendor Invoice"
 msgstr "Facture d'achat"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9250,9 +8476,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr "Nom du fournisseur"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9282,9 +8505,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "Fournisseur manquant!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9292,8 +8513,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Fournisseur absent du fichier!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9308,7 +8527,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9321,7 +8539,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9344,7 +8561,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Entrepôts"
@@ -9353,11 +8569,31 @@ msgstr "Entrepôts"
 msgid "Warning!"
 msgstr "Attention!"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+#, fuzzy
+msgid "Warning: Your password will expire in [_1] days"
 msgstr "Attention:  Votre mot de passe expirera dans [_1]"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+#, fuzzy
+msgid "Warning: Your password will expire in [_1] months"
+msgstr "Attention:  Votre mot de passe expirera dans [_1]"
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+#, fuzzy
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr "Attention:  Votre mot de passe expirera dans [_1]"
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+#, fuzzy
+msgid "Warning: Your password will expire in [_1] years"
+msgstr "Attention:  Votre mot de passe expirera dans [_1]"
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+#, fuzzy
+msgid "Warning: Your password will expire today"
+msgstr "Attention:  Votre mot de passe expirera dans [_1]"
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr "Mer."
@@ -9367,7 +8603,6 @@ msgstr "Mer."
 msgid "Week"
 msgstr "Semaine"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr "Semaine débutant le"
@@ -9384,13 +8619,11 @@ msgstr ""
 msgid "Weeks"
 msgstr "Semaines"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Poids"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Unité de poids"
@@ -9407,7 +8640,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9425,11 +8657,11 @@ msgstr "Fiche de traitement"
 msgid "Work order"
 msgstr "Fiche de traitement"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9472,16 +8704,10 @@ msgstr "Écriture de fin d'exercice complétée"
 msgid "Years"
 msgstr "Années"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Oui"
-
-#: UI/users/preferences.html:52
-#, fuzzy
-msgid "Your password will expire in [_1]"
-msgstr "Attention:  Votre mot de passe expirera dans [_1]"
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9508,7 +8734,7 @@ msgstr "Code Postal:"
 msgid "Zip/Postal Code"
 msgstr "Code Postal"
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9572,17 +8798,12 @@ msgstr "jours"
 msgid "debits"
 msgstr "débits"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9599,7 +8820,7 @@ msgstr ""
 msgid "done"
 msgstr "fait"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9627,8 +8848,6 @@ msgstr ""
 msgid "in months"
 msgstr "en mois"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9637,22 +8856,18 @@ msgstr ""
 msgid "in years"
 msgstr "en années"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr "est inférieur à 0"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr "est nul"
@@ -9677,7 +8892,6 @@ msgstr ""
 msgid "sent"
 msgstr "envoyé"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9702,8 +8916,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""
@@ -9725,6 +8937,13 @@ msgstr ""
 
 #~ msgid "Version"
 #~ msgstr "Version"
+
+#~ msgid "Warning:  Your password will expire in [_1]"
+#~ msgstr "Attention:  Votre mot de passe expirera dans [_1]"
+
+#, fuzzy
+#~ msgid "Your password will expire in [_1]"
+#~ msgstr "Attention:  Votre mot de passe expirera dans [_1]"
 
 #~ msgid "cash"
 #~ msgstr "comptant"

--- a/locale/po/hu.po
+++ b/locale/po/hu.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Hungarian (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,27 +15,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr "#Számlák"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr "%Csökk."
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr "(+) Maradványérték"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr "(-) Halmozott écs."
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr "(=) Nettó k.é."
@@ -48,12 +43,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -99,7 +90,6 @@ msgstr "Szállítók"
 msgid "AP Aging"
 msgstr "Szállító lejárati lista"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr "Szállító számla"
@@ -108,7 +98,6 @@ msgstr "Szállító számla"
 msgid "AP Invoices"
 msgstr "Szállító számlák"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -123,7 +112,6 @@ msgstr "Kifizetetlen szállítószámlák"
 msgid "AP Transaction"
 msgstr "Szállító tranzakció"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Szállító tranzakciók"
@@ -136,9 +124,7 @@ msgstr "Új szállító utalvány"
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -157,7 +143,6 @@ msgstr "Vevők"
 msgid "AR Aging"
 msgstr "Vevő lejárati lista"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr "Vevőszámla"
@@ -166,7 +151,6 @@ msgstr "Vevőszámla"
 msgid "AR Invoices"
 msgstr "Vevőszámlák"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -181,7 +165,6 @@ msgstr "Kifizetetlen vevőszámlák"
 msgid "AR Transaction"
 msgstr "Vevő tranzakció"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Vevő tranzakciók"
@@ -194,9 +177,7 @@ msgstr "Új vevő utalvány"
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -205,8 +186,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Vevő tranzakció"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -216,16 +195,11 @@ msgstr "Vevő/Szállító/Vegyes könyvelés összege"
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr "Hozzáférés megtagadva"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -251,38 +225,20 @@ msgstr "Hozzáférés megtagadva"
 msgid "Account"
 msgstr "Számla"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr "Számla leírása"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr "Számla címke"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr "Számla neve"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -303,23 +259,18 @@ msgstr "Számla neve"
 msgid "Account Number"
 msgstr "Számlaszám"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr "Számlaszám vége"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr "Számlaszám kezdete"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr "Számla megnevezése"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -359,17 +310,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -381,7 +330,7 @@ msgstr "Teljesítés alapján"
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr "Összesített értékcsökkenés"
 
@@ -409,12 +358,10 @@ msgstr "Aktív"
 msgid "Active On"
 msgstr "Aktív be"
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr "Aktív munkamenetek"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -437,11 +384,11 @@ msgstr "Új számla"
 msgid "Add Assembly"
 msgstr "Új saját termék"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr "Új eszköz"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr "Eszközosztály hozzáadása"
 
@@ -566,7 +513,6 @@ msgstr "Új vevőrendelés"
 msgid "Add Service"
 msgstr "Új szolgáltatás"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr "Új adóűrlap"
@@ -633,7 +579,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Frissítés"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -658,7 +603,6 @@ msgstr "Cím:"
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -668,12 +612,11 @@ msgstr "Címek"
 msgid "Adj"
 msgstr "Igazítás"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr "Korrigált alap"
 
@@ -693,8 +636,7 @@ msgstr ""
 msgid "Aged"
 msgstr "Lejárt"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr "Lejárati lista"
 
@@ -747,7 +689,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr "Lefoglalva"
@@ -756,11 +697,6 @@ msgstr "Lefoglalva"
 msgid "Allow Input"
 msgstr "Felülírható"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -794,14 +730,10 @@ msgstr "Felülírható"
 msgid "Amount"
 msgstr "Összeg"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr "Költségvetés összege"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -810,27 +742,21 @@ msgstr "Költségvetés összege"
 msgid "Amount Due"
 msgstr "Esedékes összeg"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr "Összegtől"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr "Az összeg nagyobb mint"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr "Az összeg kisebb mint"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -848,14 +774,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -874,17 +800,14 @@ msgstr ""
 msgid "Any"
 msgstr "Bármelyik"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr "Alkalmazott árengedmény"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr "Árengedmény a túlfizetésből"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr "Engedményadás"
@@ -893,13 +816,6 @@ msgstr "Engedményadás"
 msgid "Approval Status"
 msgstr "Jóváhagyás állapota"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -908,7 +824,6 @@ msgstr "Jóváhagyás állapota"
 msgid "Approve"
 msgstr "Jóváhagy"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -917,14 +832,12 @@ msgstr "Jóváhagy"
 msgid "Approved"
 msgstr "Jóváhagyva"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr "Jóváhagyta"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr "Jóváhagyva"
 
@@ -936,19 +849,16 @@ msgstr "Jóváhagyó aláírása"
 msgid "Apr"
 msgstr "Ápr."
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "Április"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr "Megszerzett érték"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -964,7 +874,6 @@ msgstr "Biztosan törölni akarja az ajánlatot"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -983,19 +892,17 @@ msgstr "Saját termékek készletre véve."
 msgid "Asset"
 msgstr "Eszköz"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr "Eszköz számla"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr "Eszközosztály"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1008,29 +915,26 @@ msgstr "Eszközosztály:"
 msgid "Asset Classes"
 msgstr "Eszközosztályok"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr "Eszköz értékcsökkenés"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr "Eszköz selejtezés jelentés"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr "Eszköz részleges selejtezés jelentés"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr "Eszköz címke"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1046,7 +950,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1144,8 +1047,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Aug."
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Augusztus"
 
@@ -1157,7 +1059,6 @@ msgstr ""
 msgid "Automatic"
 msgstr "Automatikus"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1171,7 +1072,6 @@ msgstr "Rendelkezésre álló adatbázisok"
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1184,7 +1084,6 @@ msgstr "Rendelkezésre álló többlet befizetések"
 msgid "Average Cost"
 msgstr "Átlag költség"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1218,8 +1117,6 @@ msgstr "Adatbázis mentése"
 msgid "Backup Roles"
 msgstr "Biztonsági mentés szabályok"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1234,7 +1131,6 @@ msgstr "Egyenleg"
 msgid "Balance Sheet"
 msgstr "Mérleg"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1255,7 +1151,6 @@ msgstr "Bankszámla"
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1266,7 +1161,6 @@ msgstr "Bankszámlák"
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1276,18 +1170,15 @@ msgstr "Pénznem"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr "Alap"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr "Köteg"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr "Köteg osztály"
@@ -1300,12 +1191,10 @@ msgstr "Köteg ellenőrző kódja"
 msgid "Batch Date"
 msgstr "Köteg dátuma"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr "Köteg leírása"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr "Köteg ID"
@@ -1322,13 +1211,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr "Köteg neve"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr "Köteg azonosító"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr "Köteg keresése"
@@ -1369,8 +1256,6 @@ msgstr ""
 msgid "Billion"
 msgstr "milliárd"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1417,17 +1302,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr "Költségvetés azonosító"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr "Büdzsé keresés eredményei"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr "Költségvetés eltérés riport"
@@ -1440,12 +1322,10 @@ msgstr "Költségvetés"
 msgid "Business"
 msgstr "Partnercsoport"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Adószám"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1455,12 +1335,10 @@ msgstr "Partnercsoport"
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1482,7 +1360,6 @@ msgstr "Partnercsoport elmentve!"
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1514,18 +1391,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr "Érvénytelenített számlát nem lehet még egyszer érvényteleníteni!"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr "Megszakítja a műveletet?"
 
@@ -1651,12 +1526,11 @@ msgstr "Jelszó megváltoztatása"
 msgid "Chargeable"
 msgstr "Számlázandó"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr "Táblázat ID"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Számlatükör"
 
@@ -1676,7 +1550,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "Készlet ellenőrzés"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr "Csekk (bankutalvány) előtag"
@@ -1705,7 +1578,7 @@ msgstr ""
 msgid "Class"
 msgstr "Osztály"
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr "Dátum törlése"
 
@@ -1717,9 +1590,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "Kitörölve"
 
@@ -1747,15 +1620,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Lezárt"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1770,8 +1641,6 @@ msgstr "Záró egyenleg"
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1786,22 +1655,18 @@ msgstr "A kód hiányzik!"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1813,39 +1678,31 @@ msgstr ""
 msgid "Company"
 msgstr "Társaság"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr "Társaság címe"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr "Társaság faxszáma"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Társaság neve"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr "Társaság telefonszáma"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1866,7 +1723,7 @@ msgstr "Erősítse meg a műveletet"
 msgid "Confirm!"
 msgstr "Erősítse meg!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr "Meglévő adattal való ütközés. Elképzelhető, hogy már megadta korábban?"
 
@@ -1884,7 +1741,6 @@ msgstr "Meglévő adattal való ütközés. Elképzelhető, hogy már megadta ko
 msgid "Contact"
 msgstr "Kapcsolat"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1900,7 +1756,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr "Kapcsolat információk"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1918,9 +1773,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1950,7 +1802,6 @@ msgstr ""
 msgid "Contra"
 msgstr "Ellen"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1958,10 +1809,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1992,20 +1839,16 @@ msgstr "Újba másol"
 msgid "Copy to New Name"
 msgstr "Új névbe másol"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Költség"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2021,26 +1864,20 @@ msgstr "Nem lehet elmenteni!"
 msgid "Could not transfer Inventory!"
 msgstr "Nem lehet a készletet áthelyezni!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr "Számlált"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2052,7 +1889,6 @@ msgstr ""
 msgid "Country"
 msgstr "Ország"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2065,7 +1901,7 @@ msgstr "Ország:"
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2073,11 +1909,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr "Köteg készítése"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr "Új cégadatbázis létrehozása?"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2105,8 +1941,6 @@ msgstr "Létrehozta"
 msgid "Created On"
 msgstr "Létrehozva"
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2114,17 +1948,14 @@ msgstr "Létrehozva"
 msgid "Credit"
 msgstr "Követel"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr "Hitel számla"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr "Hitel számlaszám"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr "Hitel számla"
@@ -2149,29 +1980,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr "Új kéziszámla korrekció"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr "Követel"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Pénznem"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2194,18 +2015,14 @@ msgstr "Pénznem"
 msgid "Currency"
 msgstr "Pénznem"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Aktuális"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2215,11 +2032,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2234,7 +2047,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Vevő"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2253,9 +2065,6 @@ msgstr "A vevő hiányzik az adatbázisból!"
 msgid "Customer Name"
 msgstr "Vevő neve"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2275,9 +2084,7 @@ msgstr "Vevő partner keresése"
 msgid "Customer missing!"
 msgstr "A vevő hiányzik!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2289,7 +2096,7 @@ msgstr "A vevő hiányzik az adatbázisból!"
 msgid "Customer/Vendor Accounts"
 msgstr "Vevő/Szállító számlák"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr "Écs."
 
@@ -2313,12 +2120,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr "Az adat nem került mentésre. Kérem próbálja újra."
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr "Az adatok nem kerültek mentésre.  Kérem frissítsen még egyszer."
 
@@ -2351,28 +2157,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr "Az adatbázis nem létezik."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2419,19 +2213,14 @@ msgstr ""
 msgid "Date"
 msgstr "Dátum"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr "Dátumformátum"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr "Mettől"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2453,7 +2242,6 @@ msgstr "Beérkezés dátuma"
 msgid "Date Reversed"
 msgstr "Visszahívás dátuma"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2517,8 +2305,6 @@ msgstr "Nap"
 msgid "Days"
 msgstr "Napok"
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2534,10 +2320,8 @@ msgstr "Új számlakorrekció"
 msgid "Debit Note"
 msgstr "Új kéziszámla korrekció"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2547,17 +2331,14 @@ msgstr "Tartozik"
 msgid "Dec"
 msgstr "Dec."
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "December"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2567,7 +2348,6 @@ msgstr "Levonás osztály"
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr "Levonás típusa"
@@ -2580,47 +2360,38 @@ msgstr "Alapértelmezett szállító"
 msgid "Default AR"
 msgstr "Alapértelmezett vevő"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr "Alapértelmezett ország"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr "Alapértelmezett email titkos másolat"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr "Alapértelmezett email másolat"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr "Alapértelmezett email feladó"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr "Alapértelmezett email címzett"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr "Alapértelmezett jelenthető"
@@ -2633,21 +2404,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "Alapbeállítások"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2665,7 +2429,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Törlés"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr "Köteg törlése"
@@ -2678,7 +2441,6 @@ msgstr "Nyelv törlése"
 msgid "Delete Schedule"
 msgstr "Ütemezés törlése"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr "Utalványok törlése"
@@ -2692,37 +2454,33 @@ msgstr ""
 msgid "Delivery"
 msgstr "Szállítás"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Szállítás dátuma"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr "Écs. alapja"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr "Écs. módja"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr "Écs. indul"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2744,20 +2502,17 @@ msgstr "Értékcsökkenés"
 msgid "Depreciate Through"
 msgstr "Értékcsökkentés ezen keresztül"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr "Értékcsökkenés"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr "Értékcsökkenési számla"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2768,46 +2523,7 @@ msgstr "Értékcsökkentés módszere"
 msgid "Depreciation Starts"
 msgstr "Értékcsökkenés kezdete"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2918,12 +2634,10 @@ msgstr "Részletek"
 msgid "Details"
 msgstr "Részletek"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr "Vissza gomb letiltása"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr "Árk"
@@ -2936,7 +2650,6 @@ msgstr "Árk"
 msgid "Disc %"
 msgstr "Kedv.%"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2945,7 +2658,6 @@ msgstr "Kedv.%"
 msgid "Discount"
 msgstr "Engedmény"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr "Engedmény (%)"
@@ -2954,28 +2666,28 @@ msgstr "Engedmény (%)"
 msgid "Discount:"
 msgstr "Engedmény:"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr "Selejtezés"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr "Selejtezés dátuma"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr "Selejtezés módja"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr "Nullával osztás probléma"
 
@@ -2983,7 +2695,6 @@ msgstr "Nullával osztás probléma"
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr "Dokumentum"
@@ -2992,7 +2703,7 @@ msgstr "Dokumentum"
 msgid "Document Type"
 msgstr "Dokumentum típusa"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr "Nem tudom, mit kellene tennem a biztonsági mentéssel"
 
@@ -3000,12 +2711,10 @@ msgstr "Nem tudom, mit kellene tennem a biztonsági mentéssel"
 msgid "Done"
 msgstr "Elvégezve"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3018,12 +2727,10 @@ msgstr "Dr."
 msgid "Draft Posted"
 msgstr "A vázlat rögzítve"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr "Vázlat keresése"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr "Vázlat típusa"
@@ -3032,19 +2739,16 @@ msgstr "Vázlat típusa"
 msgid "Drafts"
 msgstr "Vázlatok"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Rajz"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr "Legördülők"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3060,10 +2764,6 @@ msgstr "Legördülők"
 msgid "Due"
 msgstr "Esedékes"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3082,7 +2782,7 @@ msgstr "Esedékesség hiányzik!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3108,7 +2808,7 @@ msgstr "E-mail üzenet"
 msgid "E-mailed"
 msgstr "E-mail elküldve"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr "ECA eredménykimutatás"
 
@@ -3138,7 +2838,7 @@ msgstr "Vevő tranzakció szerkesztése"
 msgid "Edit Assembly"
 msgstr "Saját termék szerkesztése"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr "Eszközosztály szerkesztése"
 
@@ -3282,8 +2982,6 @@ msgstr ""
 msgid "Email"
 msgstr "Email"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3297,7 +2995,6 @@ msgstr "Email"
 msgid "Employee"
 msgstr "Alkalmazott"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3307,12 +3004,11 @@ msgstr "Alkalmazott azonosítója"
 msgid "Employee Search"
 msgstr "Alkalmazott keresése"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3322,37 +3018,26 @@ msgstr "Alkalmazott azonosítója"
 msgid "Employees"
 msgstr "Alkalmazottak"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3376,7 +3061,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr "Záró egyenleg"
@@ -3401,12 +3085,10 @@ msgstr "Készlet bevitel"
 msgid "Enter User"
 msgstr "Felhasználó bevitel"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3416,7 +3098,7 @@ msgstr "Rögzítette"
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr "Felrögzítve"
 
@@ -3424,7 +3106,6 @@ msgstr "Felrögzítve"
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr "Egyed"
@@ -3450,7 +3131,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Egység kódja"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr "Bejegyzés ID"
 
@@ -3462,14 +3143,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Tőke"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3483,16 +3161,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr "Hiba történt a biztonsági mentés fájl létrehozása során"
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr "Hiba történt a köteg létrehozásakor. Kérem próbálja újra."
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr "Hiba a funkcióban:"
 
@@ -3500,7 +3177,7 @@ msgstr "Hiba a funkcióban:"
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr "Hiba: Más legördülő menü nem tartalmazhatja a gyűjtőszámlát"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr "Becsült élettartam"
 
@@ -3513,8 +3190,6 @@ msgstr "Minden"
 msgid "Exch"
 msgstr "Árf"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3529,7 +3204,6 @@ msgstr "Átváltási árfolyam"
 msgid "Exchange rate for payment missing!"
 msgstr "A fizetett összeg átváltási árfolyama hiányzik!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3538,7 +3212,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "Az átváltási árfolyam hiányzik!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr "Várt"
@@ -3556,13 +3229,10 @@ msgstr "Költségszámla"
 msgid "Expense/Asset"
 msgstr "Ktg./Eszköz"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3640,8 +3310,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb."
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Február"
 
@@ -3657,14 +3326,10 @@ msgstr "ötven"
 msgid "File"
 msgstr "Fájl"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr "Importált fájl"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3675,11 +3340,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr "Fájl neve"
 
@@ -3690,7 +3355,6 @@ msgstr "Fájl neve"
 msgid "File type"
 msgstr "Fájl típusa"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr "Fájlok"
@@ -3748,12 +3412,10 @@ msgstr "Tárgyi eszközök"
 msgid "For"
 msgstr "Ismétlés"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Árfolyamnyereség"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Árfolyamveszteség"
@@ -3762,12 +3424,10 @@ msgstr "Árfolyamveszteség"
 msgid "Form"
 msgstr "Űrlap"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3784,7 +3444,6 @@ msgstr "négy"
 msgid "Fourteen"
 msgstr "tizennégy"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3803,18 +3462,10 @@ msgstr ""
 msgid "From"
 msgstr "Mettől"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3835,7 +3486,6 @@ msgstr "Kezdő fájl"
 msgid "From Warehouse"
 msgstr "Raktárból"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr "Kezdő dátum"
@@ -3846,15 +3496,10 @@ msgstr "Kezdő dátum"
 msgid "Full"
 msgstr "Teljes"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr "Teljes jogosultság"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3868,10 +3513,8 @@ msgstr "Teljes jogosultság"
 msgid "GIFI"
 msgstr "Gyűjtőkód"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3892,7 +3535,6 @@ msgstr "Gyűjtőkód elmentve!"
 msgid "GL"
 msgstr "Vegyes Könyvelés"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr "Vegyes könyvelés referenciaszám"
@@ -3901,7 +3543,7 @@ msgstr "Vegyes könyvelés referenciaszám"
 msgid "Gain"
 msgstr "Nyereség"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr "Nyereség (veszteség)"
 
@@ -3909,12 +3551,11 @@ msgstr "Nyereség (veszteség)"
 msgid "Gain Account"
 msgstr "Nyereség számla"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 #, fuzzy
 msgid "Gain/Loss"
 msgstr "Nyereség (veszteség)"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3923,7 +3564,7 @@ msgstr ""
 msgid "General Journal"
 msgstr "Főkönyv"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr "Főkönyvi jelentés"
 
@@ -3931,9 +3572,8 @@ msgstr "Főkönyvi jelentés"
 msgid "General Ledger Reports"
 msgstr "Főkönyvi jelentés"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr "Generálás"
 
@@ -3949,7 +3589,7 @@ msgstr "Rendelések készítése"
 msgid "Generate Purchase Orders"
 msgstr "Beszerzési rendelés készítése"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3957,7 +3597,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr "Értékesítési rendelések készítése"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3973,12 +3613,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr "Cikkek és szolgáltatások"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3987,7 +3625,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr "Végösszeg"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4061,21 +3698,6 @@ msgstr "Óra"
 msgid "Hundred"
 msgstr "száz"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4106,7 +3728,6 @@ msgstr ""
 msgid "Identification"
 msgstr "Azonosítás"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4116,13 +3737,11 @@ msgstr "Évzárás figyelmen kívül hagyása"
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Kép"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr "Képek a sablonokban"
@@ -4165,7 +3784,6 @@ msgstr ""
 msgid "In"
 msgstr "-ben"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4199,14 +3817,10 @@ msgstr "Mely tranzakció(k)-nál lehessen kiválasztani?:"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr "Cikkszámmal"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4214,12 +3828,10 @@ msgstr "Cikkszámmal"
 msgid "Income"
 msgstr "Árbevétel"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr "Jövedelem osztály"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4230,7 +3842,6 @@ msgstr "Eredménykimutatás"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr "Jövedelem típusa"
@@ -4240,7 +3851,6 @@ msgstr "Jövedelem típusa"
 msgid "Income statement"
 msgstr "Eredménykimutatás"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4260,11 +3870,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr "Belső adatbázis hiba"
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4274,30 +3883,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "Belső feljegyzés"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr "Valótlan jelentés alap"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr "Érvénytelen biztonsági mentés kérés"
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr "Érvénytelen dátum/idő lett megadva"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr "Érvénytelen a kimutatás egyenlege.  Tipp: Próbáljon bevinni egy számot"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4307,17 +3912,14 @@ msgstr "Készlet"
 msgid "Inventory Activity"
 msgstr "Készletmozgások"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr "Készlet korrekció részletei"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr "Készlet korrekció"
@@ -4347,11 +3949,7 @@ msgstr "Készlet elmentve!"
 msgid "Inventory transferred!"
 msgstr "Készlet áthelyezve!"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4393,8 +3991,6 @@ msgstr "Számla kelte"
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4410,11 +4006,6 @@ msgstr "A teljesítés dátuma hiányzik!"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4433,7 +4024,6 @@ msgstr "Számlaszám"
 msgid "Invoice Number missing!"
 msgstr "Számlaszám hiányzik!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr "Számla nyereség/veszteség"
@@ -4463,12 +4053,10 @@ msgstr "Fizetés dátuma"
 msgid "Invoice not found"
 msgstr "A számla nem található"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4526,8 +4114,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Jan."
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Január"
 
@@ -4556,8 +4143,7 @@ msgstr "Napló sorok"
 msgid "Jul"
 msgstr "Júl."
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Július"
 
@@ -4565,8 +4151,8 @@ msgstr "Július"
 msgid "Jun"
 msgstr "Jún."
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Június"
 
@@ -4579,10 +4165,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "LaTeX sablonok"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4604,15 +4186,12 @@ msgstr "Művelet"
 msgid "Labor/Service Code"
 msgstr "Művelet/Szolgáltatáskód"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Nyelv"
@@ -4633,7 +4212,6 @@ msgstr "Nincsenek megadva nyelvek!"
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4644,7 +4222,6 @@ msgstr "Utolsó beszerzési ár"
 msgid "Last Name"
 msgstr "Vezetékneve"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr "Utolsó módosítás"
@@ -4666,40 +4243,39 @@ msgstr "Átfutási idő"
 msgid "Leadtime"
 msgstr "Átfutási idő"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4711,9 +4287,7 @@ msgstr "LedgerSMB adatbázis statisztika"
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4735,9 +4309,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4751,8 +4323,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr "Levélfejléc"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4769,7 +4339,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr "Élettartam mértékegysége"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4806,7 +4375,6 @@ msgstr "Nyelvlista"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4832,7 +4400,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr "Raktárlista"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4850,7 +4417,6 @@ msgstr "Hely"
 msgid "Locations"
 msgstr "Címek"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4871,7 +4437,7 @@ msgstr ""
 msgid "Login"
 msgstr "Belépés"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4899,45 +4465,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Gyártmány"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr "Felhasználók kezelése"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4959,40 +4518,34 @@ msgstr "Kézi"
 msgid "Mar"
 msgstr "Márc."
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Március"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Árrés"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr "Max. bejegyzés a legördülő listában"
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "Máj."
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Megjegyzés"
@@ -5009,7 +4562,6 @@ msgstr "Üzenet"
 msgid "Message: "
 msgstr "Üzenet:"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Módszer"
@@ -5018,7 +4570,6 @@ msgstr "Módszer"
 msgid "Method Default"
 msgstr "Alapértelmezett mód"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5037,14 +4588,11 @@ msgstr "Középső neve"
 msgid "Million"
 msgstr "millió"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5058,7 +4606,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr "Min. adóköteles"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5071,14 +4618,12 @@ msgstr "Nem egyező tranzakciók (feltöltésből)"
 msgid "Miss."
 msgstr "Kisasszony"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Modell"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5096,7 +4641,7 @@ msgstr "Hónap"
 msgid "Months"
 msgstr "Hónapok"
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr "További információk találhatók a hibanaplóban"
 
@@ -5120,14 +4665,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5136,15 +4679,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5163,7 +4697,6 @@ msgstr "Név"
 msgid "Name:"
 msgstr "Név:"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr "Nettó könyv szerinti érték"
@@ -5214,8 +4747,6 @@ msgstr "Következő dátum"
 msgid "Next Number"
 msgstr "Következő azonosító"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5237,12 +4768,10 @@ msgstr "tizenkilenc"
 msgid "Ninety"
 msgstr "kilencven"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Nem"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr "Nincs kiválasztva vevő vagy szállító számla"
@@ -5251,7 +4780,7 @@ msgstr "Nincs kiválasztva vevő vagy szállító számla"
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5259,11 +4788,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr "Nincs beállítva ID"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5271,7 +4800,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5282,11 +4810,11 @@ msgstr ""
 "Nincsenek beállítva pénznemek. Kérem állítson be pénznemeket a Rendszer/"
 "Alapbeállítások menüpont alatt."
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr "Nem töltődött fel fájl"
 
@@ -5294,21 +4822,18 @@ msgstr "Nem töltődött fel fájl"
 msgid "No open Projects!"
 msgstr "Nincs nyitott projekt!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr "Nincs kiválasztva túlfizetés számla.  Létezik ilyen számla egyébként?"
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5327,12 +4852,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5341,12 +4864,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr "Nem raktározott tétel"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5384,11 +4905,6 @@ msgstr "Megjegyzés osztálya"
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5434,23 +4950,18 @@ msgstr "Nincs mit áthelyezni!"
 msgid "Nov"
 msgstr "Nov."
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "November"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5481,7 +4992,7 @@ msgstr ""
 msgid "Number"
 msgstr "Azonosító"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Számformátum"
 
@@ -5502,13 +5013,11 @@ msgstr "Rk"
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Elavult"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr "Elavultatta"
@@ -5517,8 +5026,7 @@ msgstr "Elavultatta"
 msgid "Oct"
 msgstr "Okt."
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Október"
 
@@ -5530,9 +5038,6 @@ msgstr "Elenged"
 msgid "Old Password"
 msgstr "Régi jelszó"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5582,7 +5087,6 @@ msgstr ""
 msgid "Open"
 msgstr "Nyitott"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5605,9 +5109,6 @@ msgstr "Vagy"
 msgid "Or Add To Batch"
 msgstr "Vagy hozzáadás köteghez"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5653,7 +5154,6 @@ msgstr "A rendelés dátuma hiányzik!"
 msgid "Order Entry"
 msgstr "Rendelések"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5675,7 +5175,6 @@ msgstr "Rendelés törölve!"
 msgid "Order generation failed!"
 msgstr "Sikertelen rendelés készítés!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5697,7 +5196,7 @@ msgstr "A rendelések elkészültek!"
 msgid "Other Actions"
 msgstr "Egyéb műveletek"
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr "Saját egyenleg"
 
@@ -5743,7 +5242,6 @@ msgstr "Túlfizetés"
 msgid "Overpayment Account"
 msgstr "Túlfizetés számla"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5762,10 +5260,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr "BR #"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5809,11 +5303,6 @@ msgstr "Szállítólevél száma hiányzik!"
 msgid "Packing list"
 msgstr "Szállítólevél"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5831,12 +5320,10 @@ msgstr "Fizetve"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Cikk"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5846,14 +5333,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5885,14 +5364,10 @@ msgstr "Részletek"
 msgid "Partial"
 msgstr "Részleges"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5908,15 +5383,12 @@ msgstr "Cikkszám"
 msgid "Parts"
 msgstr "Cikk"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr "Cikkcsoport"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5926,7 +5398,6 @@ msgstr ""
 msgid "Password"
 msgstr "Jelszó"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5939,7 +5410,6 @@ msgstr "A jelszavaknak egyezniük kell."
 msgid "Pay From"
 msgstr "Fizetés innen"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5953,7 +5423,6 @@ msgstr "Fizetés az ő nevében"
 msgid "Payables"
 msgstr "Kötelezettségek"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5962,7 +5431,6 @@ msgstr "Kötelezettségek"
 msgid "Payment"
 msgstr "Kifizetés"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr "Kifizetés értéke"
@@ -5975,7 +5443,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr "Kifizetés feldolgozása"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr "Fizetési eredmények"
@@ -5992,7 +5459,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6030,15 +5496,15 @@ msgstr ""
 "Az érvénytelenített számlához tartozó fizetési tételeket korrigálni kell "
 "majd, pl. visszautalni, kivezetni!"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr "Százalék"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr "Selejtezés százaléka"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr "Maradék százalék"
 
@@ -6057,7 +5523,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr "Személy"
@@ -6088,108 +5553,88 @@ msgstr "Kitárolási lista"
 msgid "Pick list"
 msgstr "Kitárolási lista"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6205,7 +5650,6 @@ msgstr "Kérem adja meg az árat és szállítási határidőt a következő té
 msgid "Please select a customer with unused overpayments"
 msgstr "Kérem válasszon ki egy vevőt fel nem használt túlfizetéssel"
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6214,24 +5658,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr "Kérem válasszon ki egy szállítót fel nem használt túlfizetéssel"
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6240,13 +5682,11 @@ msgstr ""
 msgid "Post"
 msgstr "Rögzítés"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr "Köteg rögzítése"
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr "Rögzítés dátuma"
 
@@ -6287,7 +5727,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Postscript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6325,20 +5764,16 @@ msgstr "Előtag"
 msgid "Price"
 msgstr "Ár"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6374,8 +5809,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6385,7 +5818,6 @@ msgstr ""
 msgid "Print"
 msgstr "Nyomtatás"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6402,7 +5834,7 @@ msgstr "Újként nyomtat és ment"
 msgid "Printed"
 msgstr "Kinyomtatva"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Nyomtató"
 
@@ -6446,17 +5878,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr "Bevételek"
 
@@ -6485,7 +5915,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr "Nyereség/veszteség készlet értékesítéskor"
@@ -6504,7 +5933,6 @@ msgstr "Projekt megnevezések fordítása"
 msgid "Project Number"
 msgstr "Projekt azonosító"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6513,9 +5941,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Projektek"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6525,7 +5950,6 @@ msgstr "Vásárlás dátuma"
 msgid "Purchase Date:"
 msgstr "Vásárlás dátuma:"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6543,22 +5967,16 @@ msgstr "Beszerzési napló"
 msgid "Purchase Order"
 msgstr "Beszerzési rendelés"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "Beszerzési rendelés száma"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Beszerzési rendelések"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6573,14 +5991,10 @@ msgstr "Beszerzési érték:"
 msgid "Purchase order"
 msgstr "Beszerzési rendelés"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6611,7 +6025,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Menny."
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6625,8 +6038,6 @@ msgstr "A mennyiség meghaladja a készletet!"
 msgid "Quarter"
 msgstr "Negyedév"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6663,9 +6074,7 @@ msgstr "Az ajánlat azonosítója hiányzik!"
 msgid "Quotation deleted!"
 msgstr "Ajánlat törölve!"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6686,25 +6095,20 @@ msgstr "Ajánlatkérés"
 msgid "RFQ #"
 msgstr "Ajánlatkérés #"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "Ajánlatkérési azonosító"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "Ajánlatkérések"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "Újrarendelési pont"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6716,7 +6120,6 @@ msgstr "Árfolyam"
 msgid "Rate (%)"
 msgstr "Ráta (%)"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6739,13 +6142,9 @@ msgstr "Könyvelés újranyitása"
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6763,7 +6162,6 @@ msgstr "Befizetés"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6777,8 +6175,7 @@ msgstr "Befizetések"
 msgid "Receivables"
 msgstr "Követelések"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Bevételezés"
 
@@ -6786,7 +6183,6 @@ msgstr "Bevételezés"
 msgid "Receive Merchandise"
 msgstr "Áru érkeztetés"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr "Befolyt"
@@ -6807,7 +6203,6 @@ msgstr "Egyeztetés"
 msgid "Reconciliation Report"
 msgstr "Egyeztető Lista"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6828,13 +6223,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Ismétlődő tranzakciók"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6873,12 +6261,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr "Visszautasít"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr "Maradék élettartam"
@@ -6916,7 +6302,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr "Eredmények listája"
 
@@ -6928,7 +6314,7 @@ msgstr "Jelentés elküldve"
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6941,7 +6327,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr "Jelentés alapja"
@@ -6991,7 +6376,7 @@ msgstr "Olvasási visszaigazolás kérése"
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -7011,13 +6396,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Kért kiszállítás"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr "Nincs megadva elegendő adat"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7047,7 +6429,6 @@ msgstr "Vissza a bejelentkező képernyőre."
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7056,7 +6437,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7073,7 +6453,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr "Fordított kifizetés"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr "Fordított pénzmozgások"
@@ -7123,11 +6502,11 @@ msgstr "SKU"
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7153,7 +6532,6 @@ msgstr "Értékesítés"
 msgid "Sales Invoice"
 msgstr "Új vevőszámla"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Vevőszámla/tranzakció azonosító"
@@ -7169,20 +6547,17 @@ msgstr "Vevőszámla/tranzakció azonosító"
 msgid "Sales Order"
 msgstr "Vevőrendelés"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "Vevőrendelés azonosító"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Vevőrendelések"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "Ajánlat azonosító"
@@ -7205,9 +6580,6 @@ msgstr "Megszólítás"
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7231,13 +6603,10 @@ msgstr "Megszólítás"
 msgid "Salvage Value:"
 msgstr "Maradványérték:"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7257,7 +6626,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7267,7 +6636,6 @@ msgstr "Mentés"
 msgid "Save As New"
 msgstr "Mentés újként"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr "Köteg mentése"
@@ -7326,11 +6694,10 @@ msgstr "Mentés újként"
 msgid "Save as new"
 msgstr "Mentés újként"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7353,10 +6720,8 @@ msgstr "Beütemez"
 msgid "Scheduled"
 msgstr "Ütemezve"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Képernyő"
 
@@ -7376,7 +6741,6 @@ msgstr "Képernyő"
 msgid "Search"
 msgstr "Keresés"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7385,7 +6749,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7438,11 +6801,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7454,11 +6817,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr "Egyeztető jelentések keresése"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7470,7 +6833,7 @@ msgstr "Jóváhagyásra váró tranzakciók keresése"
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr "Keresési jelentések"
 
@@ -7478,7 +6841,6 @@ msgstr "Keresési jelentések"
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7534,7 +6896,6 @@ msgstr "Válasszon txt, postscript vagy PDF formátumot!"
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr "Kiválasztott"
@@ -7543,9 +6904,6 @@ msgstr "Kiválasztott"
 msgid "Sell"
 msgstr "Eladás"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7599,13 +6957,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Szept."
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr "Jogok elkülönítése"
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "Szeptember"
 
@@ -7626,9 +6982,6 @@ msgstr "Sorozatszám"
 msgid "Serial No."
 msgstr "Sorozatszám"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7658,7 +7011,6 @@ msgstr "Szolgáltatás kód"
 msgid "Services"
 msgstr "Szolgáltatás"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 #, fuzzy
 msgid "Session Timeout (e.g. \"90 minutes\")"
@@ -7672,7 +7024,7 @@ msgstr "Munkamenetek"
 msgid "Setting"
 msgstr "Sorszám típusa"
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr "Beállítások"
 
@@ -7692,10 +7044,10 @@ msgstr "tizenhét"
 msgid "Seventy"
 msgstr "hetven"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Kiszállítás"
 
@@ -7722,10 +7074,6 @@ msgstr "Szállítási cím"
 msgid "Ship To:"
 msgstr "Szállítási cím:"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7786,10 +7134,6 @@ msgstr "A szállítás dátuma hiányzik!"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7831,7 +7175,6 @@ msgstr "Szállítás dátuma"
 msgid "Short"
 msgstr "Hiányzó"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7873,7 +7216,6 @@ msgstr "hatvan"
 msgid "Skip"
 msgstr "Kihagy"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr "Eladva"
@@ -7886,12 +7228,6 @@ msgstr "Néhány"
 msgid "Sort by"
 msgstr "Rendezve"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7918,7 +7254,6 @@ msgstr "Bizonylatszám"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr "Bizonylat induljon ezzel"
@@ -7940,21 +7275,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Standard"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "TEÁOR/SZJ kód (SIC)"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7986,8 +7310,6 @@ msgstr "Kezdje használni a LedgerSMB-t"
 msgid "Startdate"
 msgstr "Kezdő dátum"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8024,13 +7346,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Kimutatás"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Kimutatás egyenlege"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8061,7 +7381,7 @@ msgstr "Saját termék bevét"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Stíluslap"
 
@@ -8086,7 +7406,6 @@ msgstr "Elküldés státusza"
 msgid "Submit"
 msgstr "Elküldés"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8129,7 +7448,6 @@ msgstr "Összegzés"
 msgid "Summary account for"
 msgstr "Gyűjtőszámla"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr "Vas"
@@ -8162,12 +7480,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr "Végösszeg"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8179,9 +7491,6 @@ msgstr "Címke"
 msgid "Tag:"
 msgstr "Címke:"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8200,8 +7509,6 @@ msgstr "Adó számla"
 msgid "Tax Code"
 msgstr "Adó kód"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8212,17 +7519,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr "Adóűrlap"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr "Adó űrlapok listája"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8366,7 +7670,6 @@ msgstr ""
 msgid "Template"
 msgstr "Sablonok"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8375,7 +7678,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8428,7 +7730,7 @@ msgstr "Köszönjük hogy nálunk vásárolt!"
 msgid "The amount of"
 msgstr "Az összeg"
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr "Partner egyenlege"
 
@@ -8440,7 +7742,7 @@ msgstr "Partner hitele"
 msgid "Their Debits"
 msgstr "Partner tartozása"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8492,24 +7794,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr "Ezt a dokumentumot jóváhagyta"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr "Ez a vegyes könyvelési tétel egy pénzmozgásos tranzakció következménye"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr "Ez könyvelési tétel mozgás egy túlfizetéses tranzakció eredménye"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8532,14 +7831,10 @@ msgstr "Küszöb"
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8583,7 +7878,6 @@ msgstr "Munkalap"
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr "Időkártyák"
@@ -8613,19 +7907,10 @@ msgstr ""
 msgid "To"
 msgstr "Meddig"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8662,7 +7947,6 @@ msgstr "Email küldés"
 msgid "To my browser"
 msgstr "Böngészőbe küldés"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr "Fizetendő"
@@ -8687,16 +7971,7 @@ msgstr ""
 msgid "Top-level"
 msgstr "Legfelső szint"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8739,7 +8014,7 @@ msgstr "Legfelső szint"
 msgid "Total"
 msgstr "Végösszeg"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr "Összesített écs."
 
@@ -8747,7 +8022,6 @@ msgstr "Összesített écs."
 msgid "Total Outstanding"
 msgstr "Összes kintlévőség"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8768,7 +8042,6 @@ msgstr "Tranzakció"
 msgid "Transaction Approval"
 msgstr "Tranzakció jóváhagyás"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8784,14 +8057,12 @@ msgstr "Tranzakció dátuma hiányzik!"
 msgid "Transaction Dates"
 msgstr "Tranzakció dátumok"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr "Tranzakció típusa"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8830,7 +8101,6 @@ msgstr "Fordítások"
 msgid "Translations saved!"
 msgstr "A fordítások mentése megtörtént!"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Főkönyvi kivonat"
@@ -8839,7 +8109,6 @@ msgstr "Főkönyvi kivonat"
 msgid "Trillion"
 msgstr "billió"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8896,10 +8165,6 @@ msgstr "huszonkettő"
 msgid "Two"
 msgstr "kettő"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8934,39 +8199,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr "Egyedi vevőszámla azonosítók"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr "Egyedi vevő azonosító"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr "Egyedi szállító azonosító"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr "Egyedi élő cikkszám"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8985,43 +8244,37 @@ msgstr "Egység"
 msgid "Unit Price"
 msgstr "Egységár"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr "Ismeretlen adatbázist találtam."
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9029,23 +8282,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr "Nem támogatott szám"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr "Nem támogatott számla típus"
@@ -9062,7 +8310,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9090,21 +8337,16 @@ msgstr "Frissítési információk"
 msgid "Upload"
 msgstr "Feltöltés"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9113,7 +8355,6 @@ msgstr ""
 msgid "Url"
 msgstr "Link"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9131,24 +8372,19 @@ msgstr "Saját túlfizetés használata"
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr "Használja a túlfizetést/előutalást"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr "Használt"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9158,7 +8394,6 @@ msgstr "Felhasználó"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr "A felhasználó már létezik. Beolvassa az adatait?"
@@ -9179,7 +8414,6 @@ msgstr "Felhasználónév"
 msgid "Users"
 msgstr "Felhasználók"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9205,8 +8439,6 @@ msgstr "Érvényesség"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9216,11 +8448,7 @@ msgstr "Eltérés"
 msgid "Variance:"
 msgstr "Eltérés:"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9236,7 +8464,6 @@ msgstr "Eltérés:"
 msgid "Vendor"
 msgstr "Szállító"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9250,7 +8477,6 @@ msgstr "Szállító történet"
 msgid "Vendor Invoice"
 msgstr "Új beszerzési számla"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr "Szállító számla/tranzakció azonosító"
@@ -9260,9 +8486,6 @@ msgstr "Szállító számla/tranzakció azonosító"
 msgid "Vendor Name"
 msgstr "Szállító neve"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9292,9 +8515,7 @@ msgstr "Szállító partner keresése"
 msgid "Vendor missing!"
 msgstr "Hiányzik a szállító!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9302,8 +8523,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "A szállító nincs az adatbázisban!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9318,7 +8537,6 @@ msgstr ""
 msgid "Void"
 msgstr "Érvénytelenít"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr "Utalványok"
@@ -9331,7 +8549,6 @@ msgstr "Utalványok"
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9354,7 +8571,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Raktárak"
@@ -9363,11 +8579,26 @@ msgstr "Raktárak"
 msgid "Warning!"
 msgstr "Figyelmeztetés!"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9377,7 +8608,6 @@ msgstr ""
 msgid "Week"
 msgstr "Hét"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9394,13 +8624,11 @@ msgstr ""
 msgid "Weeks"
 msgstr "Hetek"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Súly"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Súlyegység"
@@ -9417,7 +8645,6 @@ msgstr "Hová küldjük a biztonsági mentést?"
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9435,11 +8662,11 @@ msgstr "Munka rendelés"
 msgid "Work order"
 msgstr "Munka rendelés"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9482,15 +8709,10 @@ msgstr "Evzárás elvégezve"
 msgid "Years"
 msgstr "Évek"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Igen"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9517,7 +8739,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr "Irányítószám"
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9581,17 +8803,12 @@ msgstr "nap"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr "törlés"
 
@@ -9608,7 +8825,7 @@ msgstr ""
 msgid "done"
 msgstr "elvégezve"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9636,8 +8853,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9646,22 +8861,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr "nagyobb, mint a rendelkezésre álló összeg"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr "kevesebb mint 0"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr "kevesebb, mint a valós fizetés értéke"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr "nulla"
@@ -9686,7 +8897,6 @@ msgstr ""
 msgid "sent"
 msgstr "elküldve"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 #, fuzzy
 msgid "system type"
@@ -9712,8 +8922,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr "váratlan hiba!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr "felhasznál egy túlfizetést"

--- a/locale/po/id.po
+++ b/locale/po/id.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Indonesian (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,27 +15,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -48,12 +43,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -99,7 +90,6 @@ msgstr "Hutang"
 msgid "AP Aging"
 msgstr "Umur Hutang"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -108,7 +98,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -123,7 +112,6 @@ msgstr "Hutang Belum Lunas"
 msgid "AP Transaction"
 msgstr "Transkasi Hutang"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Transkasi Hutang"
@@ -136,9 +124,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -157,7 +143,6 @@ msgstr "Piutang"
 msgid "AR Aging"
 msgstr "Umur Piutang"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -166,7 +151,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -181,7 +165,6 @@ msgstr "Piutang Belum Lunas"
 msgid "AR Transaction"
 msgstr "Transaksi Piutang"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Transaksi Piutang"
@@ -194,9 +177,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -205,8 +186,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Transaksi Piutang"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -216,16 +195,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr "Akses ditolak"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -251,38 +225,20 @@ msgstr "Akses ditolak"
 msgid "Account"
 msgstr "Akun"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr "Deskripsi Akun"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr "Label Akun"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr "Nama Akun"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -303,23 +259,18 @@ msgstr "Nama Akun"
 msgid "Account Number"
 msgstr "Nomor Akun"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr "No. Akun Awal"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr "No.Akun Awal"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr "Judul Akun"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -359,17 +310,15 @@ msgstr "Akun Awal"
 msgid "Accounts To"
 msgstr "Akun Akhir"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -381,7 +330,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -409,12 +358,10 @@ msgstr "Aktif"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -437,11 +384,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr "Tambah Rakitan"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -566,7 +513,6 @@ msgstr "Tambah Pesanan Penjualan (SO)"
 msgid "Add Service"
 msgstr "Tambah Jasa"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -633,7 +579,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Diupdate"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -658,7 +603,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -668,12 +612,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -693,8 +636,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -747,7 +689,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -756,11 +697,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -794,14 +730,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Jumlah"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -810,27 +742,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Jumlah Terhutang"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -848,14 +774,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -874,17 +800,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -893,13 +816,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -908,7 +824,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -917,14 +832,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -936,19 +849,16 @@ msgstr ""
 msgid "Apr"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "April"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -964,7 +874,6 @@ msgstr "Apakah anda yakin akan menghapus Nomor Quotasi"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -983,19 +892,17 @@ msgstr "Barang Rakitan telah di stock ulang!"
 msgid "Asset"
 msgstr "Aktiva"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1008,29 +915,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1046,7 +950,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1144,8 +1047,7 @@ msgstr ""
 msgid "Aug"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Agustus"
 
@@ -1157,7 +1059,6 @@ msgstr ""
 msgid "Automatic"
 msgstr "Otomatis"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1171,7 +1072,6 @@ msgstr "Database Tersedia"
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1184,7 +1084,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1218,8 +1117,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1234,7 +1131,6 @@ msgstr "Saldo"
 msgid "Balance Sheet"
 msgstr "Neraca"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1255,7 +1151,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1266,7 +1161,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1276,18 +1170,15 @@ msgstr "Mata Uang"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1300,12 +1191,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1322,13 +1211,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1369,8 +1256,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1416,17 +1301,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1439,12 +1321,10 @@ msgstr ""
 msgid "Business"
 msgstr "Bisnis"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Nomor Bisnis"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1454,12 +1334,10 @@ msgstr "Tipe Bisnis"
 msgid "Business Type:"
 msgstr "Tipe Bisnis:"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1481,7 +1359,6 @@ msgstr "Bisnis telah disimpan!"
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1513,18 +1390,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr "Batal"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr "Batalkan?"
 
@@ -1650,12 +1525,11 @@ msgstr "Ubah Password"
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Bagan Akun"
 
@@ -1675,7 +1549,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1704,7 +1577,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1716,9 +1589,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr ""
 
@@ -1746,15 +1619,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1768,8 +1639,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1784,22 +1653,18 @@ msgstr "Kode harap diisi!"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr "Kombinasi"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1811,39 +1676,31 @@ msgstr ""
 msgid "Company"
 msgstr "Perusahaan"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr "Alamat"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr "Fax"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr "Informasi"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Nama Perusahaan"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr "Telefon"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1864,7 +1721,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Konfirmasi!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1882,7 +1739,6 @@ msgstr ""
 msgid "Contact"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1898,7 +1754,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1916,9 +1771,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1948,7 +1800,6 @@ msgstr ""
 msgid "Contra"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1956,10 +1807,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1990,20 +1837,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Biaya"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2019,26 +1862,20 @@ msgstr "Tidak dapat menyimpan"
 msgid "Could not transfer Inventory!"
 msgstr "Tidak dapat mentransfer Inventory"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2050,7 +1887,6 @@ msgstr ""
 msgid "Country"
 msgstr "Negara"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr "Nama Negara"
@@ -2063,7 +1899,7 @@ msgstr "Negara:"
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2071,11 +1907,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2103,8 +1939,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2112,17 +1946,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Kredit"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2147,29 +1978,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Mata Uang"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2192,18 +2013,14 @@ msgstr "Mata Uang"
 msgid "Currency"
 msgstr "Mata Uang"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2213,11 +2030,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2232,7 +2045,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Pelanggan"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2251,9 +2063,6 @@ msgstr "Pelanggan tidak ditemukan!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2273,9 +2082,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "Pelanggan harap diisi!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2287,7 +2094,7 @@ msgstr "Pelanggan tidak ditemukan!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2311,12 +2118,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr "Data tidak tersimpan. Silahkan Coba kembali"
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr "Data tidak tersimpan. Silahkan tambah kembali"
 
@@ -2349,28 +2155,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2417,19 +2211,14 @@ msgstr ""
 msgid "Date"
 msgstr "Tanggal"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr "Format Tanggal"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2451,7 +2240,6 @@ msgstr "Tanggal Diterima"
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2515,8 +2303,6 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2532,10 +2318,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2545,17 +2329,14 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Desember"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2565,7 +2346,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2578,47 +2358,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2631,21 +2402,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "Default"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2663,7 +2427,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Hapus"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2676,7 +2439,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2690,37 +2452,33 @@ msgstr ""
 msgid "Delivery"
 msgstr "Pengiriman"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Tanggal Kirim"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2742,20 +2500,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2766,46 +2521,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2916,12 +2632,10 @@ msgstr "Detil"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2934,7 +2648,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2943,7 +2656,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Diskon"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2952,28 +2664,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2981,7 +2693,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr "Dokumen"
@@ -2990,7 +2701,7 @@ msgstr "Dokumen"
 msgid "Document Type"
 msgstr "Tipe Dokumen"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -2998,12 +2709,10 @@ msgstr ""
 msgid "Done"
 msgstr "Selesai"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3016,12 +2725,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3030,19 +2737,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3058,10 +2762,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3080,7 +2780,7 @@ msgstr "Tanggal Jatuh Tempo harap diisi!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3106,7 +2806,7 @@ msgstr ""
 msgid "E-mailed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3136,7 +2836,7 @@ msgstr "Edit Transaksi Piutang"
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3280,8 +2980,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3295,7 +2993,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Karyawan"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3305,12 +3002,11 @@ msgstr "Nomor Karyawan"
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3320,37 +3016,26 @@ msgstr "Nomor Karyawan"
 msgid "Employees"
 msgstr "Karyawan"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3374,7 +3059,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3399,12 +3083,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3414,7 +3096,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3422,7 +3104,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3448,7 +3129,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Nama Negara"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3460,14 +3141,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Modal"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3481,16 +3159,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3498,7 +3175,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3511,8 +3188,6 @@ msgstr ""
 msgid "Exch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3527,7 +3202,6 @@ msgstr "Kurs"
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3536,7 +3210,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "Kurs harap diisi!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3554,13 +3227,10 @@ msgstr "Akun Biaya"
 msgid "Expense/Asset"
 msgstr "Biaya/Aktiva"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3638,8 +3308,7 @@ msgstr ""
 msgid "Feb"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Februari"
 
@@ -3655,14 +3324,10 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3673,11 +3338,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3688,7 +3353,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3746,12 +3410,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Keuntungan Selisih Kurs"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Kerugian Selisih Kurs"
@@ -3760,12 +3422,10 @@ msgstr "Kerugian Selisih Kurs"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3782,7 +3442,6 @@ msgstr "Empat"
 msgid "Fourteen"
 msgstr "Empat Belas"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3801,18 +3460,10 @@ msgstr ""
 msgid "From"
 msgstr "Dari"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3833,7 +3484,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3844,15 +3494,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3866,10 +3511,8 @@ msgstr ""
 msgid "GIFI"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3890,7 +3533,6 @@ msgstr ""
 msgid "GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3899,7 +3541,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3907,12 +3549,11 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 #, fuzzy
 msgid "Gain/Loss"
 msgstr "Laba/Rugi"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3921,7 +3562,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3929,9 +3570,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3947,7 +3587,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3955,7 +3595,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3971,12 +3611,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3985,7 +3623,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4059,21 +3696,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4104,7 +3726,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4114,13 +3735,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4163,7 +3782,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4197,14 +3815,10 @@ msgstr "Tampilkan pada menu drop-down"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4212,12 +3826,10 @@ msgstr ""
 msgid "Income"
 msgstr "Pendapatan"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4228,7 +3840,6 @@ msgstr "Laba Rugi"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4238,7 +3849,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Laba Rugi"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4258,11 +3868,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4272,30 +3881,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4305,17 +3910,14 @@ msgstr ""
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4341,11 +3943,7 @@ msgstr "Inventory sudah disimpan!"
 msgid "Inventory transferred!"
 msgstr "Inventory sudah di-transfer"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4387,8 +3985,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4404,11 +4000,6 @@ msgstr "Tanggal Invoice harap diisi!"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4427,7 +4018,6 @@ msgstr "Nomor Invoice"
 msgid "Invoice Number missing!"
 msgstr "Nomor Invoice harap diisi"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4457,12 +4047,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4520,8 +4108,7 @@ msgstr ""
 msgid "Jan"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Januari"
 
@@ -4550,8 +4137,7 @@ msgstr ""
 msgid "Jul"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Juli"
 
@@ -4559,8 +4145,8 @@ msgstr "Juli"
 msgid "Jun"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Juni"
 
@@ -4573,10 +4159,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "Template LaTeX"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4598,15 +4180,12 @@ msgstr "Tenaga Kerja/ Overhead"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Bahasa"
@@ -4627,7 +4206,6 @@ msgstr "Bahasa tidak terdefinisi!"
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4638,7 +4216,6 @@ msgstr ""
 msgid "Last Name"
 msgstr "Nama Belakang"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4660,41 +4237,40 @@ msgstr ""
 msgid "Leadtime"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr "LedgerSMB 1.2 db tidak ditemukan."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr "LedgerSMB 1.3 db tidak ditemukan."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr "LedgerSMB 1.4 db tidak ditemukan."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr "LedgerSMB 1.5 db tidak ditemukan."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 #, fuzzy
 msgid "LedgerSMB 1.8 db found."
 msgstr "LedgerSMB 1.2 db tidak ditemukan."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 #, fuzzy
 msgid "LedgerSMB 1.9 db found."
 msgstr "LedgerSMB 1.2 db tidak ditemukan."
@@ -4707,9 +4283,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4731,9 +4305,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4747,8 +4319,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4765,7 +4335,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4802,7 +4371,6 @@ msgstr "Daftar Bahasa"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4828,7 +4396,6 @@ msgstr "Daftar Pengguna"
 msgid "List Warehouse"
 msgstr "Daftar Gudang"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4846,7 +4413,6 @@ msgstr "Lokasi"
 msgid "Locations"
 msgstr "Lokasi"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4867,7 +4433,7 @@ msgstr ""
 msgid "Login"
 msgstr "Masuk"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4895,45 +4461,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Pembuatan"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr "Pengaturan Pengguna/User"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4955,40 +4514,34 @@ msgstr ""
 msgid "Mar"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Maret"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr ""
@@ -5005,7 +4558,6 @@ msgstr "Pesan"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Metoda"
@@ -5014,7 +4566,6 @@ msgstr "Metoda"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5033,14 +4584,11 @@ msgstr "Nama Tengah"
 msgid "Million"
 msgstr "Juta"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5054,7 +4602,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5067,14 +4614,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Model"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5092,7 +4637,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5116,14 +4661,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5132,15 +4675,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5159,7 +4693,6 @@ msgstr "Nama"
 msgid "Name:"
 msgstr "Nama:"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5210,8 +4743,6 @@ msgstr ""
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5233,12 +4764,10 @@ msgstr "Sembilan Belas"
 msgid "Ninety"
 msgstr "Sembilan Puluh"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Tidak"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5247,7 +4776,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5255,11 +4784,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5267,7 +4796,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr "Tidak Ada Perubahan"
@@ -5276,11 +4804,11 @@ msgstr "Tidak Ada Perubahan"
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5288,21 +4816,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5321,12 +4846,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5335,12 +4858,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5378,11 +4899,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5428,23 +4944,18 @@ msgstr "Tidak ada yang akan di-transfer!"
 msgid "Nov"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "November"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5475,7 +4986,7 @@ msgstr ""
 msgid "Number"
 msgstr "Nomor"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Format Angka"
 
@@ -5496,13 +5007,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Kadaluarsa"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5511,8 +5020,7 @@ msgstr ""
 msgid "Oct"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Oktober"
 
@@ -5524,9 +5032,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5576,7 +5081,6 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5598,9 +5102,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5646,7 +5147,6 @@ msgstr "Tanggal Pesanan harap diisi!"
 msgid "Order Entry"
 msgstr "Pesanan"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5668,7 +5168,6 @@ msgstr "Pesanan sudah dihapus!"
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5690,7 +5189,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5736,7 +5235,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5755,10 +5253,6 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5801,11 +5295,6 @@ msgstr "Nomor Packing List harap diisi!"
 msgid "Packing list"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5823,12 +5312,10 @@ msgstr "Dibayar"
 msgid "Parent"
 msgstr "Induk"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Barang"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5838,14 +5325,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5875,14 +5354,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5898,15 +5373,12 @@ msgstr "Nomor Barang"
 msgid "Parts"
 msgstr "Barang"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5916,7 +5388,6 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5929,7 +5400,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5943,7 +5413,6 @@ msgstr ""
 msgid "Payables"
 msgstr "Hutang"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5952,7 +5421,6 @@ msgstr "Hutang"
 msgid "Payment"
 msgstr "Pembayaran"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5965,7 +5433,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5982,7 +5449,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6018,15 +5484,15 @@ msgstr "Pembayaran"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6045,7 +5511,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6076,108 +5541,88 @@ msgstr ""
 msgid "Pick list"
 msgstr "Daftar Harga"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6193,7 +5638,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6202,24 +5646,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6228,13 +5670,11 @@ msgstr ""
 msgid "Post"
 msgstr "Posting"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6275,7 +5715,6 @@ msgstr ""
 msgid "Postscript"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6312,20 +5751,16 @@ msgstr ""
 msgid "Price"
 msgstr "Harga"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6361,8 +5796,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6372,7 +5805,6 @@ msgstr ""
 msgid "Print"
 msgstr "Cetak"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6389,7 +5821,7 @@ msgstr ""
 msgid "Printed"
 msgstr "Sudah dicetak"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr ""
 
@@ -6433,17 +5865,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6473,7 +5903,6 @@ msgstr "Laba dan Rugi"
 msgid "Profit/Loss"
 msgstr "Laba/Rugi"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6492,7 +5921,6 @@ msgstr ""
 msgid "Project Number"
 msgstr "Nomor Proyek"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6501,9 +5929,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Proyek"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6513,7 +5938,6 @@ msgstr "Tanggal Pembelian"
 msgid "Purchase Date:"
 msgstr "Tanggal Pembelian:"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6531,22 +5955,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Pesanan Pembelian (PO)"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "Nomor Pesanan Pembelian (PO)"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Pesanan Pembelian (PO)"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6561,14 +5979,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Pesanan Pembelian (PO)"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6599,7 +6013,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Banyak"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr "Kuantiti"
@@ -6613,8 +6026,6 @@ msgstr "Jumlah melebihi unit yang tersedia pada inventory!"
 msgid "Quarter"
 msgstr "Kwartal"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6651,9 +6062,7 @@ msgstr "Nomor Quotation harap diisi!"
 msgid "Quotation deleted!"
 msgstr "Nomor Quotation sudah dihapus!"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6674,25 +6083,20 @@ msgstr ""
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6704,7 +6108,6 @@ msgstr ""
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 msgid "Rate Type"
 msgstr ""
@@ -6725,13 +6128,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6749,7 +6148,6 @@ msgstr "Penerimaan"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6763,8 +6161,7 @@ msgstr "Penerimaan"
 msgid "Receivables"
 msgstr "Piutang"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Penerimaan"
 
@@ -6772,7 +6169,6 @@ msgstr "Penerimaan"
 msgid "Receive Merchandise"
 msgstr "Penerimaan Barang"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6793,7 +6189,6 @@ msgstr "Rekonsiliasi"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6814,13 +6209,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6859,12 +6247,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6902,7 +6288,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6914,7 +6300,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6927,7 +6313,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6977,7 +6362,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -6997,13 +6382,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Tanggal Kirim"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7033,7 +6415,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7042,7 +6423,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr "Reversal"
@@ -7059,7 +6439,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7109,11 +6488,11 @@ msgstr ""
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7139,7 +6518,6 @@ msgstr "Penjualan"
 msgid "Sales Invoice"
 msgstr "Invoice Penjualan"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7155,20 +6533,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr "Pesanan Penjualan (SO)"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "Nomor Pesanan Penjualan (SO)"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Pesanan Penjualan (SO)"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "Nomor Sales Quotation"
@@ -7191,9 +6566,6 @@ msgstr "Nomor Sales Quotation"
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7217,13 +6589,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7243,7 +6612,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7253,7 +6622,6 @@ msgstr "Simpan"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7312,11 +6680,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "Simpan sbg yg baru"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7339,10 +6706,8 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Layar"
 
@@ -7362,7 +6727,6 @@ msgstr "Layar"
 msgid "Search"
 msgstr "Cari"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr "Cari Hutang"
@@ -7371,7 +6735,6 @@ msgstr "Cari Hutang"
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr "Cari Piutang"
@@ -7424,11 +6787,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7440,11 +6803,11 @@ msgstr "Cari Penerimaan"
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7456,7 +6819,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7464,7 +6827,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7520,7 +6882,6 @@ msgstr "Pilih txt, postscript atau PDF!"
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7529,9 +6890,6 @@ msgstr ""
 msgid "Sell"
 msgstr "Jual"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7585,13 +6943,11 @@ msgstr ""
 msgid "Sep"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr ""
 
@@ -7612,9 +6968,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "No. Seri"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7644,7 +6997,6 @@ msgstr ""
 msgid "Services"
 msgstr "Jasa"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 msgid "Session Timeout (e.g. \"90 minutes\")"
 msgstr ""
@@ -7657,7 +7009,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7677,10 +7029,10 @@ msgstr "Tujuh belas"
 msgid "Seventy"
 msgstr "Tujuh puluh"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Kirim"
 
@@ -7707,10 +7059,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7771,10 +7119,6 @@ msgstr "Tanggal Pengiriman harap diisi!"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7816,7 +7160,6 @@ msgstr "Tanggal Pengiriman"
 msgid "Short"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7857,7 +7200,6 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7870,12 +7212,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7902,7 +7238,6 @@ msgstr "Bukti"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7924,21 +7259,10 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7969,8 +7293,6 @@ msgstr ""
 msgid "Startdate"
 msgstr "Tanggal Mulai"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8007,13 +7329,11 @@ msgstr ""
 msgid "Statement"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8044,7 +7364,7 @@ msgstr ""
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr ""
 
@@ -8069,7 +7389,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8112,7 +7431,6 @@ msgstr "Ringkasan"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8145,12 +7463,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8162,9 +7474,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8183,8 +7492,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8195,17 +7502,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8349,7 +7653,6 @@ msgstr ""
 msgid "Template"
 msgstr "Template LaTeX"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8358,7 +7661,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8411,7 +7713,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8423,7 +7725,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8474,24 +7776,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8514,14 +7813,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8565,7 +7860,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8595,19 +7889,10 @@ msgstr ""
 msgid "To"
 msgstr "Sampai"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8644,7 +7929,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8669,16 +7953,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8721,7 +7996,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8729,7 +8004,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8750,7 +8024,6 @@ msgstr "Transaksi"
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8766,14 +8039,12 @@ msgstr "Tanggal Transaksi harap diisi"
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8812,7 +8083,6 @@ msgstr ""
 msgid "Translations saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Neraca Percobaan"
@@ -8821,7 +8091,6 @@ msgstr "Neraca Percobaan"
 msgid "Trillion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8878,10 +8147,6 @@ msgstr "Dua Puluh Dua"
 msgid "Two"
 msgstr "Dua"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8916,39 +8181,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8967,43 +8226,37 @@ msgstr "Satuan"
 msgid "Unit Price"
 msgstr "Satuan Harga"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9011,23 +8264,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9044,7 +8292,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9072,21 +8319,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9095,7 +8337,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9113,24 +8354,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr "Digunakan"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9140,7 +8376,6 @@ msgstr "Pengguna"
 msgid "User Name"
 msgstr "Nama Pengguna"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9161,7 +8396,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9187,8 +8421,6 @@ msgstr "Valid hingga"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9198,11 +8430,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9218,7 +8446,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Supplier"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr "Akun Supplier"
@@ -9232,7 +8459,6 @@ msgstr "Historis Supplier"
 msgid "Vendor Invoice"
 msgstr "Invoice Supplier"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9242,9 +8468,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr "Nama Supplier"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9274,9 +8497,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "Data Supplier harap diisi!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9284,8 +8505,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Data Supplier tidak ditemukan!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9300,7 +8519,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9313,7 +8531,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9336,7 +8553,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Gudang"
@@ -9345,11 +8561,26 @@ msgstr "Gudang"
 msgid "Warning!"
 msgstr "Peringatan!"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9359,7 +8590,6 @@ msgstr ""
 msgid "Week"
 msgstr "Pekan"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr "Awal Pekan"
@@ -9376,13 +8606,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Berat"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Satuan Berat"
@@ -9399,7 +8627,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9416,11 +8643,11 @@ msgstr ""
 msgid "Work order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9463,15 +8690,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Ya"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9498,7 +8720,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9562,17 +8784,12 @@ msgstr "hari"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9589,7 +8806,7 @@ msgstr ""
 msgid "done"
 msgstr "selesai"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9617,8 +8834,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9627,22 +8842,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9667,7 +8878,6 @@ msgstr ""
 msgid "sent"
 msgstr "sudah dikirim"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9692,8 +8902,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/is.po
+++ b/locale/po/is.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Icelandic (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,27 +15,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n % 10 != 1 || n % 100 == 11);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -48,12 +43,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -99,7 +90,6 @@ msgstr "Innkaupakerfi"
 msgid "AP Aging"
 msgstr "Aldursgreining"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -108,7 +98,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -123,7 +112,6 @@ msgstr ""
 msgid "AP Transaction"
 msgstr "Innkaupafærsla"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Innkaupafærslur"
@@ -136,9 +124,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -157,7 +143,6 @@ msgstr "Sölukerfi"
 msgid "AR Aging"
 msgstr "Aldursgreining"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -166,7 +151,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -181,7 +165,6 @@ msgstr ""
 msgid "AR Transaction"
 msgstr "Sölufærsla"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Sölufærslur"
@@ -194,9 +177,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -205,8 +186,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Sölufærsla"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -216,16 +195,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -251,38 +225,20 @@ msgstr ""
 msgid "Account"
 msgstr "Reikningur"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -303,23 +259,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Reikningsnúmer"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -359,17 +310,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -381,7 +330,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -409,12 +358,10 @@ msgstr "Virkja"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -437,11 +384,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr "Ný samsetning"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -566,7 +513,6 @@ msgstr "Ný sölupöntun"
 msgid "Add Service"
 msgstr "Ný þjónusta"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -633,7 +579,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Uppfærsla"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -658,7 +603,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -668,12 +612,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -693,8 +636,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -747,7 +689,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -756,11 +697,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -794,14 +730,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Upphæð"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -810,27 +742,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Eindagi"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -848,14 +774,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -874,17 +800,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -893,13 +816,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -908,7 +824,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -917,14 +832,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -936,19 +849,16 @@ msgstr ""
 msgid "Apr"
 msgstr "apr"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "apríl"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -964,7 +874,6 @@ msgstr ""
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -983,19 +892,17 @@ msgstr "Samsetningar endurunnar"
 msgid "Asset"
 msgstr "Eignir"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1008,29 +915,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1046,7 +950,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1144,8 +1047,7 @@ msgstr ""
 msgid "Aug"
 msgstr "ágú"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "ágúst"
 
@@ -1157,7 +1059,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1171,7 +1072,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1184,7 +1084,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1218,8 +1117,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1234,7 +1131,6 @@ msgstr "Afstemming"
 msgid "Balance Sheet"
 msgstr "Staða"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1255,7 +1151,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1266,7 +1161,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1276,18 +1170,15 @@ msgstr "Gjaldmiðill"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1300,12 +1191,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1322,13 +1211,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1369,8 +1256,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1416,17 +1301,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1439,12 +1321,10 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Viðskiptanúmer"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1454,12 +1334,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1481,7 +1359,6 @@ msgstr ""
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1513,18 +1390,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1650,12 +1525,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Listi yfir lykkla/reikninga"
 
@@ -1675,7 +1549,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1704,7 +1577,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1716,9 +1589,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr ""
 
@@ -1746,15 +1619,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Lokað"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1768,8 +1639,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1784,22 +1653,18 @@ msgstr ""
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1811,39 +1676,31 @@ msgstr ""
 msgid "Company"
 msgstr "Fyritæki"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1864,7 +1721,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Staðfesta!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1882,7 +1739,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Talsmaður"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1898,7 +1754,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1916,9 +1771,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1948,7 +1800,6 @@ msgstr ""
 msgid "Contra"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1956,10 +1807,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1990,20 +1837,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2019,26 +1862,20 @@ msgstr ""
 msgid "Could not transfer Inventory!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2050,7 +1887,6 @@ msgstr ""
 msgid "Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2063,7 +1899,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2071,11 +1907,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2103,8 +1939,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2112,17 +1946,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Kredit"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2147,29 +1978,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Gjaldm"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2192,18 +2013,14 @@ msgstr "Gjaldm"
 msgid "Currency"
 msgstr "Gjaldmiðill"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Núvirði"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2213,11 +2030,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2232,7 +2045,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Viðskiptavinur"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2251,9 +2063,6 @@ msgstr "Viðskiptavinur ekki á skrá!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2273,9 +2082,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "Viðskiptavin vantar!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2287,7 +2094,7 @@ msgstr "Viðskiptavinur ekki á skrá!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2311,12 +2118,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2349,28 +2155,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2417,19 +2211,14 @@ msgstr ""
 msgid "Date"
 msgstr "Dagsetning"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2451,7 +2240,6 @@ msgstr ""
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2515,8 +2303,6 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2532,10 +2318,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2545,17 +2329,14 @@ msgstr ""
 msgid "Dec"
 msgstr "des"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "desember"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2565,7 +2346,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2578,47 +2358,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2631,21 +2402,14 @@ msgstr ""
 msgid "Defaults"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2663,7 +2427,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Eyða"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2676,7 +2439,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2690,37 +2452,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Afgreiðsludags."
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2742,20 +2500,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2766,46 +2521,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2916,12 +2632,10 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2934,7 +2648,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2943,7 +2656,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Afsláttur"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2952,28 +2664,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2981,7 +2693,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2990,7 +2701,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -2998,12 +2709,10 @@ msgstr ""
 msgid "Done"
 msgstr "Búið"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3016,12 +2725,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3030,19 +2737,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Dregið"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3058,10 +2762,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3080,7 +2780,7 @@ msgstr "Vantar dags. lokið!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3106,7 +2806,7 @@ msgstr ""
 msgid "E-mailed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3136,7 +2836,7 @@ msgstr ""
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3280,8 +2980,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3295,7 +2993,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Starfsmenn"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3305,12 +3002,11 @@ msgstr ""
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 msgid "Employee wage screen"
 msgstr ""
@@ -3319,37 +3015,26 @@ msgstr ""
 msgid "Employees"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3373,7 +3058,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3398,12 +3082,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3413,7 +3095,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3421,7 +3103,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3446,7 +3127,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3458,14 +3139,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Eigiðfé"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3479,16 +3157,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3496,7 +3173,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3509,8 +3186,6 @@ msgstr ""
 msgid "Exch"
 msgstr "Vx"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3525,7 +3200,6 @@ msgstr "Vextir"
 msgid "Exchange rate for payment missing!"
 msgstr "Vextir fyrir greiðslu vantar!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3534,7 +3208,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "Vantar vexti!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3552,13 +3225,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Kostnaður/Eignir"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3636,8 +3306,7 @@ msgstr ""
 msgid "Feb"
 msgstr "feb"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "febrúar"
 
@@ -3653,14 +3322,10 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3671,11 +3336,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3686,7 +3351,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3744,12 +3408,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Gengishagnaður"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Gengistap"
@@ -3758,12 +3420,10 @@ msgstr "Gengistap"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3780,7 +3440,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3799,18 +3458,10 @@ msgstr ""
 msgid "From"
 msgstr "Frá"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3831,7 +3482,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3842,15 +3492,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3864,10 +3509,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "GIFI"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3888,7 +3531,6 @@ msgstr "GIFI geymt!"
 msgid "GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3897,7 +3539,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3905,11 +3547,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3918,7 +3559,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3926,9 +3567,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3944,7 +3584,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3952,7 +3592,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3968,12 +3608,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3982,7 +3620,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4056,21 +3693,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4101,7 +3723,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4111,13 +3732,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Mynd"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4160,7 +3779,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4194,14 +3812,10 @@ msgstr "Innifela í fellivalmynd"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4209,12 +3823,10 @@ msgstr ""
 msgid "Income"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4225,7 +3837,6 @@ msgstr "Inn yfirlýsing"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4235,7 +3846,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Inn yfirlýsing"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4255,11 +3865,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4269,30 +3878,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4302,17 +3907,14 @@ msgstr "Lager"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4338,11 +3940,7 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4384,8 +3982,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4401,11 +3997,6 @@ msgstr "Sölureiknings dags. vantar!"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4424,7 +4015,6 @@ msgstr "Sölureikningur Númer"
 msgid "Invoice Number missing!"
 msgstr "Sölureikningsnúmer vantar!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4454,12 +4044,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4517,8 +4105,7 @@ msgstr ""
 msgid "Jan"
 msgstr "jan"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "janúar"
 
@@ -4547,8 +4134,7 @@ msgstr ""
 msgid "Jul"
 msgstr "júl"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "júlí"
 
@@ -4556,8 +4142,8 @@ msgstr "júlí"
 msgid "Jun"
 msgstr "jún"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "júní"
 
@@ -4570,10 +4156,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "LaTeX-skabalón"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4595,15 +4177,12 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Túngumál"
@@ -4624,7 +4203,6 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4635,7 +4213,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4657,40 +4234,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4702,9 +4278,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4726,9 +4300,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4742,8 +4314,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4760,7 +4330,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4797,7 +4366,6 @@ msgstr ""
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4823,7 +4391,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4841,7 +4408,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4862,7 +4428,7 @@ msgstr ""
 msgid "Login"
 msgstr "Tengjast"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4890,45 +4456,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Tegund"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4950,40 +4509,34 @@ msgstr ""
 msgid "Mar"
 msgstr "mar"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "mars"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "maí"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr ""
@@ -5000,7 +4553,6 @@ msgstr "Skilaboð"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr ""
@@ -5009,7 +4561,6 @@ msgstr ""
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5028,14 +4579,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5049,7 +4597,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5062,14 +4609,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Model"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5087,7 +4632,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5111,14 +4656,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5127,15 +4670,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5154,7 +4688,6 @@ msgstr "Nafn"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5205,8 +4738,6 @@ msgstr ""
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5228,12 +4759,10 @@ msgstr ""
 msgid "Ninety"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Nei"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5242,7 +4771,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5250,11 +4779,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5262,7 +4791,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5271,11 +4799,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5283,21 +4811,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5316,12 +4841,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5330,12 +4853,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5373,11 +4894,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5423,23 +4939,18 @@ msgstr ""
 msgid "Nov"
 msgstr "nóv"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "nóvember"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5470,7 +4981,7 @@ msgstr ""
 msgid "Number"
 msgstr "Númer"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Númera útlit"
 
@@ -5491,13 +5002,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Úrelt"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5506,8 +5015,7 @@ msgstr ""
 msgid "Oct"
 msgstr "ókt"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "óktóber"
 
@@ -5519,9 +5027,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5571,7 +5076,6 @@ msgstr ""
 msgid "Open"
 msgstr "opna"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5593,9 +5097,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5641,7 +5142,6 @@ msgstr "Pöntunar dags. vantar"
 msgid "Order Entry"
 msgstr "Pöntunarblað"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5663,7 +5163,6 @@ msgstr "Pöntun eytt"
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5685,7 +5184,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5730,7 +5229,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5749,10 +5247,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5796,11 +5290,6 @@ msgstr "Númer fylgiseðils vantar!"
 msgid "Packing list"
 msgstr "Fylgiseðill"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5818,12 +5307,10 @@ msgstr "Greitt"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Vara"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5833,14 +5320,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5870,14 +5349,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5893,15 +5368,12 @@ msgstr ""
 msgid "Parts"
 msgstr "Vara"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5911,7 +5383,6 @@ msgstr ""
 msgid "Password"
 msgstr "Aðgangsorð"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5924,7 +5395,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5938,7 +5408,6 @@ msgstr ""
 msgid "Payables"
 msgstr "Útistandandi"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5947,7 +5416,6 @@ msgstr "Útistandandi"
 msgid "Payment"
 msgstr "Greislur"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5960,7 +5428,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5977,7 +5444,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6013,15 +5479,15 @@ msgstr "Greiðslur"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6040,7 +5506,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6070,108 +5535,88 @@ msgstr ""
 msgid "Pick list"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6187,7 +5632,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6196,24 +5640,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6222,13 +5664,11 @@ msgstr ""
 msgid "Post"
 msgstr "Bókfæra"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6269,7 +5709,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Postscript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6307,20 +5746,16 @@ msgstr ""
 msgid "Price"
 msgstr "Verð"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6356,8 +5791,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6367,7 +5800,6 @@ msgstr ""
 msgid "Print"
 msgstr "Prenta"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6384,7 +5816,7 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Prentari"
 
@@ -6428,17 +5860,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6467,7 +5897,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6486,7 +5915,6 @@ msgstr ""
 msgid "Project Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6495,9 +5923,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Verkefni"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6507,7 +5932,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6525,22 +5949,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Innkaupspöntun"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Innkaupspantanir"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6555,14 +5973,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Innkaupspöntun"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6593,7 +6007,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Magn"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6607,8 +6020,6 @@ msgstr ""
 msgid "Quarter"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6645,9 +6056,7 @@ msgstr ""
 msgid "Quotation deleted!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6668,25 +6077,20 @@ msgstr ""
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6698,7 +6102,6 @@ msgstr "Taxti"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6721,13 +6124,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6745,7 +6144,6 @@ msgstr "Kvittun"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6759,8 +6157,7 @@ msgstr "Kvittanir"
 msgid "Receivables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr ""
 
@@ -6768,7 +6165,6 @@ msgstr ""
 msgid "Receive Merchandise"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6789,7 +6185,6 @@ msgstr "Afstemingar"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6810,13 +6205,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6855,12 +6243,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6898,7 +6284,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6910,7 +6296,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6923,7 +6309,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6972,7 +6357,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -6992,13 +6377,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Pantað af"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7028,7 +6410,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7037,7 +6418,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7054,7 +6434,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7104,11 +6483,11 @@ msgstr ""
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7134,7 +6513,6 @@ msgstr "Sala"
 msgid "Sales Invoice"
 msgstr "Sölureikningur"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7150,20 +6528,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr "Sölupöntun"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Sölupantanir"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr ""
@@ -7185,9 +6560,6 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7211,13 +6583,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7237,7 +6606,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7247,7 +6616,6 @@ msgstr "Geyma"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7306,11 +6674,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "Geyma sem nýtt"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7333,10 +6700,8 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Skjá"
 
@@ -7356,7 +6721,6 @@ msgstr "Skjá"
 msgid "Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7365,7 +6729,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7418,11 +6781,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7434,11 +6797,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7450,7 +6813,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7458,7 +6821,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7514,7 +6876,6 @@ msgstr ""
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7523,9 +6884,6 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7579,13 +6937,11 @@ msgstr ""
 msgid "Sep"
 msgstr "sep"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "september"
 
@@ -7606,9 +6962,6 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7638,7 +6991,6 @@ msgstr ""
 msgid "Services"
 msgstr "Þjónusta"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 msgid "Session Timeout (e.g. \"90 minutes\")"
 msgstr ""
@@ -7651,7 +7003,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7671,10 +7023,10 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Senda"
 
@@ -7701,10 +7053,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7765,10 +7113,6 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7809,7 +7153,6 @@ msgstr ""
 msgid "Short"
 msgstr "Stutt"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7850,7 +7193,6 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7863,12 +7205,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7895,7 +7231,6 @@ msgstr "Frálag"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7917,21 +7252,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Standart"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7962,8 +7286,6 @@ msgstr ""
 msgid "Startdate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8000,13 +7322,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Uppgjör"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "jöfnunaruppgjör"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8036,7 +7356,7 @@ msgstr "Lager samsetning"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Stílblað"
 
@@ -8061,7 +7381,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8104,7 +7423,6 @@ msgstr ""
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8137,12 +7455,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8154,9 +7466,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8175,8 +7484,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8187,17 +7494,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8341,7 +7645,6 @@ msgstr ""
 msgid "Template"
 msgstr "HTML-skabalón"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8350,7 +7653,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8403,7 +7705,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8415,7 +7717,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8466,24 +7768,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8506,14 +7805,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8557,7 +7852,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8587,19 +7881,10 @@ msgstr ""
 msgid "To"
 msgstr "til"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8636,7 +7921,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8661,16 +7945,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8713,7 +7988,7 @@ msgstr ""
 msgid "Total"
 msgstr "Samtals"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8721,7 +7996,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8742,7 +8016,6 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8758,14 +8031,12 @@ msgstr "Dags. vantar!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8804,7 +8075,6 @@ msgstr ""
 msgid "Translations saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Prufu staða"
@@ -8813,7 +8083,6 @@ msgstr "Prufu staða"
 msgid "Trillion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8870,10 +8139,6 @@ msgstr ""
 msgid "Two"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8908,39 +8173,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8959,43 +8218,37 @@ msgstr "Einingar"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9003,23 +8256,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9036,7 +8284,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9064,21 +8311,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9087,7 +8329,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9105,24 +8346,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9132,7 +8368,6 @@ msgstr "Notandi"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9153,7 +8388,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9179,8 +8413,6 @@ msgstr ""
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9190,11 +8422,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9210,7 +8438,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Byrgir"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9224,7 +8451,6 @@ msgstr ""
 msgid "Vendor Invoice"
 msgstr "Innkaupsreikningur"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9234,9 +8460,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9266,9 +8489,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "Byrgja vantar!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9276,8 +8497,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Byrgir ekki til í gagnagrunni!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9292,7 +8511,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9305,7 +8523,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9328,7 +8545,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr ""
@@ -9337,11 +8553,26 @@ msgstr ""
 msgid "Warning!"
 msgstr ""
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9351,7 +8582,6 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9368,13 +8598,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Vigt"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Vigtareining"
@@ -9391,7 +8619,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9408,11 +8635,11 @@ msgstr ""
 msgid "Work order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9455,15 +8682,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Já"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9490,7 +8712,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9554,17 +8776,12 @@ msgstr "dagar"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9581,7 +8798,7 @@ msgstr ""
 msgid "done"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9609,8 +8826,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9619,22 +8834,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9659,7 +8870,6 @@ msgstr ""
 msgid "sent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9684,8 +8894,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/it.po
+++ b/locale/po/it.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Italian (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -16,27 +16,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr "fatture n."
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr "% Amm."
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr "(-) Ammortamento"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr "Valore residuo"
@@ -49,12 +44,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -103,7 +94,6 @@ msgstr "Debiti Fornitori"
 msgid "AP Aging"
 msgstr "Partite Aperte"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr "Fattura a debito"
@@ -112,7 +102,6 @@ msgstr "Fattura a debito"
 msgid "AP Invoices"
 msgstr "Fatture a debito"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -127,7 +116,6 @@ msgstr ""
 msgid "AP Transaction"
 msgstr "Transazione Fornitore"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Transazioni Fornitori"
@@ -140,9 +128,7 @@ msgstr "Voucher a debito"
 msgid "AP account"
 msgstr "Conto a debito"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -161,7 +147,6 @@ msgstr "Crediti Clienti"
 msgid "AR Aging"
 msgstr "Partite Aperte"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr "Fattura a credito"
@@ -170,7 +155,6 @@ msgstr "Fattura a credito"
 msgid "AR Invoices"
 msgstr "Fatture a credito"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -185,7 +169,6 @@ msgstr ""
 msgid "AR Transaction"
 msgstr "Transazione Cliente"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Transazioni Clienti"
@@ -198,9 +181,7 @@ msgstr "Voucher a credito"
 msgid "AR account"
 msgstr "Conto a credito"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -209,8 +190,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Transazione Cliente"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -220,16 +199,11 @@ msgstr "Somma Crediti/Debiti/Libro giornale"
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr "Accesso negato"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -255,38 +229,20 @@ msgstr "Accesso negato"
 msgid "Account"
 msgstr "Conto"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr "Descrizione conto"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr "Nome conto"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr "Nome conto"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -307,23 +263,18 @@ msgstr "Nome conto"
 msgid "Account Number"
 msgstr "Numero di conto"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr "Numero conto finale"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr "Numero conto iniziale"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr "Nome conto"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -363,17 +314,15 @@ msgstr "Conti da"
 msgid "Accounts To"
 msgstr "Conti a"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr "Conti senza intestazione"
 
@@ -385,7 +334,7 @@ msgstr "Rateo"
 msgid "Accrual Basis:"
 msgstr "Rateo base:"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -413,12 +362,10 @@ msgstr "Attivo"
 msgid "Active On"
 msgstr "Attivo"
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr "Sessioni attive"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -441,11 +388,11 @@ msgstr "Aggiungi conti"
 msgid "Add Assembly"
 msgstr "Nuovo Assemblato"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr "Nuovo cespite"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr "Nuova classe cespite"
 
@@ -570,7 +517,6 @@ msgstr "Nuovo ordine di vendita"
 msgid "Add Service"
 msgstr "Nuovo Servizio"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr "Nuova tassazione"
@@ -637,7 +583,6 @@ msgstr "Aggiungi/Modifica stipendio"
 msgid "Add/Update"
 msgstr "Aggiorna"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr "Aggiunto id [_1]"
@@ -662,7 +607,6 @@ msgstr "Indirizzo:"
 msgid "Address: [_1]"
 msgstr "Indirizzo: [_1]"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -672,12 +616,11 @@ msgstr "Indirizzi"
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -697,8 +640,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -751,7 +693,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr "Tutti i prezzi in [_1]"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -760,11 +701,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -798,14 +734,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Importo"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr "Totale preventivato"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -814,27 +746,21 @@ msgstr "Totale preventivato"
 msgid "Amount Due"
 msgstr "Importo Dovuto"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr "Somma da"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr "Importo maggiore di"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr "Importo minore di"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -852,14 +778,14 @@ msgstr "Importo"
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -878,17 +804,14 @@ msgstr ""
 msgid "Any"
 msgstr "Nessuno"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr "Sconto applicato"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr "Applica sconto"
@@ -897,13 +820,6 @@ msgstr "Applica sconto"
 msgid "Approval Status"
 msgstr "Stato approvazione"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -912,7 +828,6 @@ msgstr "Stato approvazione"
 msgid "Approve"
 msgstr "Approva"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -921,14 +836,12 @@ msgstr "Approva"
 msgid "Approved"
 msgstr "Approvato"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr "Approvato da"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr "Approvato il"
 
@@ -940,19 +853,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Apr"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "Aprile"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr "Valore acquisito"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -968,7 +878,6 @@ msgstr "Vuoi cancellare l'offerta numero"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -987,19 +896,17 @@ msgstr "Assemblati ricaricati!"
 msgid "Asset"
 msgstr "Attivit&agrave;"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr "Conto attività"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr "Classe attivo"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr "Elenco classi attivo"
@@ -1012,29 +919,26 @@ msgstr "Classe attivo:"
 msgid "Asset Classes"
 msgstr "Classi attività"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr "Lista attività"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1050,7 +954,6 @@ msgstr "Attività a patrimonio"
 msgid "Assets to Liabilities"
 msgstr "Attività a passività"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1148,8 +1051,7 @@ msgstr "Att.ne: [_1]"
 msgid "Aug"
 msgstr "Ago"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Agosto"
 
@@ -1161,7 +1063,6 @@ msgstr "Autore: [_1]"
 msgid "Automatic"
 msgstr "Automatico"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1175,7 +1076,6 @@ msgstr "Database disponibili"
 msgid "Available Users"
 msgstr "Utenti disponibili"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1188,7 +1088,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr "Costo medio"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr "Costo medio"
@@ -1222,8 +1121,6 @@ msgstr "Backup DB"
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1238,7 +1135,6 @@ msgstr "Saldo"
 msgid "Balance Sheet"
 msgstr "Stato Patrimoniale"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1259,7 +1155,6 @@ msgstr "Conto bancario"
 msgid "Bank Account:"
 msgstr "Conto bancario"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1270,7 +1165,6 @@ msgstr "Conti bancari"
 msgid "Bar Code"
 msgstr "Codice a barre"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1280,18 +1174,15 @@ msgstr "Valuta"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1304,12 +1195,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1326,13 +1215,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1373,8 +1260,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1420,17 +1305,14 @@ msgstr ""
 msgid "Budget"
 msgstr "Preventivo"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr "Preventivo n."
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr "Preventivi trovati"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1443,12 +1325,10 @@ msgstr "Preventivi"
 msgid "Business"
 msgstr "Azienda"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Partita IVA"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1458,12 +1338,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1485,7 +1363,6 @@ msgstr ""
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1517,18 +1394,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr "Annulla"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr "Annullo?"
 
@@ -1654,12 +1529,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Piano dei Conti"
 
@@ -1679,7 +1553,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1708,7 +1581,7 @@ msgstr "City:"
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1720,9 +1593,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr ""
 
@@ -1750,15 +1623,13 @@ msgstr "Chiudi anno"
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Chiuso"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1773,8 +1644,6 @@ msgstr "Bilancio finale"
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1789,22 +1658,18 @@ msgstr ""
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr "Combina ordini acquisto"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr "Combina ordini vendita"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1816,39 +1681,31 @@ msgstr "Combina ordini vendita"
 msgid "Company"
 msgstr "Azienda"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr "Indirizzo azienda"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr "Fax azienda"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr "Informazioni  azienda"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr "Numero al Registro Imprese"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Ragione sociale"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr "Telefono azienda"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr "Partita IVA"
@@ -1869,7 +1726,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Conferma!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1887,7 +1744,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Contatto"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1903,7 +1759,6 @@ msgstr "Info contatto:"
 msgid "Contact Information"
 msgstr "Informazioni contatto"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1921,9 +1776,6 @@ msgstr "Rubrica"
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1953,7 +1805,6 @@ msgstr ""
 msgid "Contra"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1961,10 +1812,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1995,20 +1842,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2024,26 +1867,20 @@ msgstr ""
 msgid "Could not transfer Inventory!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2055,7 +1892,6 @@ msgstr ""
 msgid "Country"
 msgstr "Nazione"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr "Nome nazione"
@@ -2068,7 +1904,7 @@ msgstr "Nazione"
 msgid "Create"
 msgstr "Crea"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2076,11 +1912,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2108,8 +1944,6 @@ msgstr "Creato da"
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2117,17 +1951,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Avere"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2152,29 +1983,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr "Nota di accredito"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Valuta"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2197,18 +2018,14 @@ msgstr "Valuta"
 msgid "Currency"
 msgstr "Valuta"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Corrente"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2218,11 +2035,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2237,7 +2050,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Cliente"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2256,9 +2068,6 @@ msgstr "Cliente non sul file!"
 msgid "Customer Name"
 msgstr "Nome cliente"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2278,9 +2087,7 @@ msgstr "Cerca cliente"
 msgid "Customer missing!"
 msgstr "Cliente mancante!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2292,7 +2099,7 @@ msgstr "Cliente non sul file!"
 msgid "Customer/Vendor Accounts"
 msgstr "Conti fornitori"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2316,12 +2123,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2354,28 +2160,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2422,19 +2216,14 @@ msgstr ""
 msgid "Date"
 msgstr "Data"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr "Formato data"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2456,7 +2245,6 @@ msgstr ""
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2520,8 +2308,6 @@ msgstr "Giorno(i)"
 msgid "Days"
 msgstr "Giorni"
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2537,10 +2323,8 @@ msgstr "Fattura a debito"
 msgid "Debit Note"
 msgstr "Nota di addebito"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2550,17 +2334,14 @@ msgstr "Debiti"
 msgid "Dec"
 msgstr "Dic"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Dicembre"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr "Cifre decimali denaro"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2570,7 +2351,6 @@ msgstr "Classe di deduzione"
 msgid "Deduction Type"
 msgstr "Tipo deduzione"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr "Tipi di deduzione"
@@ -2583,47 +2363,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr "Nazione di serie"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2636,21 +2407,14 @@ msgstr ""
 msgid "Defaults"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2668,7 +2432,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Cancella"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2681,7 +2444,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2695,37 +2457,33 @@ msgstr ""
 msgid "Delivery"
 msgstr "Consegna"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Data di consegna"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2747,20 +2505,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2771,46 +2526,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2921,12 +2637,10 @@ msgstr "Dettaglio"
 msgid "Details"
 msgstr "Dettagli"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr "Sconto"
@@ -2939,7 +2653,6 @@ msgstr "Sconto"
 msgid "Disc %"
 msgstr "% sconto"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2948,7 +2661,6 @@ msgstr "% sconto"
 msgid "Discount"
 msgstr "Sconto"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr "Sconto (%)"
@@ -2957,28 +2669,28 @@ msgstr "Sconto (%)"
 msgid "Discount:"
 msgstr "Sconto"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2986,7 +2698,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2995,7 +2706,7 @@ msgstr ""
 msgid "Document Type"
 msgstr "Tipo documento"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -3003,12 +2714,10 @@ msgstr ""
 msgid "Done"
 msgstr "Fatto"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr "Duplicato numero fornitore"
@@ -3021,12 +2730,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr "Prima nota scritta"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr "Cerca prima nota"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr "Tipo prima nota"
@@ -3035,19 +2742,16 @@ msgstr "Tipo prima nota"
 msgid "Drafts"
 msgstr "Prima nota"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Disegno"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3063,10 +2767,6 @@ msgstr ""
 msgid "Due"
 msgstr "Scadenza"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3085,7 +2785,7 @@ msgstr "Data di Scadenza mancante!"
 msgid "Duplicate User Found: Importing User"
 msgstr "Trovato duplicato utente: importando utente"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr "Numero impiegato duplicato"
 
@@ -3111,7 +2811,7 @@ msgstr "Messaggio E-mail"
 msgid "E-mailed"
 msgstr "Inviata email"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3141,7 +2841,7 @@ msgstr ""
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3285,8 +2985,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3300,7 +2998,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Dipendente"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3310,12 +3007,11 @@ msgstr "Dipendente numero"
 msgid "Employee Search"
 msgstr "Cerca dipendente"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3325,37 +3021,26 @@ msgstr "Dipendente numero"
 msgid "Employees"
 msgstr "Dipendenti"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr "Conto a debito vuoto"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr "Conto a credito vuoto"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr "Senza codici cliente"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr "Fornitori senza codici"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3379,7 +3064,6 @@ msgstr "Data finale:"
 msgid "Ending"
 msgstr "Fine"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr "Bilancio finale"
@@ -3404,12 +3088,10 @@ msgstr "Inserisci inventario"
 msgid "Enter User"
 msgstr "Inserisci utente"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr "Inserisci i numeri degli impiegati dove mancano"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3419,7 +3101,7 @@ msgstr "Inserito da"
 msgid "Entered For"
 msgstr "Inserito per"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr "Inserito il"
 
@@ -3427,7 +3109,6 @@ msgstr "Inserito il"
 msgid "Entered at: [_1]"
 msgstr "Inserito il: [_1]"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr "Entità"
@@ -3453,7 +3134,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Codice Entità"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3465,14 +3146,11 @@ msgstr "Busta"
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Capitale"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr "Attività e passività"
@@ -3486,16 +3164,15 @@ msgstr "Attività (temporanea)"
 msgid "Equity to Liabilities"
 msgstr "Attivita a Passività"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3503,7 +3180,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr "Durata stimata"
 
@@ -3516,8 +3193,6 @@ msgstr "Tutti"
 msgid "Exch"
 msgstr "Cambio"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3532,7 +3207,6 @@ msgstr "Tasso di cambio"
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3541,7 +3215,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr "Atteso"
@@ -3559,13 +3232,10 @@ msgstr "Conto di spesa"
 msgid "Expense/Asset"
 msgstr "Acquisti/Attivit&agrave;"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr "Costi"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3643,8 +3313,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Febbraio"
 
@@ -3660,14 +3329,10 @@ msgstr "cinquanta"
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3678,11 +3343,11 @@ msgstr "Nome file"
 msgid "File Type"
 msgstr "Tipo file"
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr "Nome file"
 
@@ -3693,7 +3358,6 @@ msgstr "Nome file"
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr "File"
@@ -3751,12 +3415,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Guadagno da cambio valuta"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Perdita da cambio valuta"
@@ -3765,12 +3427,10 @@ msgstr "Perdita da cambio valuta"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3787,7 +3447,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr "quattrodici"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3806,18 +3465,10 @@ msgstr ""
 msgid "From"
 msgstr "Dal"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3838,7 +3489,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3849,15 +3499,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3871,10 +3516,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "Codice GIFI"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3895,7 +3538,6 @@ msgstr "Codice GIFI salvato!"
 msgid "GL"
 msgstr "Libro giornale"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr "Riferimento libro giornale n."
@@ -3904,7 +3546,7 @@ msgstr "Riferimento libro giornale n."
 msgid "Gain"
 msgstr "Guadagno"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr "Guadagno (Perdita)"
 
@@ -3912,12 +3554,11 @@ msgstr "Guadagno (Perdita)"
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 #, fuzzy
 msgid "Gain/Loss"
 msgstr "Guadagno (Perdita)"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3926,7 +3567,7 @@ msgstr ""
 msgid "General Journal"
 msgstr "Libro giornale"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr "Resoconto libro giornale"
 
@@ -3934,9 +3575,8 @@ msgstr "Resoconto libro giornale"
 msgid "General Ledger Reports"
 msgstr "Resoconti libro giornale"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr "Genera"
 
@@ -3952,7 +3592,7 @@ msgstr "Genera ordini"
 msgid "Generate Purchase Orders"
 msgstr "Genera ordini acquisto"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr "Genera ordini acquisto in base a ordini vendita"
 
@@ -3960,7 +3600,7 @@ msgstr "Genera ordini acquisto in base a ordini vendita"
 msgid "Generate Sales Orders"
 msgstr "Genera ordini di vendita"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr "Genera Ordini di vendita da ordini di acquisto"
 
@@ -3976,12 +3616,10 @@ msgstr "Nome"
 msgid "Goods & Services"
 msgstr "Beni e servizi"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr "Beni e servizi"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr "Storico di beni e servizi"
@@ -3990,7 +3628,6 @@ msgstr "Storico di beni e servizi"
 msgid "Grand Total"
 msgstr "Totale generale"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4064,21 +3701,6 @@ msgstr "Ore"
 msgid "Hundred"
 msgstr "cento"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4109,7 +3731,6 @@ msgstr ""
 msgid "Identification"
 msgstr "Identificativo"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4119,13 +3740,11 @@ msgstr "Ignora fine anno"
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Immagine"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4168,7 +3787,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4202,14 +3820,10 @@ msgstr "Da includere nei menu a discesa dei seguenti moduli"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4217,12 +3831,10 @@ msgstr ""
 msgid "Income"
 msgstr "Ricavi"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4233,7 +3845,6 @@ msgstr "Conto Economico"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4243,7 +3854,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Conto Economico"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4263,11 +3873,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr "File interni"
@@ -4277,30 +3886,26 @@ msgstr "File interni"
 msgid "Internal Notes"
 msgstr "Note interne"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr "Richiesta non valida di backup"
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr "Data/ora inserita non valida"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4310,17 +3915,14 @@ msgstr "Inventario"
 msgid "Inventory Activity"
 msgstr "Attività inventariale"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr "Resoconto attività invetariale"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr "Dettagli aggiustamento inventario"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr "Sistemazione inventario"
@@ -4348,11 +3950,7 @@ msgstr "Inventario registrato!"
 msgid "Inventory transferred!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4394,8 +3992,6 @@ msgstr "Creata fattura"
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4411,11 +4007,6 @@ msgstr "Manca la data della Fattura!"
 msgid "Invoice No."
 msgstr "Numero Fattura"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4434,7 +4025,6 @@ msgstr "Numero fattura"
 msgid "Invoice Number missing!"
 msgstr "Manca il numero della Fattura!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4464,12 +4054,10 @@ msgstr "Scadenza fattura"
 msgid "Invoice not found"
 msgstr "Fattura non trovata"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4527,8 +4115,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Gen"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Gennaio"
 
@@ -4557,8 +4144,7 @@ msgstr "Righe giornale"
 msgid "Jul"
 msgstr "Lug"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Luglio"
 
@@ -4566,8 +4152,8 @@ msgstr "Luglio"
 msgid "Jun"
 msgstr "Giu"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Giugno"
 
@@ -4580,10 +4166,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "Modelli LaTeX"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4605,15 +4187,12 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Lingua"
@@ -4634,7 +4213,6 @@ msgstr "Lingue non definite!"
 msgid "Last"
 msgstr "Ultimo/a"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4645,7 +4223,6 @@ msgstr "Costo finale"
 msgid "Last Name"
 msgstr "Cognome"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr "Ultimo aggiornamento"
@@ -4667,40 +4244,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4712,9 +4288,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4736,9 +4310,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4752,8 +4324,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr "Intestazione lettera"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr "Passività"
@@ -4770,7 +4340,6 @@ msgstr "Numero patente"
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4807,7 +4376,6 @@ msgstr "Elenco lingue"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4833,7 +4401,6 @@ msgstr "Elenco utenti"
 msgid "List Warehouse"
 msgstr "Elenco magazzino"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr "Lista tipologie aziende"
@@ -4851,7 +4418,6 @@ msgstr "Sede"
 msgid "Locations"
 msgstr "Sedi"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4872,7 +4438,7 @@ msgstr ""
 msgid "Login"
 msgstr "Login"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4900,45 +4466,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Produttore"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr "Gestione utenti"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4960,40 +4519,34 @@ msgstr "Manuale"
 msgid "Mar"
 msgstr "Mar"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Marzo"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "Mag"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr ""
@@ -5010,7 +4563,6 @@ msgstr "Messaggio"
 msgid "Message: "
 msgstr "Mesaggio:"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr ""
@@ -5019,7 +4571,6 @@ msgstr ""
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5038,14 +4589,11 @@ msgstr "Secondo nome"
 msgid "Million"
 msgstr "Milione"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5059,7 +4607,6 @@ msgstr "Q.tà minima"
 msgid "Min Taxable"
 msgstr "Minimo tassabile"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5072,14 +4619,12 @@ msgstr ""
 msgid "Miss."
 msgstr "Sig.na"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Modello"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr "Lun"
@@ -5097,7 +4642,7 @@ msgstr "Mese(i)"
 msgid "Months"
 msgstr "Mesi"
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5121,14 +4666,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5137,15 +4680,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5164,7 +4698,6 @@ msgstr "Nome"
 msgid "Name:"
 msgstr "Nome:"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5215,8 +4748,6 @@ msgstr "Prossima data"
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5238,12 +4769,10 @@ msgstr "diciannove"
 msgid "Ninety"
 msgstr "novanta"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "No"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5252,7 +4781,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5260,11 +4789,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5272,7 +4801,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr "Invariato"
@@ -5281,11 +4809,11 @@ msgstr "Invariato"
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5293,21 +4821,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5326,12 +4851,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5340,12 +4863,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5383,11 +4904,6 @@ msgstr "Classe di note"
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5433,23 +4949,18 @@ msgstr "Nulla da trasferire!"
 msgid "Nov"
 msgstr "Nov"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "Novembre"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr "Nessun numero impiegati"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr "Nessun numero"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr "Nessun numero modelli"
@@ -5480,7 +4991,7 @@ msgstr "Nessun numero modelli"
 msgid "Number"
 msgstr "Partita IVA"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Formato Numerico"
 
@@ -5501,13 +5012,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Obsoleto"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5516,8 +5025,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Ott"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Ottobre"
 
@@ -5529,9 +5037,6 @@ msgstr ""
 msgid "Old Password"
 msgstr "Password precedente"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5581,7 +5086,6 @@ msgstr "Solo per dipendenti"
 msgid "Open"
 msgstr "Aperto"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5604,9 +5108,6 @@ msgstr "O"
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5652,7 +5153,6 @@ msgstr "Manca la data dell'ordine"
 msgid "Order Entry"
 msgstr "Ordini"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5674,7 +5174,6 @@ msgstr "Ordine Cancellato!"
 msgid "Order generation failed!"
 msgstr "Generazione ordine fallita!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr "Ordine/Fattura"
@@ -5696,7 +5195,7 @@ msgstr "Generati ordini"
 msgid "Other Actions"
 msgstr "Altre azioni"
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr "Nostro saldo"
 
@@ -5742,7 +5241,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5761,10 +5259,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr "Ordine acquisto #"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5808,11 +5302,6 @@ msgstr "Manca il codice della Packing List!"
 msgid "Packing list"
 msgstr "Lista Etichette"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5830,12 +5319,10 @@ msgstr "Importo Pagato"
 msgid "Parent"
 msgstr "Padre"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Articolo"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr "Descrizione particolare"
@@ -5845,14 +5332,6 @@ msgstr "Descrizione particolare"
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5884,14 +5363,10 @@ msgstr "Dettagli"
 msgid "Partial"
 msgstr "Parziale"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5907,15 +5382,12 @@ msgstr "Numero particolare"
 msgid "Parts"
 msgstr "Articolo"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5925,7 +5397,6 @@ msgstr ""
 msgid "Password"
 msgstr "Password"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5938,7 +5409,6 @@ msgstr "Le password devono coincidere"
 msgid "Pay From"
 msgstr "Pagato da"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5952,7 +5422,6 @@ msgstr "Pagato al posto di"
 msgid "Payables"
 msgstr "Debiti Fornitori"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5961,7 +5430,6 @@ msgstr "Debiti Fornitori"
 msgid "Payment"
 msgstr "Pagamento"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr "Somma pagata"
@@ -5974,7 +5442,6 @@ msgstr "Pagamento fattura numero [_1]"
 msgid "Payment Processing"
 msgstr "Pagamento in corso"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr "Risultato pagamenti"
@@ -5991,7 +5458,6 @@ msgstr "Termini di pagamento"
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6027,15 +5493,15 @@ msgstr "Pagamenti"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr "Percentuale"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6054,7 +5520,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr "Persona"
@@ -6085,108 +5550,88 @@ msgstr ""
 msgid "Pick list"
 msgstr "Listino"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6202,7 +5647,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6211,24 +5655,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6237,13 +5679,11 @@ msgstr ""
 msgid "Post"
 msgstr "Registra"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr "Data registrazione"
 
@@ -6284,7 +5724,6 @@ msgstr "Registro fattura acquisti [_1]"
 msgid "Postscript"
 msgstr "Postscript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6322,20 +5761,16 @@ msgstr ""
 msgid "Price"
 msgstr "Prezzo"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6371,8 +5806,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr "Telefono principale"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6382,7 +5815,6 @@ msgstr "Telefono principale"
 msgid "Print"
 msgstr "Stampa"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6399,7 +5831,7 @@ msgstr ""
 msgid "Printed"
 msgstr "Stampato"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Stampante"
 
@@ -6443,17 +5875,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6483,7 +5913,6 @@ msgstr "Profitti e Perdite"
 msgid "Profit/Loss"
 msgstr "Profitto/Perdita"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr "Profitto/Perdita su cespiti venduti"
@@ -6502,7 +5931,6 @@ msgstr ""
 msgid "Project Number"
 msgstr "Numero progetto"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6511,9 +5939,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Progetti"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6523,7 +5948,6 @@ msgstr "Data d'acquisto"
 msgid "Purchase Date:"
 msgstr "Data acquisto:"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6541,22 +5965,16 @@ msgstr "Storico acquisti"
 msgid "Purchase Order"
 msgstr "Ordine di acquisto"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "Numero ordine d'acquisto"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Ordini di acquisto"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6571,14 +5989,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Ordine di acquisto"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr "Comprato"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6609,7 +6023,6 @@ msgstr "Comprato"
 msgid "Qty"
 msgstr "Q.t&agrave;"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr "Quantità"
@@ -6623,8 +6036,6 @@ msgstr "La quantità eccede i pezzi in magazzino!"
 msgid "Quarter"
 msgstr "Trimestre"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6661,9 +6072,7 @@ msgstr "Manca numero d'offerta"
 msgid "Quotation deleted!"
 msgstr "OFferta cancellata"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6684,25 +6093,20 @@ msgstr ""
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "Soglia di Riordino"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6714,7 +6118,6 @@ msgstr "Tasso"
 msgid "Rate (%)"
 msgstr "Tasso (%)"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6737,13 +6140,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6761,7 +6160,6 @@ msgstr "Incasso"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6775,8 +6173,7 @@ msgstr "Incassi"
 msgid "Receivables"
 msgstr "Crediti"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Ricevuta"
 
@@ -6784,7 +6181,6 @@ msgstr "Ricevuta"
 msgid "Receive Merchandise"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr "Ricevuto"
@@ -6805,7 +6201,6 @@ msgstr "Riconciliazione"
 msgid "Reconciliation Report"
 msgstr "Resoconto di riconciliazione"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr "Resoconti riconciliazione"
@@ -6826,13 +6221,6 @@ msgstr "Transazione ricorrente per [_1]"
 msgid "Recurring Transactions"
 msgstr "Transazioni ricorrenti"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6871,12 +6259,10 @@ msgstr "Registrazione [_1]"
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr "Rifiuta"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6914,7 +6300,7 @@ msgstr ""
 msgid "Report Name"
 msgstr "Nome resoconto"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr "Resoconto risultante"
 
@@ -6926,7 +6312,7 @@ msgstr "Resoconto inviato"
 msgid "Report Type"
 msgstr "Tipo resoconto"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr "Resoconto [_1] in data [_2]"
 
@@ -6939,7 +6325,6 @@ msgstr "Resoconto al"
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr "Rendicontazione di base"
@@ -6989,7 +6374,7 @@ msgstr ""
 msgid "Required By"
 msgstr "Richiesto da"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr "Data richiesta"
 
@@ -7009,13 +6394,10 @@ msgstr "Data richiesta"
 msgid "Required by"
 msgstr "Necessario dal"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7045,7 +6427,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7054,7 +6435,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7071,7 +6451,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7121,11 +6500,11 @@ msgstr ""
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7151,7 +6530,6 @@ msgstr "Vendite"
 msgid "Sales Invoice"
 msgstr "Fattura di vendita"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7167,20 +6545,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr "Ordine di vendita"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "Numero ordine di vendita"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Ordini di vendita"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "Offerta di vendita numero"
@@ -7203,9 +6578,6 @@ msgstr "titolo"
 msgid "Sales:"
 msgstr "Vendite"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7229,13 +6601,10 @@ msgstr "titolo"
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr "Sab"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7255,7 +6624,7 @@ msgstr "Sab"
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7265,7 +6634,6 @@ msgstr "Salva"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7324,11 +6692,10 @@ msgstr "Salva come nuovo"
 msgid "Save as new"
 msgstr "Salva come nuovo"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7351,10 +6718,8 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Schermo"
 
@@ -7374,7 +6739,6 @@ msgstr "Schermo"
 msgid "Search"
 msgstr "Cerca"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr "Cerca debito"
@@ -7383,7 +6747,6 @@ msgstr "Cerca debito"
 msgid "Search AP Invoices"
 msgstr "Cerca fatture ricevute"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr "Cerca credito"
@@ -7436,11 +6799,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr "Cerca ordini acquisto"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr "Cerca offerte"
 
@@ -7452,11 +6815,11 @@ msgstr "Cerca ricevute"
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr "Cerca richieste di offerta"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr "Cerca ordini vendita"
 
@@ -7468,7 +6831,7 @@ msgstr "Cerca in prima nota"
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr "Cerca resoconti"
 
@@ -7476,7 +6839,6 @@ msgstr "Cerca resoconti"
 msgid "Secondary Phone"
 msgstr "Altro telefono"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr "Impostazioni sicurezza"
@@ -7532,7 +6894,6 @@ msgstr ""
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr "Scelto"
@@ -7541,9 +6902,6 @@ msgstr "Scelto"
 msgid "Sell"
 msgstr "Vendere"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7597,13 +6955,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Set"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "Settembre"
 
@@ -7624,9 +6980,6 @@ msgstr "Serie #"
 msgid "Serial No."
 msgstr "Serie N."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7656,7 +7009,6 @@ msgstr "Codice servizio"
 msgid "Services"
 msgstr "Servizio"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 #, fuzzy
 msgid "Session Timeout (e.g. \"90 minutes\")"
@@ -7670,7 +7022,7 @@ msgstr "Sessioni"
 msgid "Setting"
 msgstr "Impostazione"
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr "Impostazioni"
 
@@ -7690,10 +7042,10 @@ msgstr "diciassette"
 msgid "Seventy"
 msgstr "settanta"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Invio"
 
@@ -7720,10 +7072,6 @@ msgstr "Spedire a"
 msgid "Ship To:"
 msgstr "Spedire a:"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7784,10 +7132,6 @@ msgstr "Manca data spedizione"
 msgid "Shipping Label"
 msgstr "Etichetta di spedizione"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7829,7 +7173,6 @@ msgstr "Etichetta di spedizione"
 msgid "Short"
 msgstr "Corto"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr "Mostra limite credito"
@@ -7871,7 +7214,6 @@ msgstr "sessanta"
 msgid "Skip"
 msgstr "Salta"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr "Venduto"
@@ -7884,12 +7226,6 @@ msgstr "Alcuni"
 msgid "Sort by"
 msgstr "Ordina per"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7916,7 +7252,6 @@ msgstr "Sorgente"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7938,21 +7273,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Standard"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "Codifica industriale standard"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7983,8 +7307,6 @@ msgstr ""
 msgid "Startdate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8021,13 +7343,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Sollecito"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Saldo"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8058,7 +7378,7 @@ msgstr "Magazzino Assemblati"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Foglio di Stile"
 
@@ -8083,7 +7403,6 @@ msgstr ""
 msgid "Submit"
 msgstr "Invia"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8126,7 +7445,6 @@ msgstr "Riepilogo"
 msgid "Summary account for"
 msgstr "Riepilogo conto per"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8159,12 +7477,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr "TOTALE"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8176,9 +7488,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8197,8 +7506,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr "Partita IVA"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8209,17 +7516,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8363,7 +7667,6 @@ msgstr "Tel: [_1]"
 msgid "Template"
 msgstr "Modelli HTML"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8372,7 +7675,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8425,7 +7727,7 @@ msgstr "Grazie per il tuo prezioso lavoro!"
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr "Loro saldo"
 
@@ -8437,7 +7739,7 @@ msgstr "Loro crediti"
 msgid "Their Debits"
 msgstr "Loro debiti"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8488,24 +7790,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr "Documento approvato da"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8528,14 +7827,10 @@ msgstr "Soglia"
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr "gio"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8579,7 +7874,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8609,19 +7903,10 @@ msgstr ""
 msgid "To"
 msgstr "Al"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8658,7 +7943,6 @@ msgstr "Per email"
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr "Da pagare"
@@ -8683,16 +7967,7 @@ msgstr "Seleziona tutti i controlli di rimozione"
 msgid "Top-level"
 msgstr "Cima livello"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8735,7 +8010,7 @@ msgstr "Cima livello"
 msgid "Total"
 msgstr "Totale"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8743,7 +8018,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr "Totale pagato"
@@ -8764,7 +8038,6 @@ msgstr "Scrittura"
 msgid "Transaction Approval"
 msgstr "Approvazione scritture"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8780,14 +8053,12 @@ msgstr "Manca la data della transazione!"
 msgid "Transaction Dates"
 msgstr "Date scrittura"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr "Tipologia scrittura"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8826,7 +8097,6 @@ msgstr "Traduzioni"
 msgid "Translations saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Bilancio di Verifica"
@@ -8835,7 +8105,6 @@ msgstr "Bilancio di Verifica"
 msgid "Trillion"
 msgstr "mille miliardi"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr "mar"
@@ -8892,10 +8161,6 @@ msgstr "Ventidue"
 msgid "Two"
 msgstr "due"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8930,39 +8195,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr "Nome file inatteso, aspettavo [_1], ho avuto [_2]"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8981,43 +8240,37 @@ msgstr "Unit&agrave;"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr "Sconosciuto "
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr "Trovato database sconosciuto."
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr "Sblocca"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9025,23 +8278,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9058,7 +8306,6 @@ msgstr "Non usato"
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9086,21 +8333,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr "Caricato da"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9109,7 +8351,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9127,24 +8368,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr "Usato"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9154,7 +8390,6 @@ msgstr "Utente"
 msgid "User Name"
 msgstr "Nome utente"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9175,7 +8410,6 @@ msgstr "Nome utente"
 msgid "Users"
 msgstr "Utenti"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9201,8 +8435,6 @@ msgstr "Valido fino"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9212,11 +8444,7 @@ msgstr "Varianza"
 msgid "Variance:"
 msgstr "Varianza:"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9232,7 +8460,6 @@ msgstr "Varianza:"
 msgid "Vendor"
 msgstr "Fornitore"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr "Conto fornitore"
@@ -9246,7 +8473,6 @@ msgstr "Storico fornitore"
 msgid "Vendor Invoice"
 msgstr "Fattura fornitore"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9256,9 +8482,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr "Nome fornitore"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9288,9 +8511,7 @@ msgstr "Cerca fornitore"
 msgid "Vendor missing!"
 msgstr "Manca il fornitore!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9298,8 +8519,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Fornitore non in archivio!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9314,7 +8533,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr "Lista Voucher"
@@ -9327,7 +8545,6 @@ msgstr "Voucher"
 msgid "Wages and Deductions"
 msgstr "Stipendi e deduzioni"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr "Stipendi/Deduzioni"
@@ -9350,7 +8567,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Magazzini"
@@ -9359,11 +8575,31 @@ msgstr "Magazzini"
 msgid "Warning!"
 msgstr "Attenzione!"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+#, fuzzy
+msgid "Warning: Your password will expire in [_1] days"
 msgstr "Attenzione: la passowrd scade in [_1]"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+#, fuzzy
+msgid "Warning: Your password will expire in [_1] months"
+msgstr "Attenzione: la passowrd scade in [_1]"
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+#, fuzzy
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr "Attenzione: la passowrd scade in [_1]"
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+#, fuzzy
+msgid "Warning: Your password will expire in [_1] years"
+msgstr "Attenzione: la passowrd scade in [_1]"
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+#, fuzzy
+msgid "Warning: Your password will expire today"
+msgstr "Attenzione: la passowrd scade in [_1]"
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr "mer"
@@ -9373,7 +8609,6 @@ msgstr "mer"
 msgid "Week"
 msgstr "Settimana"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr "Inizio settimana"
@@ -9390,13 +8625,11 @@ msgstr ""
 msgid "Weeks"
 msgstr "Settimane"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Peso"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Unit&agrave; di misura"
@@ -9413,7 +8646,6 @@ msgstr "Dove è possibile fare il backup?"
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9431,11 +8663,11 @@ msgstr "Ordine di lavoro"
 msgid "Work order"
 msgstr "Ordine di lavoro"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr "Desideri migrare il database?"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr "Desideri aggiornare il database?"
 
@@ -9478,16 +8710,10 @@ msgstr ""
 msgid "Years"
 msgstr "Anni"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Si"
-
-#: UI/users/preferences.html:52
-#, fuzzy
-msgid "Your password will expire in [_1]"
-msgstr "Durata password "
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9514,7 +8740,7 @@ msgstr "CAP"
 msgid "Zip/Postal Code"
 msgstr "CAP"
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9578,17 +8804,12 @@ msgstr "giorni"
 msgid "debits"
 msgstr "debiti"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr "rimuovi"
 
@@ -9605,7 +8826,7 @@ msgstr "disposizione"
 msgid "done"
 msgstr "fatto"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9633,8 +8854,6 @@ msgstr "importa"
 msgid "in months"
 msgstr "in mesi"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9643,22 +8862,18 @@ msgstr ""
 msgid "in years"
 msgstr "in anni"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr "è maggiore del saldo disponibile"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr "è minore di 0"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr "è minore del totale da pagare"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr "è nullo"
@@ -9683,7 +8898,6 @@ msgstr "produzione"
 msgid "sent"
 msgstr "spedito"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9708,8 +8922,6 @@ msgstr "per_data"
 msgid "unexpected error!"
 msgstr "errore inaspettato!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""
@@ -9755,6 +8967,13 @@ msgstr ""
 
 #~ msgid "Version"
 #~ msgstr "Versione"
+
+#~ msgid "Warning:  Your password will expire in [_1]"
+#~ msgstr "Attenzione: la passowrd scade in [_1]"
+
+#, fuzzy
+#~ msgid "Your password will expire in [_1]"
+#~ msgstr "Durata password "
 
 #~ msgid "cash"
 #~ msgstr "cassa"

--- a/locale/po/lt.po
+++ b/locale/po/lt.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Lithuanian (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -17,27 +17,22 @@ msgstr ""
 "11) ? 0 : (n % 10 >= 2 && n % 10 <=9) && (n % 100 > 19 || n % 100 < 11) ? 1 : "
 "n % 1 != 0 ? 2: 3);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -50,12 +45,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -101,7 +92,6 @@ msgstr "Pirkimai"
 msgid "AP Aging"
 msgstr "Pirkimo Skolos"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -110,7 +100,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -125,7 +114,6 @@ msgstr ""
 msgid "AP Transaction"
 msgstr "Pirkimo Operaciją"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Pirkimo Operacijos"
@@ -138,9 +126,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -159,7 +145,6 @@ msgstr "Pardavimai"
 msgid "AR Aging"
 msgstr "Pardavimo Skolos"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -168,7 +153,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -183,7 +167,6 @@ msgstr ""
 msgid "AR Transaction"
 msgstr "Pardavimo Operaciją"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Pardavimo Operacijos"
@@ -196,9 +179,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -207,8 +188,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Pardavimo Operaciją"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -218,16 +197,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -253,38 +227,20 @@ msgstr ""
 msgid "Account"
 msgstr "Sąskaita"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -305,23 +261,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Sąskaitos numeris"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -361,17 +312,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -383,7 +332,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -411,12 +360,10 @@ msgstr "Aktyvus"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -439,11 +386,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr "Pridėti rinkinį"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -568,7 +515,6 @@ msgstr "Pridėti Pardavimo užsakymą"
 msgid "Add Service"
 msgstr "Pridėti Paslaugą"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -635,7 +581,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Atnaujinti"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -660,7 +605,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -670,12 +614,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -695,8 +638,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -749,7 +691,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -758,11 +699,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -796,14 +732,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Suma"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -812,27 +744,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Suma iki"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -850,14 +776,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -876,17 +802,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -895,13 +818,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -910,7 +826,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -919,14 +834,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -938,19 +851,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Bal"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "Balandis"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -966,7 +876,6 @@ msgstr ""
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -985,19 +894,17 @@ msgstr "Rinkiniai persandeliuoti!"
 msgid "Asset"
 msgstr "Turtas"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1010,29 +917,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1048,7 +952,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1146,8 +1049,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Rug"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Rugpjūtis"
 
@@ -1159,7 +1061,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1173,7 +1074,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1186,7 +1086,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1220,8 +1119,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1236,7 +1133,6 @@ msgstr "Balansas"
 msgid "Balance Sheet"
 msgstr "Balanso lėntelė"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1257,7 +1153,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1268,7 +1163,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1278,18 +1172,15 @@ msgstr "Valiūta"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1302,12 +1193,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1324,13 +1213,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1371,8 +1258,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1418,17 +1303,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1441,12 +1323,10 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Įmonės kodas"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1456,12 +1336,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1483,7 +1361,6 @@ msgstr ""
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1515,18 +1392,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1652,12 +1527,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Sąskaitų planas"
 
@@ -1677,7 +1551,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1706,7 +1579,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1718,9 +1591,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr ""
 
@@ -1748,15 +1621,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Uždaryta"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1770,8 +1641,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1786,22 +1655,18 @@ msgstr ""
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1813,39 +1678,31 @@ msgstr ""
 msgid "Company"
 msgstr "Firma"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1866,7 +1723,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Patvirtinti!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1884,7 +1741,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Kontaktas"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1900,7 +1756,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1918,9 +1773,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1950,7 +1802,6 @@ msgstr ""
 msgid "Contra"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1958,10 +1809,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1992,20 +1839,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2021,26 +1864,20 @@ msgstr ""
 msgid "Could not transfer Inventory!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2052,7 +1889,6 @@ msgstr ""
 msgid "Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2065,7 +1901,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2073,11 +1909,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2105,8 +1941,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2114,17 +1948,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Kreditas"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2149,29 +1980,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Val."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2194,18 +2015,14 @@ msgstr "Val."
 msgid "Currency"
 msgstr "Valiūta"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Dabartinis"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2215,11 +2032,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2234,7 +2047,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Klientas"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2253,9 +2065,6 @@ msgstr "Tokio kliento nėra!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2275,9 +2084,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "Kliento vardo nėra!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2289,7 +2096,7 @@ msgstr "Tokio kliento nėra!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2313,12 +2120,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2351,28 +2157,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2419,19 +2213,14 @@ msgstr ""
 msgid "Date"
 msgstr "Data"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2453,7 +2242,6 @@ msgstr ""
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2517,8 +2305,6 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2534,10 +2320,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2547,17 +2331,14 @@ msgstr ""
 msgid "Dec"
 msgstr "Grd"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Gruodis"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2567,7 +2348,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2580,47 +2360,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2633,21 +2404,14 @@ msgstr ""
 msgid "Defaults"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2665,7 +2429,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Ištrinti"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2678,7 +2441,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2692,37 +2454,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Prystatimo Data"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2744,20 +2502,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2768,46 +2523,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2918,12 +2634,10 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2936,7 +2650,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2945,7 +2658,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Nuolaidos"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2954,28 +2666,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2983,7 +2695,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2992,7 +2703,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -3000,12 +2711,10 @@ msgstr ""
 msgid "Done"
 msgstr "Įvykdyta"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3018,12 +2727,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3032,19 +2739,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Briežinys"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3060,10 +2764,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3082,7 +2782,7 @@ msgstr "Nėra Iki Datos!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3108,7 +2808,7 @@ msgstr ""
 msgid "E-mailed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3138,7 +2838,7 @@ msgstr ""
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3282,8 +2982,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3297,7 +2995,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Darbuotojas"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3307,12 +3004,11 @@ msgstr ""
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 msgid "Employee wage screen"
 msgstr ""
@@ -3321,37 +3017,26 @@ msgstr ""
 msgid "Employees"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3375,7 +3060,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3400,12 +3084,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3415,7 +3097,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3423,7 +3105,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3448,7 +3129,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3460,14 +3141,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Turtas/Nuosavybė"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3481,16 +3159,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3498,7 +3175,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3511,8 +3188,6 @@ msgstr ""
 msgid "Exch"
 msgstr "Kurs."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3527,7 +3202,6 @@ msgstr "Keitimo kursas"
 msgid "Exchange rate for payment missing!"
 msgstr "Mokėjimo keitimo kurso nėra!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3536,7 +3210,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "Keitimo kurso nėra!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3554,13 +3227,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Sąnaudos/Aktyvai"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3638,8 +3308,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Vas"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Vasaris"
 
@@ -3655,14 +3324,10 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3673,11 +3338,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3688,7 +3353,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3746,12 +3410,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Valiūtos keitimo pelnas"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Valiūtos keitimo nuostolis"
@@ -3760,12 +3422,10 @@ msgstr "Valiūtos keitimo nuostolis"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3782,7 +3442,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3801,18 +3460,10 @@ msgstr ""
 msgid "From"
 msgstr "Nuo"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3833,7 +3484,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3844,15 +3494,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3866,10 +3511,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "GIFI"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3890,7 +3533,6 @@ msgstr "GIFI išsaugotas!"
 msgid "GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3899,7 +3541,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3907,11 +3549,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3920,7 +3561,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3928,9 +3569,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3946,7 +3586,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3954,7 +3594,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3970,12 +3610,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3984,7 +3622,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4058,21 +3695,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4103,7 +3725,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4113,13 +3734,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Piešinys"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4162,7 +3781,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4196,14 +3814,10 @@ msgstr "Įdėti į išsįskleidžiančius meniu"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4211,12 +3825,10 @@ msgstr ""
 msgid "Income"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4227,7 +3839,6 @@ msgstr "Pelno/nuostolio ataskaita"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4237,7 +3848,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Pelno/nuostolio ataskaita"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4257,11 +3867,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4271,30 +3880,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4304,17 +3909,14 @@ msgstr "Prekės"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4340,11 +3942,7 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4386,8 +3984,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4403,11 +3999,6 @@ msgstr "Sąskaitos-faktūros datos nėra!"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4426,7 +4017,6 @@ msgstr "Sąskaitos-faktūros numeris"
 msgid "Invoice Number missing!"
 msgstr "Sąskaitos-faktūra numerio nėra!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4456,12 +4046,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4519,8 +4107,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Sau"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Sausis"
 
@@ -4549,8 +4136,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Lie"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Liepa"
 
@@ -4558,8 +4144,8 @@ msgstr "Liepa"
 msgid "Jun"
 msgstr "Bir"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Birželis"
 
@@ -4572,10 +4158,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "LaTeX šablonai"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4597,15 +4179,12 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Kalba"
@@ -4626,7 +4205,6 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4637,7 +4215,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4659,40 +4236,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4704,9 +4280,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4728,9 +4302,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4744,8 +4316,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4762,7 +4332,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4799,7 +4368,6 @@ msgstr ""
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4825,7 +4393,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4843,7 +4410,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4864,7 +4430,7 @@ msgstr ""
 msgid "Login"
 msgstr "Prisijungimas"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4892,45 +4458,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Gamintojas"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4952,40 +4511,34 @@ msgstr ""
 msgid "Mar"
 msgstr "Kov"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Kovas"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "Geg"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr ""
@@ -5002,7 +4555,6 @@ msgstr "Žinutė"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr ""
@@ -5011,7 +4563,6 @@ msgstr ""
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5030,14 +4581,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5051,7 +4599,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5064,14 +4611,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Modelis"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5089,7 +4634,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5113,14 +4658,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5129,15 +4672,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5156,7 +4690,6 @@ msgstr "Vardas"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5207,8 +4740,6 @@ msgstr ""
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5230,12 +4761,10 @@ msgstr ""
 msgid "Ninety"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Ne"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5244,7 +4773,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5252,11 +4781,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5264,7 +4793,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5273,11 +4801,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5285,21 +4813,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5318,12 +4843,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5332,12 +4855,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5375,11 +4896,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5425,23 +4941,18 @@ msgstr ""
 msgid "Nov"
 msgstr "Lap"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "Lapkritis"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5472,7 +4983,7 @@ msgstr ""
 msgid "Number"
 msgstr "Numeris"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Skaičiaus formatas"
 
@@ -5493,13 +5004,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Pasenę"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5508,8 +5017,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Spa"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Spalis"
 
@@ -5521,9 +5029,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5573,7 +5078,6 @@ msgstr ""
 msgid "Open"
 msgstr "Atidaryti"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5595,9 +5099,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5643,7 +5144,6 @@ msgstr "Užsakymo datos nėra!"
 msgid "Order Entry"
 msgstr "Užsakymo įrašas"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5665,7 +5165,6 @@ msgstr "Užsakymai ištrinti!"
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5687,7 +5186,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5732,7 +5231,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5751,10 +5249,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5798,11 +5292,6 @@ msgstr "Įpakavimo sąrašo numerio nėra!"
 msgid "Packing list"
 msgstr "Įpakavimo sąrašas"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5820,12 +5309,10 @@ msgstr "Apmokėta"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Prekė"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5835,14 +5322,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5872,14 +5351,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5895,15 +5370,12 @@ msgstr ""
 msgid "Parts"
 msgstr "Prekė"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5913,7 +5385,6 @@ msgstr ""
 msgid "Password"
 msgstr "Slaptažodis"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5926,7 +5397,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5940,7 +5410,6 @@ msgstr ""
 msgid "Payables"
 msgstr "Pirkimai"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5949,7 +5418,6 @@ msgstr "Pirkimai"
 msgid "Payment"
 msgstr "Mokėjimas"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5962,7 +5430,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5979,7 +5446,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6015,15 +5481,15 @@ msgstr "Mokėjimai"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6042,7 +5508,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6072,108 +5537,88 @@ msgstr ""
 msgid "Pick list"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6189,7 +5634,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6198,24 +5642,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6224,13 +5666,11 @@ msgstr ""
 msgid "Post"
 msgstr "Patvirtinti"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6271,7 +5711,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Postscript(TM)"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6309,20 +5748,16 @@ msgstr ""
 msgid "Price"
 msgstr "Kaina"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6358,8 +5793,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6369,7 +5802,6 @@ msgstr ""
 msgid "Print"
 msgstr "Spausdinti"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6386,7 +5818,7 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Spausdintuvas"
 
@@ -6430,17 +5862,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6469,7 +5899,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6488,7 +5917,6 @@ msgstr ""
 msgid "Project Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6497,9 +5925,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Projektai"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6509,7 +5934,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6527,22 +5951,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Pirkimo užsakymas"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Pirkimo užsakymai"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6557,14 +5975,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Pirkimo užsakymas"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6595,7 +6009,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Kks"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6609,8 +6022,6 @@ msgstr ""
 msgid "Quarter"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6647,9 +6058,7 @@ msgstr ""
 msgid "Quotation deleted!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6670,25 +6079,20 @@ msgstr ""
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "ROP"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6700,7 +6104,6 @@ msgstr "Kursas"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6723,13 +6126,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6747,7 +6146,6 @@ msgstr "Kasos orderis"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6761,8 +6159,7 @@ msgstr "Kasos orderiai"
 msgid "Receivables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr ""
 
@@ -6770,7 +6167,6 @@ msgstr ""
 msgid "Receive Merchandise"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6791,7 +6187,6 @@ msgstr "Sutaikinimas"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6812,13 +6207,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6857,12 +6245,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6900,7 +6286,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6912,7 +6298,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6925,7 +6311,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6974,7 +6359,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -6994,13 +6379,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Iki kada"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7030,7 +6412,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7039,7 +6420,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7056,7 +6436,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7106,11 +6485,11 @@ msgstr ""
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7136,7 +6515,6 @@ msgstr "Pardavimai"
 msgid "Sales Invoice"
 msgstr "Pardavimo SF"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7152,20 +6530,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr "Pardavimų užsakymas"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Pardavimų užsakymai"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr ""
@@ -7187,9 +6562,6 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7213,13 +6585,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7239,7 +6608,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7249,7 +6618,6 @@ msgstr "Išsaugoti"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7308,11 +6676,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "Išsaugoti kaip naują"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7335,10 +6702,8 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Ekranas"
 
@@ -7358,7 +6723,6 @@ msgstr "Ekranas"
 msgid "Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7367,7 +6731,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7420,11 +6783,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7436,11 +6799,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7452,7 +6815,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7460,7 +6823,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7516,7 +6878,6 @@ msgstr ""
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7525,9 +6886,6 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7581,13 +6939,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Rgs"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "Rūgsėjis"
 
@@ -7608,9 +6964,6 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7640,7 +6993,6 @@ msgstr ""
 msgid "Services"
 msgstr "Paslauga"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 msgid "Session Timeout (e.g. \"90 minutes\")"
 msgstr ""
@@ -7653,7 +7005,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7673,10 +7025,10 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Pristatymas"
 
@@ -7703,10 +7055,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7767,10 +7115,6 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7811,7 +7155,6 @@ msgstr ""
 msgid "Short"
 msgstr "Stoka"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7852,7 +7195,6 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7865,12 +7207,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7897,7 +7233,6 @@ msgstr "Dokumentas"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7919,21 +7254,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Standartas"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7964,8 +7288,6 @@ msgstr ""
 msgid "Startdate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8002,13 +7324,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Suvestinė"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Balanso suvestinė"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8038,7 +7358,7 @@ msgstr "Rinkiniai sandėlyje"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Stilių lentelė"
 
@@ -8063,7 +7383,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8106,7 +7425,6 @@ msgstr ""
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8139,12 +7457,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8156,9 +7468,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8177,8 +7486,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8189,17 +7496,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8343,7 +7647,6 @@ msgstr ""
 msgid "Template"
 msgstr "HTML šablonai"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8352,7 +7655,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8405,7 +7707,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8417,7 +7719,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8468,24 +7770,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8508,14 +7807,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8559,7 +7854,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8589,19 +7883,10 @@ msgstr ""
 msgid "To"
 msgstr "iki"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8638,7 +7923,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8663,16 +7947,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8715,7 +7990,7 @@ msgstr ""
 msgid "Total"
 msgstr "Iš viso"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8723,7 +7998,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8744,7 +8018,6 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8760,14 +8033,12 @@ msgstr "Operacijos datos nėra!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8806,7 +8077,6 @@ msgstr ""
 msgid "Translations saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Bandomasis balansas"
@@ -8815,7 +8085,6 @@ msgstr "Bandomasis balansas"
 msgid "Trillion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8872,10 +8141,6 @@ msgstr ""
 msgid "Two"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8910,39 +8175,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8961,43 +8220,37 @@ msgstr "Vienetas"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9005,23 +8258,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9038,7 +8286,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9066,21 +8313,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9089,7 +8331,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9107,24 +8348,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9134,7 +8370,6 @@ msgstr "Vartotojas"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9155,7 +8390,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9181,8 +8415,6 @@ msgstr ""
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9192,11 +8424,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9212,7 +8440,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Tiekėjas"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9226,7 +8453,6 @@ msgstr ""
 msgid "Vendor Invoice"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9236,9 +8462,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9268,9 +8491,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "Tiekėjo Vardo nėra!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9278,8 +8499,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Tokio tiekėjo nėra!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9294,7 +8513,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9307,7 +8525,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9330,7 +8547,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr ""
@@ -9339,11 +8555,26 @@ msgstr ""
 msgid "Warning!"
 msgstr ""
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9353,7 +8584,6 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9370,13 +8600,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Svoris"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Svorio vienetas."
@@ -9393,7 +8621,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9410,11 +8637,11 @@ msgstr ""
 msgid "Work order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9457,15 +8684,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Taip"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9492,7 +8714,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9556,17 +8778,12 @@ msgstr "dienos"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9583,7 +8800,7 @@ msgstr ""
 msgid "done"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9611,8 +8828,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9621,22 +8836,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9661,7 +8872,6 @@ msgstr ""
 msgid "sent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9686,8 +8896,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/lv.po
+++ b/locale/po/lv.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Latvian (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -16,27 +16,22 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : "
 "2);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -49,12 +44,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -100,7 +91,6 @@ msgstr "Kreditoru parādi"
 msgid "AP Aging"
 msgstr "KP novecojums"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -109,7 +99,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -124,7 +113,6 @@ msgstr "KP Neapmaksātie"
 msgid "AP Transaction"
 msgstr "KP transakcija"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "KP transakcijas"
@@ -137,9 +125,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -158,7 +144,6 @@ msgstr "Debitoru parādi"
 msgid "AR Aging"
 msgstr "DP novecojums"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -167,7 +152,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -182,7 +166,6 @@ msgstr "DP Neapmaksātie"
 msgid "AR Transaction"
 msgstr "DP transakcija"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "DP transakcijas"
@@ -195,9 +178,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -206,8 +187,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "DP transakcija"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -217,16 +196,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -252,38 +226,20 @@ msgstr ""
 msgid "Account"
 msgstr "Konts"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -304,23 +260,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Konta numurs"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -360,17 +311,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -382,7 +331,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -410,12 +359,10 @@ msgstr "Aktīvs"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -438,11 +385,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr "Pievienot komplektāciju"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -567,7 +514,6 @@ msgstr "Pievienot preču orderi"
 msgid "Add Service"
 msgstr "Pievienot pakalpojumu"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -634,7 +580,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Atjaunināt"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -659,7 +604,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -669,12 +613,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -694,8 +637,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -748,7 +690,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -757,11 +698,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -795,14 +731,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Summa"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -811,27 +743,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Nesamaksātā summa"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -849,14 +775,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -875,17 +801,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -894,13 +817,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -909,7 +825,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -918,14 +833,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -937,19 +850,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Apr"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "Aprīlī"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -965,7 +875,6 @@ msgstr "Vai jūs patiešām vēlaties dzēst tāmes numuru"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -984,19 +893,17 @@ msgstr "Komplektācijas papildinātas!"
 msgid "Asset"
 msgstr "Aktīvs"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1009,29 +916,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1047,7 +951,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1145,8 +1048,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Aug"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Augustā"
 
@@ -1158,7 +1060,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1172,7 +1073,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1185,7 +1085,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1219,8 +1118,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1235,7 +1132,6 @@ msgstr "Bilance"
 msgid "Balance Sheet"
 msgstr "Bilances pārskats"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1256,7 +1152,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1267,7 +1162,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1277,18 +1171,15 @@ msgstr "Valūta"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1301,12 +1192,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1323,13 +1212,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1370,8 +1257,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1418,17 +1303,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1441,12 +1323,10 @@ msgstr ""
 msgid "Business"
 msgstr "Komercdarbība"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Reģistrācijas numurs"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1456,12 +1336,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1483,7 +1361,6 @@ msgstr "Komercdarbība saglabāta"
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1515,18 +1392,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1652,12 +1527,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Kontu plāns"
 
@@ -1677,7 +1551,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "Čeku inventūra"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1706,7 +1579,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1718,9 +1591,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "Apmaksāts"
 
@@ -1748,15 +1621,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Aizvērts"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1770,8 +1641,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1786,22 +1655,18 @@ msgstr "Nav norādīts kods"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1813,39 +1678,31 @@ msgstr ""
 msgid "Company"
 msgstr "Uzņēmums"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Uzņēmuma nosaukums"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1866,7 +1723,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Apstiprināt!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1884,7 +1741,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Kontaktpersona"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1900,7 +1756,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1918,9 +1773,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1950,7 +1802,6 @@ msgstr ""
 msgid "Contra"
 msgstr "Kontrārais konts"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1958,10 +1809,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1992,20 +1839,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Izmaksas"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2021,26 +1864,20 @@ msgstr "Nevarēja saglabāt"
 msgid "Could not transfer Inventory!"
 msgstr "Nevarēja pārsūtīt krājumu"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2052,7 +1889,6 @@ msgstr ""
 msgid "Country"
 msgstr "Valsts"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2065,7 +1901,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2073,11 +1909,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2105,8 +1941,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2114,17 +1948,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Kredīts"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2149,29 +1980,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Val."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2194,18 +2015,14 @@ msgstr "Val."
 msgid "Currency"
 msgstr "Valūta"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Pašreizējs"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2215,11 +2032,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2234,7 +2047,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Klients"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2253,9 +2065,6 @@ msgstr "Nav tāda klienta!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2275,9 +2084,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "Nav norādīts klients!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2289,7 +2096,7 @@ msgstr "Nav tāda klienta!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2313,12 +2120,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2351,28 +2157,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2419,19 +2213,14 @@ msgstr ""
 msgid "Date"
 msgstr "Datums"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2453,7 +2242,6 @@ msgstr "Saņemšanas datums"
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2517,8 +2305,6 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2534,10 +2320,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2547,17 +2331,14 @@ msgstr ""
 msgid "Dec"
 msgstr "Dec"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Decembrī"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2567,7 +2348,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2580,47 +2360,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2633,21 +2404,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "Noklusētās vērtības"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2665,7 +2429,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Dzēst"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2678,7 +2441,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2692,37 +2454,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Piegādes datums"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2744,20 +2502,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2768,46 +2523,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2918,12 +2634,10 @@ msgstr "Sīks apraksts"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2936,7 +2650,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2945,7 +2658,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Atlaide"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2954,28 +2666,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2983,7 +2695,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2992,7 +2703,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -3000,12 +2711,10 @@ msgstr ""
 msgid "Done"
 msgstr "Izdarīts"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3018,12 +2727,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3032,19 +2739,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Čeku izrakstīšana"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3060,10 +2764,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3082,7 +2782,7 @@ msgstr "Nav norādīts apmaksas termiņš!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3108,7 +2808,7 @@ msgstr ""
 msgid "E-mailed"
 msgstr "Nosūtīts pa e-pastu"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3138,7 +2838,7 @@ msgstr ""
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3282,8 +2982,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3297,7 +2995,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Darbinieks"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3307,12 +3004,11 @@ msgstr ""
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3322,37 +3018,26 @@ msgstr "Darbinieki"
 msgid "Employees"
 msgstr "Darbinieki"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3376,7 +3061,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3401,12 +3085,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3416,7 +3098,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3424,7 +3106,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3450,7 +3131,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Uzņēmuma nosaukums"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3462,14 +3143,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Pašu kapitāls"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3483,16 +3161,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3500,7 +3177,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3513,8 +3190,6 @@ msgstr ""
 msgid "Exch"
 msgstr "Kurss"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3529,7 +3204,6 @@ msgstr "Valūtas maiņas kurss"
 msgid "Exchange rate for payment missing!"
 msgstr "Nav norādīts valūtas maiņas kurss maksājumā!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3538,7 +3212,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "Nav norādīts valūtas maiņas kurss!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3556,13 +3229,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Izdevumi/Aktīvi"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3640,8 +3310,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Februārī"
 
@@ -3657,14 +3326,10 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3675,11 +3340,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3690,7 +3355,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3748,12 +3412,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Ienākumi no valūtas maiņas"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Zaudējumi no valūtas maiņas"
@@ -3762,12 +3424,10 @@ msgstr "Zaudējumi no valūtas maiņas"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3784,7 +3444,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3803,18 +3462,10 @@ msgstr ""
 msgid "From"
 msgstr "No"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3835,7 +3486,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3846,15 +3496,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3868,10 +3513,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "GIFI"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3892,7 +3535,6 @@ msgstr "GIFI saglabāts!"
 msgid "GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3901,7 +3543,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3909,11 +3551,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3922,7 +3563,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3930,9 +3571,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3948,7 +3588,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3956,7 +3596,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3972,12 +3612,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3986,7 +3624,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4060,21 +3697,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4105,7 +3727,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4115,13 +3736,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Attēls"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4164,7 +3783,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4198,14 +3816,10 @@ msgstr "Iekļaut nolaižamo izvēlni"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4213,12 +3827,10 @@ msgstr ""
 msgid "Income"
 msgstr "Ienākums"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4229,7 +3841,6 @@ msgstr "Peļņas vai zaudējuma aprēķins"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4239,7 +3850,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Peļņas vai zaudējuma aprēķins"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4259,11 +3869,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4273,30 +3882,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "Iekšējās piezīmes"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4306,17 +3911,14 @@ msgstr "Krājumi"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4342,11 +3944,7 @@ msgstr "Krājums saglabāts"
 msgid "Inventory transferred!"
 msgstr "Krājums pārsūtīts"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4388,8 +3986,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4405,11 +4001,6 @@ msgstr "Nav norādīts rēķina datums!"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4428,7 +4019,6 @@ msgstr "Rēķina numurs"
 msgid "Invoice Number missing!"
 msgstr "Nepareizs rēķina numurs"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4458,12 +4048,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4521,8 +4109,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Jan"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Janvārī"
 
@@ -4551,8 +4138,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jūl"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Jūlijā"
 
@@ -4560,8 +4146,8 @@ msgstr "Jūlijā"
 msgid "Jun"
 msgstr "Jūn"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Jūnijā"
 
@@ -4574,10 +4160,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "LaTeX šablons"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4599,15 +4181,12 @@ msgstr "Darbs/izmaksas"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Valoda"
@@ -4628,7 +4207,6 @@ msgstr "Valodas nav definētas"
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4639,7 +4217,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4661,40 +4238,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr "Izlaides termiņš"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4706,9 +4282,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4730,9 +4304,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4746,8 +4318,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4764,7 +4334,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4801,7 +4370,6 @@ msgstr "Valodu saraksts"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4827,7 +4395,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4845,7 +4412,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4866,7 +4432,7 @@ msgstr ""
 msgid "Login"
 msgstr "Pieteikties"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4894,45 +4460,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Izveidot"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4954,40 +4513,34 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Martā"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Uzcenojums"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "Mai"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Memorands"
@@ -5004,7 +4557,6 @@ msgstr "Paziņojums"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Metode"
@@ -5013,7 +4565,6 @@ msgstr "Metode"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5032,14 +4583,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5053,7 +4601,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5066,14 +4613,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Modelis"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5091,7 +4636,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5115,14 +4660,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5131,15 +4674,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5158,7 +4692,6 @@ msgstr "Nosaukums"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5209,8 +4742,6 @@ msgstr ""
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5232,12 +4763,10 @@ msgstr ""
 msgid "Ninety"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Nē"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5246,7 +4775,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5254,11 +4783,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5266,7 +4795,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5275,11 +4803,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5287,21 +4815,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5320,12 +4845,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5334,12 +4857,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5377,11 +4898,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5427,23 +4943,18 @@ msgstr "Nav nekā pārsūtīšanai"
 msgid "Nov"
 msgstr "Nov"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "Novembrī"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5474,7 +4985,7 @@ msgstr ""
 msgid "Number"
 msgstr "Numurs"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Skaitļa formāts"
 
@@ -5495,13 +5006,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Novecojis"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5510,8 +5019,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Okt"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Oktobrī"
 
@@ -5523,9 +5031,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5575,7 +5080,6 @@ msgstr ""
 msgid "Open"
 msgstr "Atvērts"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5597,9 +5101,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5645,7 +5146,6 @@ msgstr "Nav norādīts ordera datums!"
 msgid "Order Entry"
 msgstr "Ordera ieraksts"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5667,7 +5167,6 @@ msgstr "Orderis izdzēsts"
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5689,7 +5188,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5735,7 +5234,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5754,10 +5252,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5801,11 +5295,6 @@ msgstr "Nav norādīts iesaiņojumu numurs!"
 msgid "Packing list"
 msgstr "Iesaiņojumu saraksts"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5823,12 +5312,10 @@ msgstr "Apmaksāts"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Prece"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5838,14 +5325,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5875,14 +5354,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5898,15 +5373,12 @@ msgstr "Daļas numurs"
 msgid "Parts"
 msgstr "Prece"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5916,7 +5388,6 @@ msgstr ""
 msgid "Password"
 msgstr "Parole"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5929,7 +5400,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5943,7 +5413,6 @@ msgstr ""
 msgid "Payables"
 msgstr "Kreditoru parādi"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5952,7 +5421,6 @@ msgstr "Kreditoru parādi"
 msgid "Payment"
 msgstr "Maksājums"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5965,7 +5433,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5982,7 +5449,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6018,15 +5484,15 @@ msgstr "Maksājumi"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6045,7 +5511,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6076,108 +5541,88 @@ msgstr "Izvēles saraksts"
 msgid "Pick list"
 msgstr "Izvēles saraksts"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6193,7 +5638,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6202,24 +5646,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6228,13 +5670,11 @@ msgstr ""
 msgid "Post"
 msgstr "Iegrāmatot"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6275,7 +5715,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Postscript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6313,20 +5752,16 @@ msgstr ""
 msgid "Price"
 msgstr "Cena"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6362,8 +5797,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6373,7 +5806,6 @@ msgstr ""
 msgid "Print"
 msgstr "Drukāt"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6390,7 +5822,7 @@ msgstr ""
 msgid "Printed"
 msgstr "Izdrukāts"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Printeris"
 
@@ -6434,17 +5866,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6473,7 +5903,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6492,7 +5921,6 @@ msgstr "Projekta apraksta tulkojumi"
 msgid "Project Number"
 msgstr "Projekta numurs"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6501,9 +5929,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Projekti"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6513,7 +5938,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6531,22 +5955,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Pirkšanas orderis"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Pirkšanas orderi"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6561,14 +5979,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Pirkšanas orderis"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6599,7 +6013,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Skaits"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6613,8 +6026,6 @@ msgstr "Skaits pārsniedz noliktavā esošo priekšmetu skaitu"
 msgid "Quarter"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6651,9 +6062,7 @@ msgstr "Nav norādīts tāmes numurs"
 msgid "Quotation deleted!"
 msgstr "Tāme izdzēsta"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6674,25 +6083,20 @@ msgstr "Tāmes pieprasījums"
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "Tāmes pieprasījuma numurs"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "Tāmes pieprasījumu"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "Pasūtīšanas limits"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6704,7 +6108,6 @@ msgstr "Likme"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6727,13 +6130,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6751,7 +6150,6 @@ msgstr "Kvīts"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6765,8 +6163,7 @@ msgstr "Kvītis"
 msgid "Receivables"
 msgstr "Ienākošie maksājumi"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Saņemt"
 
@@ -6774,7 +6171,6 @@ msgstr "Saņemt"
 msgid "Receive Merchandise"
 msgstr "Saņemt preces"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6795,7 +6191,6 @@ msgstr "Izlīdzināšana"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6816,13 +6211,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6861,12 +6249,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6904,7 +6290,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6916,7 +6302,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6929,7 +6315,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6979,7 +6364,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -6999,13 +6384,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Pieprasīja"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7035,7 +6417,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7044,7 +6425,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7061,7 +6441,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7111,11 +6490,11 @@ msgstr "SKU"
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7141,7 +6520,6 @@ msgstr "Pārdošanas"
 msgid "Sales Invoice"
 msgstr "Pārdošanas rēķins"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7157,20 +6535,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr "Pārdošanas orderis"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Pārdošanas orderi"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr ""
@@ -7193,9 +6568,6 @@ msgstr "Tāmi nevar izdzēst!"
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7219,13 +6591,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7245,7 +6614,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7255,7 +6624,6 @@ msgstr "Saglabāt"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7314,11 +6682,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "Saglabāt kā jaunu"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7341,10 +6708,8 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Ekrāns"
 
@@ -7364,7 +6729,6 @@ msgstr "Ekrāns"
 msgid "Search"
 msgstr "Meklēt"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7373,7 +6737,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7426,11 +6789,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7442,11 +6805,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7458,7 +6821,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7466,7 +6829,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7522,7 +6884,6 @@ msgstr ""
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7531,9 +6892,6 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7587,13 +6945,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Sep"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "Septembrī"
 
@@ -7614,9 +6970,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "Seriālais Nr."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7646,7 +6999,6 @@ msgstr ""
 msgid "Services"
 msgstr "Pakalpojums"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 msgid "Session Timeout (e.g. \"90 minutes\")"
 msgstr ""
@@ -7659,7 +7011,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7679,10 +7031,10 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Piegādāt"
 
@@ -7709,10 +7061,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7773,10 +7121,6 @@ msgstr "Nav norādīts nosūtīšanas datums"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7818,7 +7162,6 @@ msgstr "Nosūtīšanas datums"
 msgid "Short"
 msgstr "Aizdošana"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7859,7 +7202,6 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7872,12 +7214,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7904,7 +7240,6 @@ msgstr "Dokuments"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7926,21 +7261,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Standarts"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "Standarta industrijas kodi"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7971,8 +7295,6 @@ msgstr ""
 msgid "Startdate"
 msgstr "Sākuma datums"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8009,13 +7331,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Pārskats"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Bilances atskaite"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8045,7 +7365,7 @@ msgstr "Komplektācijas krājumā"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Stila lapa"
 
@@ -8070,7 +7390,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8113,7 +7432,6 @@ msgstr "Kopējais"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8146,12 +7464,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8163,9 +7475,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8184,8 +7493,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8196,17 +7503,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8350,7 +7654,6 @@ msgstr ""
 msgid "Template"
 msgstr "HTML šabloni"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8359,7 +7662,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8412,7 +7714,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8424,7 +7726,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8475,24 +7777,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8515,14 +7814,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8566,7 +7861,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8596,19 +7890,10 @@ msgstr ""
 msgid "To"
 msgstr "uz"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8645,7 +7930,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8670,16 +7954,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8722,7 +7997,7 @@ msgstr ""
 msgid "Total"
 msgstr "Pavisam Kopā"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8730,7 +8005,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8751,7 +8025,6 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8767,14 +8040,12 @@ msgstr "Nav norādīts transakcijas datums!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8813,7 +8084,6 @@ msgstr "Tulkojumi"
 msgid "Translations saved!"
 msgstr "Tulkojumi saglabāti"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Kontu bilance"
@@ -8822,7 +8092,6 @@ msgstr "Kontu bilance"
 msgid "Trillion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8879,10 +8148,6 @@ msgstr ""
 msgid "Two"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8917,39 +8182,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8968,43 +8227,37 @@ msgstr "Vienība"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9012,23 +8265,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9045,7 +8293,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9073,21 +8320,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9096,7 +8338,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9114,24 +8355,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9141,7 +8377,6 @@ msgstr "Lietotājs"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9162,7 +8397,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9188,8 +8422,6 @@ msgstr "Derīgs līdz"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9199,11 +8431,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9219,7 +8447,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Pārdevējs"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9233,7 +8460,6 @@ msgstr "Pārdevēja vēsture"
 msgid "Vendor Invoice"
 msgstr "Pārdevēja rēķins"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9243,9 +8469,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9275,9 +8498,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "Pārdevējs nav norādīts!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9285,8 +8506,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Nav tāda pārdevēja!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9301,7 +8520,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9314,7 +8532,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9337,7 +8554,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Noliktavas"
@@ -9346,11 +8562,26 @@ msgstr "Noliktavas"
 msgid "Warning!"
 msgstr "Brīdinājums!"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9360,7 +8591,6 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9377,13 +8607,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Svars"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Svara mērvienība"
@@ -9400,7 +8628,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9418,11 +8645,11 @@ msgstr "Darba orderis"
 msgid "Work order"
 msgstr "Darba orderis"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9465,15 +8692,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Jā"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9500,7 +8722,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9564,17 +8786,12 @@ msgstr "dienas"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9591,7 +8808,7 @@ msgstr ""
 msgid "done"
 msgstr "izdarīts"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9619,8 +8836,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9629,22 +8844,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9669,7 +8880,6 @@ msgstr ""
 msgid "sent"
 msgstr "nosūtīts"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9694,8 +8904,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/ms_MY.po
+++ b/locale/po/ms_MY.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Malay (Malaysia) (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,27 +15,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr "Invois"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -48,12 +43,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -99,7 +90,6 @@ msgstr "AP"
 msgid "AP Aging"
 msgstr "Penuaan AP"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr "Invois AP"
@@ -108,7 +98,6 @@ msgstr "Invois AP"
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -123,7 +112,6 @@ msgstr "AP Memberangsangkan"
 msgid "AP Transaction"
 msgstr "Transakai AP"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Transaksi Ap"
@@ -136,9 +124,7 @@ msgstr "Baucer AP"
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -157,7 +143,6 @@ msgstr "AR"
 msgid "AR Aging"
 msgstr "penuaan AR"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr "Invois AR"
@@ -166,7 +151,6 @@ msgstr "Invois AR"
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -181,7 +165,6 @@ msgstr "AR Memberangsangkan"
 msgid "AR Transaction"
 msgstr "Transaksi AR"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Transaksi AR"
@@ -194,9 +177,7 @@ msgstr "Baucer AR"
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -205,8 +186,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Transaksi AR"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -216,16 +195,11 @@ msgstr "Amaun AR/AP/GL"
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr "Akses Dinafikan"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -251,38 +225,20 @@ msgstr "Akses Dinafikan"
 msgid "Account"
 msgstr "Akaun"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr "Deskripsi Akaun"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr "Label Akaun"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr "Nama Akaun"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -303,23 +259,18 @@ msgstr "Nama Akaun"
 msgid "Account Number"
 msgstr "Nombor Akaun"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr "Pengakhiran Akaun Nombor"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr "Permulaan Akaun Nombor"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr "Nama Akaun"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -359,17 +310,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -381,7 +330,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -409,12 +358,10 @@ msgstr "Aktif"
 msgid "Active On"
 msgstr "Aktif pada"
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr "Sesi Aktif"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -437,11 +384,11 @@ msgstr "Tambah Akaun"
 msgid "Add Assembly"
 msgstr "Tambah Pemasangan "
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr "Tambah Aset"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr "Tambah Kelas Aset"
 
@@ -566,7 +513,6 @@ msgstr "Tambah Pesanan Jualan"
 msgid "Add Service"
 msgstr "Tambah Perkhidmatan"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr "Tambah Borang Cukai"
@@ -633,7 +579,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Terbaru"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -658,7 +603,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -668,12 +612,11 @@ msgstr "Alamat"
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr "Basis Yang Diubah"
 
@@ -693,8 +636,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr "Laporan Berumur"
 
@@ -747,7 +689,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -756,11 +697,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -794,14 +730,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Jumlah"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr "Jumlah yang Dibajetkan"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -810,27 +742,21 @@ msgstr "Jumlah yang Dibajetkan"
 msgid "Amount Due"
 msgstr "Jumlah terhutang"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr "Jumlah Melebihi"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr "Jumlah Kurang Daripada"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -848,14 +774,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -874,17 +800,14 @@ msgstr ""
 msgid "Any"
 msgstr "Selain"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr "Diskaun dipohon"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr "Dikaun dipohon daripada lebihan bayaran"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr "Permohonan cakera"
@@ -893,13 +816,6 @@ msgstr "Permohonan cakera"
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -908,7 +824,6 @@ msgstr ""
 msgid "Approve"
 msgstr "Diluluskan"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -917,14 +832,12 @@ msgstr "Diluluskan"
 msgid "Approved"
 msgstr "Diluluskan"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr "Diluluskan Oleh"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr "Disahkan Di"
 
@@ -936,19 +849,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Apr"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "April"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr "Nilai Diperlukan"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr "Dapatan Nilai Yang Tinggal"
 
@@ -964,7 +874,6 @@ msgstr "Adakah anda pasti ingin memadam Nombor Sebut Harga"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -983,19 +892,17 @@ msgstr "Pemasangan diisi semula"
 msgid "Asset"
 msgstr "Aset"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr "Akaun Aset"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr "Kelas Aset"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1008,29 +915,26 @@ msgstr "Mengelasan Aset"
 msgid "Asset Classes"
 msgstr "Kelas aset"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr "Laporan Aset Susut Nilai"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr "Laporan Aset Pembuangan"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr "Laporan Aset "
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr "Tanda Aset"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1046,7 +950,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1144,8 +1047,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Ogos"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Ogos"
 
@@ -1157,7 +1059,6 @@ msgstr ""
 msgid "Automatic"
 msgstr "Automatik"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1171,7 +1072,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1184,7 +1084,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr "Kos Purata"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr "Kos Purata"
@@ -1218,8 +1117,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1234,7 +1131,6 @@ msgstr "Baki"
 msgid "Balance Sheet"
 msgstr "Helaian Kira-kira"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1255,7 +1151,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1266,7 +1161,6 @@ msgstr "Akaun Bank"
 msgid "Bar Code"
 msgstr "Kod Bar"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1276,18 +1170,15 @@ msgstr "Mata Wang"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr "Asas"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr "Kumpulan"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr "Kelas Kumpulan"
@@ -1300,12 +1191,10 @@ msgstr "Kod kawalan batch"
 msgid "Batch Date"
 msgstr "Tarikh Kumpulan"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr "Deskripsi Kumpulan"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr "ID Kumpulan"
@@ -1322,13 +1211,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr "Nama Batch"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr "Nombor Kumpulan"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr "Carian Kumpulan"
@@ -1369,8 +1256,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1417,17 +1302,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr "Nombor Bajet"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr "Keputusan Carian Bajet"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr "Laporan Bajet Varian"
@@ -1440,12 +1322,10 @@ msgstr "Bajet"
 msgid "Business"
 msgstr "Perniagaan"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Nombor Bisnes"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1455,12 +1335,10 @@ msgstr "Jenis Perniagaan"
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1482,7 +1360,6 @@ msgstr "Perniagaan disimpan"
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1514,18 +1391,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr "Tidak boleh membatalkan invois yang telah dibatalkan"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr "Batal ?"
 
@@ -1653,12 +1528,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr "Carta ID"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Carta Akaun"
 
@@ -1678,7 +1552,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "Periksa Senarai Barang"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr "Semak Imbuhan"
@@ -1707,7 +1580,7 @@ msgstr ""
 msgid "Class"
 msgstr "Kelas"
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr "Tarikh dipadam"
 
@@ -1719,9 +1592,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "Padamkan"
 
@@ -1749,15 +1622,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Tutup"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1772,8 +1643,6 @@ msgstr "Baki Pengakhiran"
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1788,22 +1657,18 @@ msgstr "kod hilang"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr "Gabung"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr "Mengabung pesanan jualan"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr "Mengabung pesanan jualan"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1815,39 +1680,31 @@ msgstr "Mengabung pesanan jualan"
 msgid "Company"
 msgstr "Syarikat"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr "Alamat Syarikat"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr "Faks Syarikat"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr "Maklumat syarikat"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr "Nombor Lesen Syarikat"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Nama Syarikat"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr "Nombor Telefon Syarikat"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr "ID Cukai Jualan Syarikat"
@@ -1868,7 +1725,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Sah!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1886,7 +1743,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Hubungan"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1902,7 +1758,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1920,9 +1775,6 @@ msgstr "Kenalan"
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1952,7 +1804,6 @@ msgstr ""
 msgid "Contra"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1960,10 +1811,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1994,20 +1841,16 @@ msgstr "Salin Ke Baru"
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "kos"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr "Kos Barangan Yang Dijual"
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2023,26 +1866,20 @@ msgstr "Tidak boleh disimpan"
 msgid "Could not transfer Inventory!"
 msgstr "Tidak dapat memindahkan Inventori!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr "Dikira"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2054,7 +1891,6 @@ msgstr ""
 msgid "Country"
 msgstr "Negara"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2067,7 +1903,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2075,11 +1911,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr "Bina pankalan data?"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2107,8 +1943,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2116,17 +1950,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Kredit"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr "Akaun Kredit"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr "No Akaun Kredit"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr "Akaun Kredit"
@@ -2151,29 +1982,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr "Nota kredit"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr "Kredit"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2196,18 +2017,14 @@ msgstr ""
 msgid "Currency"
 msgstr "Mata Wang"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Semasa"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2217,11 +2034,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2236,7 +2049,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Pelanggan"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr "Akaun Pelanggan"
@@ -2255,9 +2067,6 @@ msgstr "Pelangan tiada dalam fail!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2277,9 +2086,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "Pelanggan hilang"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2291,7 +2098,7 @@ msgstr "Pelangan tiada dalam fail!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2315,12 +2122,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr "Data gagal disimpan. Sila cuba lagi"
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr "Data tidak disimpan. Tolong update semula."
 
@@ -2353,28 +2159,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr "Pengkalan data tidak wujud"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2421,19 +2215,14 @@ msgstr ""
 msgid "Date"
 msgstr "Tarikh"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr "Dari Tarikh"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2455,7 +2244,6 @@ msgstr "Tarikh diterima"
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr "Kepada Tarikh"
@@ -2519,8 +2307,6 @@ msgstr "Hari"
 msgid "Days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2536,10 +2322,8 @@ msgstr "Invois debit"
 msgid "Debit Note"
 msgstr "Nota debit"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2549,17 +2333,14 @@ msgstr "Debit"
 msgid "Dec"
 msgstr "Dis"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Disember"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr "Angka perpuluhan untuk mata wang"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2569,7 +2350,6 @@ msgstr "Kelas Pemotongan"
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr "Jenis Pemotongan"
@@ -2582,47 +2362,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr "Akaun Tetapan Utama"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr "Negara"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr "Tetapan utama Email BCC"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr "Tetapan utama Email CC"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr "Tetapan utama Email daripada"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr "Tetapan utama Email kepada"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr "Bahasa"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr "Tetapan Utama yang dilaporkan"
@@ -2635,21 +2406,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "Asal"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2667,7 +2431,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Padam"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr "Padam Kumpulan"
@@ -2680,7 +2443,6 @@ msgstr "Padam Bahasa"
 msgid "Delete Schedule"
 msgstr "Padam Jadual"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr "Padam Baucer"
@@ -2694,37 +2456,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Tarikh Penghantaran"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2746,20 +2504,17 @@ msgstr "Penyusutan"
 msgid "Depreciate Through"
 msgstr "Melalui Penyusutan"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr "Susut Nilai"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr "Akaun Susut Nilai"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2770,46 +2525,7 @@ msgstr "Kaedah Susut Nilai"
 msgid "Depreciation Starts"
 msgstr "Permulaan Susut Nilai"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2920,12 +2636,10 @@ msgstr "Butiran"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr "Disk"
@@ -2938,7 +2652,6 @@ msgstr "Disk"
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2947,7 +2660,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Diskaun"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2956,28 +2668,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr "Pembuangan"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr "Tarikh Pembuangan"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr "Cara Pembuangan"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr "Kesalahan bahagian 0"
 
@@ -2985,7 +2697,6 @@ msgstr "Kesalahan bahagian 0"
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr "Dokumen"
@@ -2994,7 +2705,7 @@ msgstr "Dokumen"
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr "Tidak mengetahui apa yang perlu dibuat dengan backup "
 
@@ -3002,12 +2713,10 @@ msgstr "Tidak mengetahui apa yang perlu dibuat dengan backup "
 msgid "Done"
 msgstr "Selesai"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3020,12 +2729,10 @@ msgstr "Dr."
 msgid "Draft Posted"
 msgstr "Draf yang tercatat"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr "Carian Draf"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr "Jenis Draf"
@@ -3034,19 +2741,16 @@ msgstr "Jenis Draf"
 msgid "Drafts"
 msgstr "Draf"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Lukisan"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr "Gugurkan"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3062,10 +2766,6 @@ msgstr "Gugurkan"
 msgid "Due"
 msgstr "Tarikh Akhir"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3084,7 +2784,7 @@ msgstr "Tarikh akhir hilang!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr "Salinan nombor pekerja"
 
@@ -3110,7 +2810,7 @@ msgstr "Pesanan e-mail"
 msgid "E-mailed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr "Penyata Gaji ECA"
 
@@ -3140,7 +2840,7 @@ msgstr ""
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr "Mengedit Kelas Aset"
 
@@ -3284,8 +2984,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3299,7 +2997,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Pekerja"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3309,12 +3006,11 @@ msgstr "Nombor Pekerja"
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3324,37 +3020,26 @@ msgstr "Nombor Pekerja"
 msgid "Employees"
 msgstr "Pekerjaan"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3378,7 +3063,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr "Baki Pengakhiran"
@@ -3403,12 +3087,10 @@ msgstr "Masukan inventori"
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3418,7 +3100,7 @@ msgstr "Dimasukkan Oleh"
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr "Di Masukkan Di"
 
@@ -3426,7 +3108,6 @@ msgstr "Di Masukkan Di"
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr "Entiti"
@@ -3452,7 +3133,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Kod Entiti"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr "Masukkan ID"
 
@@ -3464,14 +3145,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3485,16 +3163,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr "Kesalahan membina backup data"
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr "Kesalahan mencipta kumpulan. sila cuba lagi. "
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr "Kesalahan daripada fungsi"
 
@@ -3502,7 +3179,7 @@ msgstr "Kesalahan daripada fungsi"
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr "Ralat: Tidak boleh termasuk ringkasan akaun selain menu dropdown"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3515,8 +3192,6 @@ msgstr "Setiap"
 msgid "Exch"
 msgstr "Tukar"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3531,7 +3206,6 @@ msgstr "Kadar Pertukaran"
 msgid "Exchange rate for payment missing!"
 msgstr "Kadar pertukaran pembayaran hilang!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3540,7 +3214,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "Kadar pertukaran hilang!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr "Telah dijangka"
@@ -3558,13 +3231,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3642,8 +3312,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Februari"
 
@@ -3659,14 +3328,10 @@ msgstr ""
 msgid "File"
 msgstr "Fail"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr "Fail Masukkan"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3677,11 +3342,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr "Nama Fail"
 
@@ -3692,7 +3357,6 @@ msgstr "Nama Fail"
 msgid "File type"
 msgstr "Jenis Fail"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr "Fail"
@@ -3750,12 +3414,10 @@ msgstr "Aset tetap"
 msgid "For"
 msgstr "Untuk"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Keuntungan Pertukaran Asing"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Kerugian Pertukaran Asing"
@@ -3764,12 +3426,10 @@ msgstr "Kerugian Pertukaran Asing"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3786,7 +3446,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr "Jumaat"
@@ -3805,18 +3464,10 @@ msgstr "Jumaat"
 msgid "From"
 msgstr "Dari"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr "Daripada Jumlah"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3837,7 +3488,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr "Daripada gudang"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr "Dari tarikh"
@@ -3848,15 +3498,10 @@ msgstr "Dari tarikh"
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr "Permintaan penuh"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3870,10 +3515,8 @@ msgstr "Permintaan penuh"
 msgid "GIFI"
 msgstr "GIFI"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3894,7 +3537,6 @@ msgstr "GIFI disimpan"
 msgid "GL"
 msgstr "GL"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr "Nombor rujukan GL"
@@ -3903,7 +3545,7 @@ msgstr "Nombor rujukan GL"
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr "Dapat (Kerugian)"
 
@@ -3911,12 +3553,11 @@ msgstr "Dapat (Kerugian)"
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 #, fuzzy
 msgid "Gain/Loss"
 msgstr "Dapat (Kerugian)"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3925,7 +3566,7 @@ msgstr ""
 msgid "General Journal"
 msgstr "Jurnal umum"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr "Laporan Lajuran Umum"
 
@@ -3933,9 +3574,8 @@ msgstr "Laporan Lajuran Umum"
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr "Hasilkan"
 
@@ -3951,7 +3591,7 @@ msgstr "Menjana pesanan"
 msgid "Generate Purchase Orders"
 msgstr "Menjana Pesanan Pembelian"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr "Menjana Pesanan Pembelian dari Jualan Pesanan"
 
@@ -3959,7 +3599,7 @@ msgstr "Menjana Pesanan Pembelian dari Jualan Pesanan"
 msgid "Generate Sales Orders"
 msgstr "Menjana Pesanan Jualan"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr "Menjana Pesanan Pembelian dari Jualan Pesanan"
 
@@ -3975,12 +3615,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr "Barangan dan Servis"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3989,7 +3627,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4063,21 +3700,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4108,7 +3730,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4118,13 +3739,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Gambar"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr "Imej untuk templat"
@@ -4167,7 +3786,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4201,14 +3819,10 @@ msgstr ""
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr "Termasuk Nombor Bahagian"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4216,12 +3830,10 @@ msgstr "Termasuk Nombor Bahagian"
 msgid "Income"
 msgstr "Pendapatan"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr "Kelas Pendapatan"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4232,7 +3844,6 @@ msgstr "Penyata Pendapatan"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr "Jenis Pendapatan"
@@ -4242,7 +3853,6 @@ msgstr "Jenis Pendapatan"
 msgid "Income statement"
 msgstr "Penyata Pendapatan"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4262,11 +3872,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr "Kesalahan Dalaman Pangkalan Data"
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4276,30 +3885,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "Nota Dalaman"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr "Laporan Asas Tidak Sah"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr "Permintaan backup tidak sah"
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr "Tarikh/Masa tidak sah dimasukkan"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr "Baki kenyataan tidak sah. Petunjuk: Sila masukkan nombor"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4309,17 +3914,14 @@ msgstr "inventori"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr "Detail Inventori Pelarasan"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr "Inventori Pelarasan"
@@ -4345,11 +3947,7 @@ msgstr "Inventori disimpan"
 msgid "Inventory transferred!"
 msgstr "Inventori di hantar"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4391,8 +3989,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4408,11 +4004,6 @@ msgstr "Tarikh Invois hilang!"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4431,7 +4022,6 @@ msgstr "Nombor Invois"
 msgid "Invoice Number missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr "Invois Keuntungan/Kerugian"
@@ -4461,12 +4051,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr "Invois tidak dijumpai"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4524,8 +4112,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Jan"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Januari"
 
@@ -4554,8 +4141,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Julai"
 
@@ -4563,8 +4149,8 @@ msgstr "Julai"
 msgid "Jun"
 msgstr "Jun"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Jun"
 
@@ -4577,10 +4163,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "Template LaTeX"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4602,15 +4184,12 @@ msgstr "Tenaga Kerja/Overhead"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Bahasa"
@@ -4631,7 +4210,6 @@ msgstr "Bahasa tidak ditakrifkan"
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4642,7 +4220,6 @@ msgstr "Kos Lepas"
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr "Kemaskini Terakhir"
@@ -4664,40 +4241,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr "Tempoh Proses"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4709,9 +4285,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4733,9 +4307,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4749,8 +4321,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr "Tajuk Surat"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4767,7 +4337,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4804,7 +4373,6 @@ msgstr "senarai Bahasa"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4830,7 +4398,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr "Senarai Gudang"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4848,7 +4415,6 @@ msgstr "Lokasi"
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4869,7 +4435,7 @@ msgstr ""
 msgid "Login"
 msgstr "Daftar masuk"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4897,45 +4463,38 @@ msgstr ""
 msgid "Mailing"
 msgstr "Surat-menyurat"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Buat"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr "Pengguna diurus"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4957,40 +4516,34 @@ msgstr "Manual"
 msgid "Mar"
 msgstr "Mac"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Mac"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Tanda"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr "Max Invois Setiap Cek Resit "
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr "Maksima setiap penurunan"
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "Mei"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Memo"
@@ -5007,7 +4560,6 @@ msgstr "Pesanan"
 msgid "Message: "
 msgstr "Mesej: "
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Cara"
@@ -5016,7 +4568,6 @@ msgstr "Cara"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5035,14 +4586,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5056,7 +4604,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr "Tetapan Misc"
@@ -5069,14 +4616,12 @@ msgstr ""
 msgid "Miss."
 msgstr "Cik"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Model"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr "Isnin"
@@ -5094,7 +4639,7 @@ msgstr "Bulan"
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5118,14 +4663,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5134,15 +4677,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5161,7 +4695,6 @@ msgstr "Nama"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr "Nilai buku bersih"
@@ -5212,8 +4745,6 @@ msgstr "Tarikh seterusnya"
 msgid "Next Number"
 msgstr "Nombor Seterusnya"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5235,12 +4766,10 @@ msgstr ""
 msgid "Ninety"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Tidak"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr "Tiada Akaun AR atau AP Terpilih"
@@ -5249,7 +4778,7 @@ msgstr "Tiada Akaun AR atau AP Terpilih"
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5257,11 +4786,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr "Tiada Set ID"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr "Tiada Amaun"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr "Tiada Nombor Pekerja"
 
@@ -5269,7 +4798,6 @@ msgstr "Tiada Nombor Pekerja"
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5278,11 +4806,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr "Tiada mata wang ditakrifkan. Sila tetapkan mengikut sistem"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr "Tiada data dimuat naik"
 
@@ -5290,23 +4818,20 @@ msgstr "Tiada data dimuat naik"
 msgid "No open Projects!"
 msgstr "Tiada projek yang terbuka"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 "Tiada akaun lebihan pembayaran dipilih. Adakah anda telah membuka akaun "
 "tersebut?"
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr "Tiada laporan dinyatakan"
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5325,12 +4850,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5339,12 +4862,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5382,11 +4903,6 @@ msgstr "Kelas Nota"
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5432,23 +4948,18 @@ msgstr "TIada apa-apa untuk dihantar"
 msgid "Nov"
 msgstr "Nov"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "November"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5479,7 +4990,7 @@ msgstr ""
 msgid "Number"
 msgstr "Nombor"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr ""
 
@@ -5500,13 +5011,11 @@ msgstr "OH"
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Lama"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr "Dilupuskan Oleh"
@@ -5515,8 +5024,7 @@ msgstr "Dilupuskan Oleh"
 msgid "Oct"
 msgstr "Okt"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Oktober"
 
@@ -5528,9 +5036,6 @@ msgstr "Teruskan"
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5580,7 +5085,6 @@ msgstr ""
 msgid "Open"
 msgstr "Buka"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5603,9 +5107,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5651,7 +5152,6 @@ msgstr "Tarikh Pesanan Hilang!"
 msgid "Order Entry"
 msgstr "Entri pesanan"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5673,7 +5173,6 @@ msgstr "Pesanan dipadam"
 msgid "Order generation failed!"
 msgstr "Penjanaan Pesanan gagal!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5695,7 +5194,7 @@ msgstr "Pesanan dihasilkan!"
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr "Baki kita"
 
@@ -5741,7 +5240,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5760,10 +5258,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5807,11 +5301,6 @@ msgstr ""
 msgid "Packing list"
 msgstr "Senarai Bungkusan"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5829,12 +5318,10 @@ msgstr "Dibaya"
 msgid "Parent"
 msgstr "Waris"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Bahagian"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5844,14 +5331,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5881,14 +5360,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5904,15 +5379,12 @@ msgstr "Nombor Bahagian"
 msgid "Parts"
 msgstr "Bahagian"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5922,7 +5394,6 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5935,7 +5406,6 @@ msgstr "Kata laluan mestilah sempadan"
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5949,7 +5419,6 @@ msgstr ""
 msgid "Payables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5958,7 +5427,6 @@ msgstr ""
 msgid "Payment"
 msgstr "Pembayaran"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr "Jumlah Pembayaran"
@@ -5971,7 +5439,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr "Hasil Pembayaran"
@@ -5988,7 +5455,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6025,15 +5491,15 @@ msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 "Bayaran berkaitan dengan invois yang dibatalkan mungkin perlu diterbalikkan"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr "Peratus"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr "Peratusan Pembuangan"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr "Peratusan Yang Tinggal"
 
@@ -6052,7 +5518,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr "Orang"
@@ -6083,108 +5548,88 @@ msgstr "Senarai Pilihan"
 msgid "Pick list"
 msgstr "Senarai Pilihan"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6200,7 +5645,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6209,24 +5653,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6235,13 +5677,11 @@ msgstr ""
 msgid "Post"
 msgstr "Simpan"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr "Simpan Kumpulan"
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr "Tarikh disimpan"
 
@@ -6282,7 +5722,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Postscript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6320,20 +5759,16 @@ msgstr ""
 msgid "Price"
 msgstr "Harga"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6369,8 +5804,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6380,7 +5813,6 @@ msgstr ""
 msgid "Print"
 msgstr "Cetak"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6397,7 +5829,7 @@ msgstr "Cetak dan Simpan sebagai yang baru"
 msgid "Printed"
 msgstr "Sudah Dicetak"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr ""
 
@@ -6441,17 +5873,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr "Teruskan"
 
@@ -6481,7 +5911,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr "Keuntungan/Kerugian"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr "Keuntungan/Kerugian Stok Jualan"
@@ -6500,7 +5929,6 @@ msgstr "Huraian Projek Penterjemahan"
 msgid "Project Number"
 msgstr "Nombor Projek"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr "Nombor Projek/Jabatan"
@@ -6509,9 +5937,6 @@ msgstr "Nombor Projek/Jabatan"
 msgid "Projects"
 msgstr "Projek"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6521,7 +5946,6 @@ msgstr "Tarikh Pembelian"
 msgid "Purchase Date:"
 msgstr "Tarikh Pembelian"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6539,22 +5963,16 @@ msgstr "Rekod Pembelian"
 msgid "Purchase Order"
 msgstr "Beli Pesanan"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Beli Pesanan"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6569,14 +5987,10 @@ msgstr "Nilai Pembelian"
 msgid "Purchase order"
 msgstr "Beli Pesanan"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6607,7 +6021,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Kuantiti"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6621,8 +6034,6 @@ msgstr "Kuantiti melebihi unit yang ada kepada stok!"
 msgid "Quarter"
 msgstr "Suku"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6659,9 +6070,7 @@ msgstr "Nombor sebut harga hilang!"
 msgid "Quotation deleted!"
 msgstr "Sebut Harga dipadam!"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6682,25 +6091,20 @@ msgstr "RFQ"
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "Nombor RFQ"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "RFQs"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6712,7 +6116,6 @@ msgstr "Kadar"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6735,13 +6138,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6759,7 +6158,6 @@ msgstr "Resit"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr "Hasil Resit"
@@ -6773,8 +6171,7 @@ msgstr "Resit"
 msgid "Receivables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Diterima"
 
@@ -6782,7 +6179,6 @@ msgstr "Diterima"
 msgid "Receive Merchandise"
 msgstr "Penerimaan barang dagangan"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6803,7 +6199,6 @@ msgstr ""
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr "Laporan Pendamaian"
@@ -6824,13 +6219,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Perulangan Input Transaksi"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6869,12 +6257,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr "Ditolak"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6912,7 +6298,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr "Hasil Laporan"
 
@@ -6924,7 +6310,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6937,7 +6323,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr "Laporan Asas"
@@ -6987,7 +6372,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr "Tarikh yang Diperlukan"
 
@@ -7007,13 +6392,10 @@ msgstr "Tarikh yang Diperlukan"
 msgid "Required by"
 msgstr "Diperlukan oleh"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7043,7 +6425,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7052,7 +6433,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7069,7 +6449,6 @@ msgstr "Lebihan pembayaran semula"
 msgid "Reverse Payment"
 msgstr "Pembayaran Balik"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr "Pembayaran Balik"
@@ -7119,11 +6498,11 @@ msgstr "SKU"
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7149,7 +6528,6 @@ msgstr "Jualan"
 msgid "Sales Invoice"
 msgstr "Jualan Invois"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "jualan invois/nombor urus niaga AR"
@@ -7165,20 +6543,17 @@ msgstr "jualan invois/nombor urus niaga AR"
 msgid "Sales Order"
 msgstr "Pesanan Jualan"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "Nombor pesanan jualan"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Pesanan Jualan"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "Nombor Sebut Harga Jualan"
@@ -7201,9 +6576,6 @@ msgstr "Nombor Sebut Harga Jualan"
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7227,13 +6599,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr "Nilai Penyelamat"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr "Sabtu"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7253,7 +6622,7 @@ msgstr "Sabtu"
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7263,7 +6632,6 @@ msgstr "Simpan"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr "Simpan sejumlah"
@@ -7322,11 +6690,10 @@ msgstr "Simpan sebagai baru"
 msgid "Save as new"
 msgstr "Simpan sebagai baru"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7349,10 +6716,8 @@ msgstr "Jadual"
 msgid "Scheduled"
 msgstr "Sudah Dijadualkan"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Skrin"
 
@@ -7372,7 +6737,6 @@ msgstr "Skrin"
 msgid "Search"
 msgstr "Cari"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr "Mencari AP"
@@ -7381,7 +6745,6 @@ msgstr "Mencari AP"
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr "Mencari AR"
@@ -7434,11 +6797,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr "Carian kumpulan harga"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr "Mencari pesanan pembelian"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr "Cari Sebut harga"
 
@@ -7450,11 +6813,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr "Mencari sebut harga yg diminta"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr "Mencari pesanan jualan"
 
@@ -7466,7 +6829,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr "Carian dan GL"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr "Pemeriksaan Laporan"
 
@@ -7474,7 +6837,6 @@ msgstr "Pemeriksaan Laporan"
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr "Tetapan Keselamatan"
@@ -7530,7 +6892,6 @@ msgstr "Pilih txt, postscript atau PDF!"
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr "Terpilih"
@@ -7539,9 +6900,6 @@ msgstr "Terpilih"
 msgid "Sell"
 msgstr "Jual"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7595,13 +6953,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Sep"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr "Tugas Berasingan"
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "September"
 
@@ -7622,9 +6978,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "No. Siri"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7654,7 +7007,6 @@ msgstr "kod servis"
 msgid "Services"
 msgstr "Servis"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 #, fuzzy
 msgid "Session Timeout (e.g. \"90 minutes\")"
@@ -7668,7 +7020,7 @@ msgstr "Sesi"
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7688,10 +7040,10 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Hantar"
 
@@ -7718,10 +7070,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7782,10 +7130,6 @@ msgstr "Tarikh penghantaran hilang!"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7827,7 +7171,6 @@ msgstr "Tarikh penghantaran"
 msgid "Short"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7868,7 +7211,6 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7881,12 +7223,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7913,7 +7249,6 @@ msgstr "Sumber"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr "Sumber bermula dengan"
@@ -7935,21 +7270,10 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "Standart kod industri"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7980,8 +7304,6 @@ msgstr ""
 msgid "Startdate"
 msgstr "Tarikh mula"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8018,13 +7340,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Kenyataan"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Baki Penyata"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8055,7 +7375,7 @@ msgstr "Himpunan Stok "
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr ""
 
@@ -8080,7 +7400,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8123,7 +7442,6 @@ msgstr "Ringkasan"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr "Ahad"
@@ -8156,12 +7474,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8173,9 +7485,6 @@ msgstr "Tanda"
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8194,8 +7503,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr "Kod Cukai"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8206,17 +7513,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr "Bentuk cukai digunakan"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr "Cukai dalam bentuk senarai"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8360,7 +7664,6 @@ msgstr ""
 msgid "Template"
 msgstr "Simpan Templat"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8369,7 +7672,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr "templat Disimppan!"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8422,7 +7724,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr "Baki mereka"
 
@@ -8434,7 +7736,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8485,24 +7787,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr "Pertukaran gl ini ialah disebabkan oleh pembayaran transit"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr "Pergerakan gl ialah hasil daripada transit lebihan bayaran"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8525,14 +7824,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr "Khamis"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8576,7 +7871,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8606,19 +7900,10 @@ msgstr ""
 msgid "To"
 msgstr "Kepada"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr "Kepada Jumlah"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8655,7 +7940,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr "Untuk bayar"
@@ -8680,16 +7964,7 @@ msgstr ""
 msgid "Top-level"
 msgstr "Tahap Tertinggi"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8732,7 +8007,7 @@ msgstr "Tahap Tertinggi"
 msgid "Total"
 msgstr "Jumlah"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8740,7 +8015,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr "Jumlah Dibayar"
@@ -8761,7 +8035,6 @@ msgstr "Transaksi"
 msgid "Transaction Approval"
 msgstr "Transaksi Diterima"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8777,14 +8050,12 @@ msgstr "Tarikh Transaksi Hilang!"
 msgid "Transaction Dates"
 msgstr "Tarikh Penterjemahan"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8823,7 +8094,6 @@ msgstr "Terjemahan"
 msgid "Translations saved!"
 msgstr "Terjemahan disimpan"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Baki Percubaan"
@@ -8832,7 +8102,6 @@ msgstr "Baki Percubaan"
 msgid "Trillion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr "Selasa"
@@ -8889,10 +8158,6 @@ msgstr ""
 msgid "Two"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8927,39 +8192,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr "Nombor Unik AR Invois"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr "Nombor pelanggan unik"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr "Nombor Unik Pembekal"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8978,43 +8237,37 @@ msgstr "Unit"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr "Pangkalan data tidak dikenali dijumpai"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9022,23 +8275,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr "Jenis akaun yang tidak disokong"
@@ -9055,7 +8303,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9083,21 +8330,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9106,7 +8348,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9124,24 +8365,19 @@ msgstr "Menggunakan Bayaran Lebih"
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr "Guna lebihan pembayaran/prabayaran"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr "Digunakan"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9151,7 +8387,6 @@ msgstr "Pengguna"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr "Pengguna telah wujud. impot?"
@@ -9172,7 +8407,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9198,8 +8432,6 @@ msgstr "Sah Sehingga"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9209,11 +8441,7 @@ msgstr "Varian"
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9229,7 +8457,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Pembekal"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr "Akaun Pembekal"
@@ -9243,7 +8470,6 @@ msgstr "Rekod Pembekal"
 msgid "Vendor Invoice"
 msgstr "Pembekal Senarai Bekalan"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr "invois pembekal/nombor urus niaga AP"
@@ -9253,9 +8479,6 @@ msgstr "invois pembekal/nombor urus niaga AP"
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9285,9 +8508,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "Pembekal hilang!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9295,8 +8516,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Pembekal tiada dalam fail!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9311,7 +8530,6 @@ msgstr ""
 msgid "Void"
 msgstr "Batal"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr "Senarai Baucer"
@@ -9324,7 +8542,6 @@ msgstr "Baucer"
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr "Gaji/Potongan"
@@ -9347,7 +8564,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Gudang-gudang"
@@ -9356,11 +8572,26 @@ msgstr "Gudang-gudang"
 msgid "Warning!"
 msgstr ""
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr "Rabu"
@@ -9370,7 +8601,6 @@ msgstr "Rabu"
 msgid "Week"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9387,13 +8617,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Berat"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Berat Unit"
@@ -9410,7 +8638,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9428,11 +8655,11 @@ msgstr "Pesanan Kerja"
 msgid "Work order"
 msgstr "Pesanan Kerja"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9475,15 +8702,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Ya"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9510,7 +8732,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9574,17 +8796,12 @@ msgstr "Hari"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr "padam"
 
@@ -9601,7 +8818,7 @@ msgstr ""
 msgid "done"
 msgstr "selesai"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9629,8 +8846,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9639,22 +8854,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr "lebih besar daripada jumlah yang tersedia"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr "kurang daripada 0"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr "kurang daripada jumlah perlu dibayar"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr "kosong"
@@ -9679,7 +8890,6 @@ msgstr ""
 msgid "sent"
 msgstr "hantar"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 #, fuzzy
 msgid "system type"
@@ -9705,8 +8915,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr "Kesilapan yang tidak dijangka"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr "guna lebihan bayaran"

--- a/locale/po/nb.po
+++ b/locale/po/nb.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Norwegian Bokmål (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -20,27 +20,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr "# Fakturaer"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr "% Nedskrevet."
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr "(+) Beregnet Verdi"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr "(-) Akkum. Nedskrivning"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr "(=) Nedskrevet verdi"
@@ -53,12 +48,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr "."
 
@@ -107,7 +98,6 @@ msgstr "Leverandører"
 msgid "AP Aging"
 msgstr "Leverandører Aldersfordeling"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr "Inngående faktura"
@@ -116,7 +106,6 @@ msgstr "Inngående faktura"
 msgid "AP Invoices"
 msgstr "Inngående fakturaer"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -131,7 +120,6 @@ msgstr "Ubetalte Inngående fakturaer"
 msgid "AP Transaction"
 msgstr "Leverandør Postering"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Leverandør Posteringer"
@@ -144,9 +132,7 @@ msgstr "Kredittbilag Leverandør"
 msgid "AP account"
 msgstr "Leverandørerkonto"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr "Leverandørkonto er tilgjengelig når leverandører er valgt"
 
@@ -165,7 +151,6 @@ msgstr "Kunder"
 msgid "AR Aging"
 msgstr "Aldersfordeling Kunder"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr "Utgående Faktura"
@@ -174,7 +159,6 @@ msgstr "Utgående Faktura"
 msgid "AR Invoices"
 msgstr "Utgående Fakturaer"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -189,7 +173,6 @@ msgstr "Utestående fordringer Kunder"
 msgid "AR Transaction"
 msgstr "Kunde Postering"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Kunde Postering"
@@ -202,9 +185,7 @@ msgstr "Kundekupong"
 msgid "AR account"
 msgstr "Kundekonto"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr "Kunde konto tilgjengelig når kundene er registret."
 
@@ -213,8 +194,6 @@ msgstr "Kunde konto tilgjengelig når kundene er registret."
 msgid "AR transaction"
 msgstr "Kunde Postering"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -224,16 +203,11 @@ msgstr "Kunde/Leverandør/Hovedbok Beløp"
 msgid "Abandonment"
 msgstr "Skrinlagt"
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr "Nektet Adgang"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -259,38 +233,20 @@ msgstr "Nektet Adgang"
 msgid "Account"
 msgstr "Konto"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr "Kontobeskrivelse"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr "Kontobetegnelse"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr "Kontonavn"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -311,23 +267,18 @@ msgstr "Kontonavn"
 msgid "Account Number"
 msgstr "Kontonummer"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr "Kontonummer siste"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr "Kontonummer første"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr "Kontotype"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -367,17 +318,15 @@ msgstr "Kontoskjema"
 msgid "Accounts To"
 msgstr "Konter til"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr "Kontoer merket for avstemming - en gang"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr "Kontoer markert for avstemming eksisterer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr "Kontoer uten overskrift"
 
@@ -389,7 +338,7 @@ msgstr "Kostnad"
 msgid "Accrual Basis:"
 msgstr "Kostnadsbase"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr "Akkumulert Nedskrivning"
 
@@ -417,12 +366,10 @@ msgstr "Aktiv"
 msgid "Active On"
 msgstr "Aktiv på"
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr "Aktiv økt"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -445,11 +392,11 @@ msgstr "Nye kontoer"
 msgid "Add Assembly"
 msgstr "Ny montering"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr "Ny Eiendel"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr "Ny Eiendel klasse"
 
@@ -574,7 +521,6 @@ msgstr "Ny salgsordre"
 msgid "Add Service"
 msgstr "Ny tjeneste"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr "Legg til MVA skjema"
@@ -641,7 +587,6 @@ msgstr "Ny/Forandre Lønn"
 msgid "Add/Update"
 msgstr "Oppdatér"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr "Lagt til nr [_1]"
@@ -666,7 +611,6 @@ msgstr "Adresse:"
 msgid "Address: [_1]"
 msgstr "Adresse1:"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -676,12 +620,11 @@ msgstr "Adresser"
 msgid "Adj"
 msgstr "Just"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr "justert"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr "Juster grunnlag"
 
@@ -701,8 +644,7 @@ msgstr "Justeringsdetaljer"
 msgid "Aged"
 msgstr "Gamle"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr "Gammel Rapport"
 
@@ -755,7 +697,6 @@ msgstr "Alle priser i [_1] midler"
 msgid "All prices in [_1]."
 msgstr "Alle priser i [_1]."
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr "Opptatt"
@@ -764,11 +705,6 @@ msgstr "Opptatt"
 msgid "Allow Input"
 msgstr "Tillat Innlegg"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -802,14 +738,10 @@ msgstr "Tillat Innlegg"
 msgid "Amount"
 msgstr "Beløp"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr "Beløp Budsjettert"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -818,27 +750,21 @@ msgstr "Beløp Budsjettert"
 msgid "Amount Due"
 msgstr "Forfalt beløp"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr "Beløp skjema"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr "Beløp større enn"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr "Beløp mindre enn"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -856,7 +782,7 @@ msgstr "Beløp å betale"
 msgid "Amount/Rate"
 msgstr "Beløp/Kurs"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
@@ -866,7 +792,7 @@ msgstr ""
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -888,17 +814,14 @@ msgstr "Årlig rett linje Månedlig"
 msgid "Any"
 msgstr "Noen"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr "Lagt til rabatt"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr "Lagt til rabatt på grunn av overbetaling"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr "Legg til Disk"
@@ -907,13 +830,6 @@ msgstr "Legg til Disk"
 msgid "Approval Status"
 msgstr "Godkjennings  status"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -922,7 +838,6 @@ msgstr "Godkjennings  status"
 msgid "Approve"
 msgstr "Godkjenne"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -931,14 +846,12 @@ msgstr "Godkjenne"
 msgid "Approved"
 msgstr "Godkjent"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr "Godkjent av"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr "Godkjent ved"
 
@@ -950,19 +863,16 @@ msgstr "Godkjent signatur"
 msgid "Apr"
 msgstr "apr"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "april"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr "Ervervet verdi"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr "Ervervet verdi gjennstår"
 
@@ -978,7 +888,6 @@ msgstr "Er du sikker på at du vil fjerne tilbudsnummer"
 msgid "As per"
 msgstr "Per"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr "Montert"
@@ -997,19 +906,17 @@ msgstr "Monterte omplassert!"
 msgid "Asset"
 msgstr "Eiendeler"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr "Eiendel kontoer"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr "Eiendel klasser"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr "Eiendel klasse Oversikt"
@@ -1022,29 +929,26 @@ msgstr "Eiendel klasse:"
 msgid "Asset Classes"
 msgstr "Eiendel klasser"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr "Eiendel nedskrivnings Rapport"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr "Eiendel disposisjons Rapport"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr "Eiendel oversikt"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr "Eiendel begrenset disposisjons Rapport"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr "Eiendel Merkelapp"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1060,7 +964,6 @@ msgstr "Eiendel til Egenkapital"
 msgid "Assets to Liabilities"
 msgstr "Eiendel til Gjeld"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1158,8 +1061,7 @@ msgstr "Attn: [_1]"
 msgid "Aug"
 msgstr "aug"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "august"
 
@@ -1171,7 +1073,6 @@ msgstr "Revisor: [_1]"
 msgid "Automatic"
 msgstr "Automatisk"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1185,7 +1086,6 @@ msgstr "Tilgjengelige databaser"
 msgid "Available Users"
 msgstr "Tilgjengelige Brukere"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1198,7 +1098,6 @@ msgstr "Tilgjengelig overbetalte"
 msgid "Average Cost"
 msgstr "Gjennomsnittlige kostnader"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr "Snitt Kostnader"
@@ -1232,8 +1131,6 @@ msgstr "Sikkerhetskopi DB"
 msgid "Backup Roles"
 msgstr "Sikkerhetskopi roller"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1248,7 +1145,6 @@ msgstr "Balanse"
 msgid "Balance Sheet"
 msgstr "Balanse"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr "Balanse"
@@ -1269,7 +1165,6 @@ msgstr "Bankkonto"
 msgid "Bank Account:"
 msgstr "Bankkonto:"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1280,7 +1175,6 @@ msgstr "Bankkontoer"
 msgid "Bar Code"
 msgstr "Strekkode"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1290,18 +1184,15 @@ msgstr "Valuta"
 msgid "Base system"
 msgstr "Grunn systemet"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr "Basis"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr "Gruppe"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr "Gruppe Klasse"
@@ -1314,12 +1205,10 @@ msgstr "Gruppe kontrollkode"
 msgid "Batch Date"
 msgstr "Batch dato"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr "Gruppe beskrivelse"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr "Gruppe ID"
@@ -1336,13 +1225,11 @@ msgstr "Gruppe Informasjon"
 msgid "Batch Name"
 msgstr "Gruppe navn"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr "Batch nummer"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr "Gruppe Søk"
@@ -1383,8 +1270,6 @@ msgstr "Fakturering E-mail"
 msgid "Billion"
 msgstr "Milliard "
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1431,17 +1316,14 @@ msgstr "Bokføring er lukket fram til"
 msgid "Budget"
 msgstr "Beudsjett"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr "Budsjettnummer"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr "Budsjett søke resultat"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr "Budsjett Avviksrapport"
@@ -1454,12 +1336,10 @@ msgstr "Budsjetter"
 msgid "Business"
 msgstr "Firma"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Firmanummer"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1469,12 +1349,10 @@ msgstr "Firma type"
 msgid "Business Type:"
 msgstr "Firma type"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr "Firma Avdelingsliste"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr "Firma Avdelingsnummer"
@@ -1496,7 +1374,6 @@ msgstr "Firma lagret!"
 msgid "CC"
 msgstr "Kopi"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1528,18 +1405,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr "Kan ikke annullere en annullert Faktura"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr "Avbryt <b>hele overføringen</b>"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr "Avbryt?"
 
@@ -1665,12 +1540,11 @@ msgstr "Skift passord"
 msgid "Chargeable"
 msgstr "Kan forandres"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr "Chart ID"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Kontoplan"
 
@@ -1690,7 +1564,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "Sjekk varebeholdning"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr "Sjekk Prefix"
@@ -1719,7 +1592,7 @@ msgstr "Poststed"
 msgid "Class"
 msgstr "Klasse"
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr "Slett dato"
 
@@ -1731,9 +1604,9 @@ msgstr "Oppgjørs datoen er [*,_1,dag] inn i fremtiden etter postering."
 msgid "Clear date over [*,_1,day]"
 msgstr "Oppgjørs dato over  [*,_1,day]"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "Slettet"
 
@@ -1761,15 +1634,13 @@ msgstr "Avslutt år"
 msgid "Close books"
 msgstr "Lukk bokføring"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Avsluttet"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1784,8 +1655,6 @@ msgstr "Avslutt data"
 msgid "Closing data"
 msgstr "Avslutt data"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1800,22 +1669,18 @@ msgstr "Mangler kode"
 msgid "Cold Lead"
 msgstr "Ikke interessert/Kald tråd"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr "Slå sammen"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr "Slå sammen Innkjøpsordrer"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr "Slå sammen Salgsordrer"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1827,39 +1692,31 @@ msgstr "Slå sammen Salgsordrer"
 msgid "Company"
 msgstr "Firma"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr "Firmaadresse"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr "Firma fax"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr "Firma Informasjon"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr "Firma Lisens Nummer"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Firmanavn"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr "Firmatelefon"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr "Firmaets MVA nummer"
@@ -1880,7 +1737,7 @@ msgstr "Bekreft handling"
 msgid "Confirm!"
 msgstr "Bekreft!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr "Konflikt med eksisterende data, kanskje ar det lagt inn før?"
 
@@ -1898,7 +1755,6 @@ msgstr "Konflikt med eksisterende data, kanskje ar det lagt inn før?"
 msgid "Contact"
 msgstr "Kontakt"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1914,7 +1770,6 @@ msgstr "Kontakt Info:"
 msgid "Contact Information"
 msgstr "Kontakt Informasjon"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1932,9 +1787,6 @@ msgstr "Kontakter"
 msgid "Content"
 msgstr "Innhold"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1964,7 +1816,6 @@ msgstr "Fortsett til forrige vindu"
 msgid "Contra"
 msgstr "Kontra"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1975,10 +1826,6 @@ msgstr ""
 "se igjennom forslagene for å gjøre alle faktura tallene unike. Oppføringer "
 "med konflikt presenteres med par, med et suffiks lagt til fakturanummeret"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -2009,20 +1856,16 @@ msgstr "Kopier til Ny"
 msgid "Copy to New Name"
 msgstr "Kopier til Nytt Navn"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Kostpris"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr "Kostnader for solgte varer"
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr "Kunne ikke laste Mal fra DB"
 
@@ -2038,26 +1881,20 @@ msgstr "Kunne ikke lagre"
 msgid "Could not transfer Inventory!"
 msgstr "Kunne ikke overføre varebeholdning!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr "Tellet"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr "Motpart"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr "Motpartsnummer"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2069,7 +1906,6 @@ msgstr "Motpartsnummer"
 msgid "Country"
 msgstr "Land"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr "Navn på Land"
@@ -2082,7 +1918,7 @@ msgstr "Land"
 msgid "Create"
 msgstr "Opprett"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2090,11 +1926,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr "Opprett Gruppe"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr "Opprett Database"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2122,8 +1958,6 @@ msgstr "Laget av"
 msgid "Created On"
 msgstr "Laget på"
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2131,17 +1965,14 @@ msgstr "Laget på"
 msgid "Credit"
 msgstr "Kredit"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr "Kredittkonto"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr "Kredittkontonummer"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr "Kredittkontoer"
@@ -2166,29 +1997,19 @@ msgstr "Kredittgrense:"
 msgid "Credit Note"
 msgstr "Kreditnota"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr "Kreditt"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Val"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2211,18 +2032,14 @@ msgstr "Val"
 msgid "Currency"
 msgstr "Valuta"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Nåværende"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2232,11 +2049,7 @@ msgstr "Nåværende fortjeneste"
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2251,7 +2064,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Kunde"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr "Kundekonto"
@@ -2270,9 +2082,6 @@ msgstr "Kunde mangler i databasen!"
 msgid "Customer Name"
 msgstr "Kundenavn"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2292,9 +2101,7 @@ msgstr "Kunde søk"
 msgid "Customer missing!"
 msgstr "Kunde mangler!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr "Kunde mangler"
 
@@ -2306,7 +2113,7 @@ msgstr "Kunde mangler i databasen!"
 msgid "Customer/Vendor Accounts"
 msgstr "Kunde/Leverandør Kontoer"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr "D M"
 
@@ -2330,12 +2137,11 @@ msgstr "Data fra kontoutskriften"
 msgid "Data from your ledger"
 msgstr "Data fra hovedbok"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr "Data ikke lagret. Prøv igjen."
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr "Data ikke lagret. Prøv oppdater igjen."
 
@@ -2368,28 +2174,16 @@ msgstr "Database administrator rettigheter"
 msgid "Database component"
 msgstr "Database komponent"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr "Databasen eksisterer ikke"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr "Databasen eksisterer."
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2436,19 +2230,14 @@ msgstr "Databasen eksisterer."
 msgid "Date"
 msgstr "Dato"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr "Datoformat"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr "Datoskjema"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2470,7 +2259,6 @@ msgstr "Mottaksdato"
 msgid "Date Reversed"
 msgstr "Dato Reversert"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr "Til Dato"
@@ -2534,8 +2322,6 @@ msgstr "Dag(er)"
 msgid "Days"
 msgstr "Dager"
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2551,10 +2337,8 @@ msgstr "Faktura"
 msgid "Debit Note"
 msgstr "Regning"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2564,17 +2348,14 @@ msgstr "Tilgodehavende"
 msgid "Dec"
 msgstr "des"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "desember"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr "Antall desimaler"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2584,7 +2365,6 @@ msgstr "Fradragsklasse"
 msgid "Deduction Type"
 msgstr "Fradragstype"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr "Fradragsklasser"
@@ -2597,47 +2377,38 @@ msgstr "Standard Leverandører"
 msgid "Default AR"
 msgstr "Standard Kunde"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr "Stsndardkontoer"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr "Standard Land"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr "Standard E_mail Blind kopi"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr "Standard E_mail kopi"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr "Standard E_mail Fra"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr "Standard E_mail Til"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr "Standardformat"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr "Standardspråk"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr "Standard Rapport Tabell"
@@ -2650,21 +2421,14 @@ msgstr "Standardbeløp"
 msgid "Defaults"
 msgstr "Standardinnstillinger"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2682,7 +2446,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Slett"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr "Slett Gruppe"
@@ -2695,7 +2458,6 @@ msgstr "Slett Språk"
 msgid "Delete Schedule"
 msgstr "Slette Fordelinger"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr "Slette Kuponger"
@@ -2709,37 +2471,33 @@ msgstr "Slettes et språk slettes også malen til språket [_1]"
 msgid "Delivery"
 msgstr "Levering"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Leveringsdato"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr "Avdeling Basis"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr "Avdeling Metode"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr "Avdeling Start"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr "Nedskrevet gjennom"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr "Avdeling YTD"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr "Avdeling denne kjøring"
 
@@ -2761,20 +2519,17 @@ msgstr "Avskrive"
 msgid "Depreciate Through"
 msgstr "Avskrive igjennom"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr "Avskrivning"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr "Avskrivnings Konto"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2785,46 +2540,7 @@ msgstr "Avskrivnings Metode"
 msgid "Depreciation Starts"
 msgstr "Avskrivnings Start"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2935,12 +2651,10 @@ msgstr "Detalj"
 msgid "Details"
 msgstr "Detaljer"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr "Deaktiver Tilbake Knapp"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr "Rab"
@@ -2953,7 +2667,6 @@ msgstr "Rab"
 msgid "Disc %"
 msgstr "Rab %"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2962,7 +2675,6 @@ msgstr "Rab %"
 msgid "Discount"
 msgstr "Rabatt"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr "Rabatt (%)"
@@ -2971,28 +2683,28 @@ msgstr "Rabatt (%)"
 msgid "Discount:"
 msgstr "Rabatt:"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr "Vis Aktivert Verdi"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr "Deponert"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr "Deponert Dato"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr "Deponert Metode"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr "Deponert Rapport [_1] på dato [_2]"
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr "Feil, dividert på 0"
 
@@ -3000,7 +2712,6 @@ msgstr "Feil, dividert på 0"
 msgid "Do not keep field empty [_1]"
 msgstr "Doble kundenummer"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr "Dokument"
@@ -3009,7 +2720,7 @@ msgstr "Dokument"
 msgid "Document Type"
 msgstr "Dokumenttype"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr "Vei ikke hvordan å bruke backup"
 
@@ -3017,12 +2728,10 @@ msgstr "Vei ikke hvordan å bruke backup"
 msgid "Done"
 msgstr "Ferdig"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr "Doble kundenummer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr "Doble leverandørnummer"
@@ -3035,12 +2744,10 @@ msgstr "Dr."
 msgid "Draft Posted"
 msgstr "Kladd Sendt"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr "Søk kladd"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr "Kladd type"
@@ -3049,19 +2756,16 @@ msgstr "Kladd type"
 msgid "Drafts"
 msgstr "Kladd"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Tegning"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr "Dropdowns"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3077,10 +2781,6 @@ msgstr "Dropdowns"
 msgid "Due"
 msgstr "Forfall"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3099,7 +2799,7 @@ msgstr "Forfallsdato mangler!"
 msgid "Duplicate User Found: Importing User"
 msgstr "Dublikat bruker funnet: Import bruker"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr "Ansattnummer finnes fra før"
 
@@ -3125,7 +2825,7 @@ msgstr "E-post melding"
 msgid "E-mailed"
 msgstr "Epost sendt"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr "Selvangivelse"
 
@@ -3155,7 +2855,7 @@ msgstr "Endre Kunde Postering"
 msgid "Edit Assembly"
 msgstr "Endre montering"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr "Endre Eiendel Klasse"
 
@@ -3299,8 +2999,6 @@ msgstr "Eleve-o"
 msgid "Email"
 msgstr "E-mail"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3314,7 +3012,6 @@ msgstr "E-mail"
 msgid "Employee"
 msgstr "Ansatt"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3324,14 +3021,13 @@ msgstr "Ansattnummer"
 msgid "Employee Search"
 msgstr "Søk Ansatt"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 "Ansattnavn inneholder ikke de opplysningene som er nødvendig. (f.eks. ikke "
 "tom, alfanumerisk)"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3341,37 +3037,26 @@ msgstr "Ansattnummer"
 msgid "Employees"
 msgstr "Ansatte"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr "Tøm "
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr "Tøm kundekonto"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr "Tomme firmaer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr "Tomme kundenummer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr "Tomme leverandørnummer"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3395,7 +3080,6 @@ msgstr "Slutt dato:"
 msgid "Ending"
 msgstr "Slutt"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr "Sluttbalanse"
@@ -3420,12 +3104,10 @@ msgstr "Legg inn Lagerbeholdning"
 msgid "Enter User"
 msgstr "Legg inn Bruker"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr "Legg inn ansattnummer hvor de mangler"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3435,7 +3117,7 @@ msgstr "Lagt inn av"
 msgid "Entered For"
 msgstr "Lagt inn For"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr "Lagt inn ved"
 
@@ -3443,7 +3125,6 @@ msgstr "Lagt inn ved"
 msgid "Entered at: [_1]"
 msgstr "Lagt inn ved: [_1]"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr "Eksisterende"
@@ -3469,7 +3150,7 @@ msgstr "Eksisterende Kredittkonto"
 msgid "Entity Name"
 msgstr "Eksisterende Kode"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr "Eksisterende ID"
 
@@ -3481,14 +3162,11 @@ msgstr "Konvulutt"
 msgid "Environment"
 msgstr "miljø"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Egenkapital"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr "Egenkapital & Gjeld"
@@ -3502,16 +3180,15 @@ msgstr "Egenkapital (midlertidig)"
 msgid "Equity to Liabilities"
 msgstr "Egenkapital til Gjeld"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr "Feil ved kreering av backup fil"
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr "Feil ved kreering av Gruppe fil. Prøv igjen."
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr "Feil fra Funksjon "
 
@@ -3519,7 +3196,7 @@ msgstr "Feil fra Funksjon "
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr "Feil: Kan ikke inkludere sumkonto i andre nedtrekksmenyer"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr "Est. Levetid"
 
@@ -3532,8 +3209,6 @@ msgstr "Hver"
 msgid "Exch"
 msgstr "Vxl"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3548,7 +3223,6 @@ msgstr "Vekslingskurs"
 msgid "Exchange rate for payment missing!"
 msgstr "Vekslingskurs for betaling mangler!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr "Vekslingskurs er ikke definert!"
@@ -3557,7 +3231,6 @@ msgstr "Vekslingskurs er ikke definert!"
 msgid "Exchange rate missing!"
 msgstr "Vekslingskurs mangler!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr "Ventet"
@@ -3575,13 +3248,10 @@ msgstr "Utgiftskonto"
 msgid "Expense/Asset"
 msgstr "Utgift/Eiendel"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr "Utgifter"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3659,8 +3329,7 @@ msgstr "Faks: [_1]"
 msgid "Feb"
 msgstr "feb"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "februar"
 
@@ -3676,14 +3345,10 @@ msgstr "Femti"
 msgid "File"
 msgstr "Fil"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr "Importert Fil"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3694,11 +3359,11 @@ msgstr "Filnavn"
 msgid "File Type"
 msgstr "Filtype"
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr "Filnavn"
 
@@ -3709,7 +3374,6 @@ msgstr "Filnavn"
 msgid "File type"
 msgstr "Filtype"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr "Filer"
@@ -3767,12 +3431,10 @@ msgstr "Faste Eiendeler"
 msgid "For"
 msgstr "For"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Gevinst på valutahandel"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Tap på valutahandel"
@@ -3781,12 +3443,10 @@ msgstr "Tap på valutahandel"
 msgid "Form"
 msgstr "Skjema"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr "Skjemanavn"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr "Format"
@@ -3803,7 +3463,6 @@ msgstr "Fire"
 msgid "Fourteen"
 msgstr "Fjorten"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr "Fri"
@@ -3822,18 +3481,10 @@ msgstr "Fri"
 msgid "From"
 msgstr "Fra"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr "Fra Beløp"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3854,7 +3505,6 @@ msgstr "Fra Fil"
 msgid "From Warehouse"
 msgstr "Fra Lager"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr "Fra Dato"
@@ -3865,15 +3515,10 @@ msgstr "Fra Dato"
 msgid "Full"
 msgstr "Full"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr "Fulle Rettigheter"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3887,10 +3532,8 @@ msgstr "Fulle Rettigheter"
 msgid "GIFI"
 msgstr "SRU"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr "SRU kontoer ikke i \"sru\" tabeller"
 
@@ -3911,7 +3554,6 @@ msgstr "SRU lagret!"
 msgid "GL"
 msgstr "Hovedbok"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr "GL Referansenummer"
@@ -3920,7 +3562,7 @@ msgstr "GL Referansenummer"
 msgid "Gain"
 msgstr "Overskudd"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr "Overskudd (Tap)"
 
@@ -3928,12 +3570,11 @@ msgstr "Overskudd (Tap)"
 msgid "Gain Account"
 msgstr "Oversuddskonto"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 #, fuzzy
 msgid "Gain/Loss"
 msgstr "Overskudd (Tap)"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr "Kunder uten opphold"
@@ -3942,7 +3583,7 @@ msgstr "Kunder uten opphold"
 msgid "General Journal"
 msgstr "Hovedbok "
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr "Hovedboks Rapport"
 
@@ -3950,9 +3591,8 @@ msgstr "Hovedboks Rapport"
 msgid "General Ledger Reports"
 msgstr "Hovedboks Rapporter"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr "Generer"
 
@@ -3968,7 +3608,7 @@ msgstr "Generer orderere"
 msgid "Generate Purchase Orders"
 msgstr "Generer innkjøpsorderere"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr "Generer Innkjøpsordre fra Salgsordre"
 
@@ -3976,7 +3616,7 @@ msgstr "Generer Innkjøpsordre fra Salgsordre"
 msgid "Generate Sales Orders"
 msgstr "Generer salgsorderer"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr "Generer Salgsordre fra Innkjøpsordre"
 
@@ -3992,12 +3632,10 @@ msgstr "Fornavn"
 msgid "Goods & Services"
 msgstr "Varer & Tjenester"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr "Varer og Tjenester"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr "Varer og Tjeneste Historikk"
@@ -4006,7 +3644,6 @@ msgstr "Varer og Tjeneste Historikk"
 msgid "Grand Total"
 msgstr "Grand Total"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4080,21 +3717,6 @@ msgstr "Timer"
 msgid "Hundred"
 msgstr "Hundre"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4125,7 +3747,6 @@ msgstr "IRC"
 msgid "Identification"
 msgstr "Identifikasjon"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4135,13 +3756,11 @@ msgstr "Ignorer Årsavslutning"
 msgid "Ignore year-closing"
 msgstr "Ignorer Årsavslutning"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Bilde"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr "Bilder i Maler"
@@ -4184,7 +3803,6 @@ msgstr "Importer eksisterende bruker"
 msgid "In"
 msgstr "Inn"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr "Inn Svc"
@@ -4219,14 +3837,10 @@ msgstr "Inkludér i rullegardin-menyer"
 msgid "Includes Part"
 msgstr "Importere Vare"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr "Varenummer"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4234,12 +3848,10 @@ msgstr "Varenummer"
 msgid "Income"
 msgstr "Inntekt"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr "Inntektsklasse"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4250,7 +3862,6 @@ msgstr "Driftsregnskap"
 msgid "Income Type"
 msgstr "Inntekts type"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr "Inntekts Typer"
@@ -4260,7 +3871,6 @@ msgstr "Inntekts Typer"
 msgid "Income statement"
 msgstr "Driftsregnskap"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr "Inntekts Filer"
@@ -4283,11 +3893,10 @@ msgstr ""
 "fordringen er fullt betalt. Returnerte varer blir belastet med 10% i "
 "behandlings kostnader. "
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr "Intern Database Error"
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr "Interne Filer"
@@ -4297,30 +3906,26 @@ msgstr "Interne Filer"
 msgid "Internal Notes"
 msgstr "Interne notater"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr "Invalid Rapport Grunnlag"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr "Invalid backup forespørsel"
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr "Invalid Dato/Tid lagt inn"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr "Invalid Rapport Saldo. Hint: Prøv å legge inn et nummer"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4330,17 +3935,14 @@ msgstr "Varebeholdning"
 msgid "Inventory Activity"
 msgstr "Varebeholdning aktivitet"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr "Varebeholdning aktivitetsrapport"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr "Varebeholdning Justeringer Detaljer"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr "Varebeholdning"
@@ -4370,11 +3972,7 @@ msgstr "Varebeholdning lagret"
 msgid "Inventory transferred!"
 msgstr "Varebeholdning overført"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4416,8 +4014,6 @@ msgstr "Faktura Opprettet"
 msgid "Invoice Created Date missing!"
 msgstr "Faktura Opprettet Dato mangler!"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4433,11 +4029,6 @@ msgstr "Fakturadato mangler!"
 msgid "Invoice No."
 msgstr "Fakturanummer."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4456,7 +4047,6 @@ msgstr "Fakturanummer"
 msgid "Invoice Number missing!"
 msgstr "Fakturanummer mangler!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr "Faktura Fortjeneste/Tap"
@@ -4486,12 +4076,10 @@ msgstr "Fakturaforfall"
 msgid "Invoice not found"
 msgstr "Faktura ikke funnet"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr "Fakturasum"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4552,8 +4140,7 @@ msgstr ""
 msgid "Jan"
 msgstr "jan"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "januar"
 
@@ -4582,8 +4169,7 @@ msgstr "Protokoll Linjer"
 msgid "Jul"
 msgstr "jul"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "juli"
 
@@ -4591,8 +4177,8 @@ msgstr "juli"
 msgid "Jun"
 msgstr "jun"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "juni"
 
@@ -4605,10 +4191,6 @@ msgstr "Likviditetsgrad"
 msgid "LaTeX Templates"
 msgstr "LaTeX-Maler"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4630,15 +4212,12 @@ msgstr "Arbeid/kostnader"
 msgid "Labor/Service Code"
 msgstr "Arbeide/Tjenester"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Språk"
@@ -4659,7 +4238,6 @@ msgstr "Språkene er ikke definert!"
 msgid "Last"
 msgstr "Siste"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4670,7 +4248,6 @@ msgstr "Siste Kostnad"
 msgid "Last Name"
 msgstr "Etternavn"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr "Siste Oppdatering"
@@ -4692,41 +4269,40 @@ msgstr "Lede Tid"
 msgid "Leadtime"
 msgstr "forsinkelsestid"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr "Hovedbok sum"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr "LedgerSMB 1.2 db found."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr "LedgerSMB 1.3 db found."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr "LedgerSMB 1.4 db found."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr "LedgerSMB 1.5 db found."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr "LedgerSMB 1.6 database funnet"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr "LedgerSMB 1.7 database funnet."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 #, fuzzy
 msgid "LedgerSMB 1.8 db found."
 msgstr "LedgerSMB 1.2 db found."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 #, fuzzy
 msgid "LedgerSMB 1.9 db found."
 msgstr "LedgerSMB 1.2 db found."
@@ -4739,9 +4315,7 @@ msgstr "LedgerSMB Databasestatistikk"
 msgid "LedgerSMB [_1]"
 msgstr "LedgerSMB [_1]"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4765,9 +4339,7 @@ msgstr "LedgerSMB støtter flere <em>Leverandør</em> kontoer "
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr "LedgerSMB støtter flere <em>kunde</em> kontoer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4783,8 +4355,6 @@ msgstr "Mindre Utestående Sjekker:"
 msgid "Letterhead"
 msgstr "Brevhode"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr "Passiva"
@@ -4801,7 +4371,6 @@ msgstr "Lisensnummer"
 msgid "Lifetime Measured In"
 msgstr "Levetid Målt i"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr "Linje Artikkel Varekostnad Rapport"
@@ -4838,7 +4407,6 @@ msgstr "Vis språk"
 msgid "List Overpayments"
 msgstr "Vis Overbetalinger"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4864,7 +4432,6 @@ msgstr "Vis Brukere"
 msgid "List Warehouse"
 msgstr "Vis Lagerbeholdning"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr "Vis Firma Typer"
@@ -4882,7 +4449,6 @@ msgstr "Lokalisering"
 msgid "Locations"
 msgstr "Lokaliseringer"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr "Lås Varebeskrivelse"
@@ -4903,7 +4469,7 @@ msgstr "Logg inn. Vent litt"
 msgid "Login"
 msgstr "Login"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr "Logg inn?"
 
@@ -4931,32 +4497,29 @@ msgstr "MSN"
 msgid "Mailing"
 msgstr "Forsendelse"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Fabrikat"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr "Gjør ansattnummer unike"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr "Gjør Fakturanummer Unike"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr "Gjør ikke foreldede metanummer unike"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr "Vær sikker på at metanummer unike"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
@@ -4964,14 +4527,10 @@ msgstr ""
 "Forsikre deg om at alle navn kun består av alfanumeriske tegn (og "
 "understreker) og er minst ett tegn langt"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr "Behandle Brukere"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4993,40 +4552,34 @@ msgstr "Bruksanvisning"
 msgid "Mar"
 msgstr "mar"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "mars"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Markup"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr "Maks antall Fakturaer pr. Sjekktalong"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr "Maks pr. nedtrekk"
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "mai"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Notat"
@@ -5043,7 +4596,6 @@ msgstr "Melding"
 msgid "Message: "
 msgstr "Melding:"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Metode"
@@ -5052,7 +4604,6 @@ msgstr "Metode"
 msgid "Method Default"
 msgstr "Standard Metode"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5071,14 +4622,11 @@ msgstr "Mellom Navn"
 msgid "Million"
 msgstr "Million"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr "Mime Type"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr "Min. Tomme linjer"
@@ -5092,7 +4640,6 @@ msgstr "Min antall"
 msgid "Min Taxable"
 msgstr "Min. MVA pliktig"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr "Min. Skattepliktig"
@@ -5105,14 +4652,12 @@ msgstr "Ikke samsvar i Posteringer (Fra opplasting)"
 msgid "Miss."
 msgstr "Miss."
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Modell"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr "Man"
@@ -5130,7 +4675,7 @@ msgstr "Måned(er)"
 msgid "Months"
 msgstr "Måneder"
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr "Mere informasjon finnes i error loggene"
 
@@ -5155,14 +4700,12 @@ msgstr "Flere Datoer"
 msgid "Multiple dates"
 msgstr "Flere Datoer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr "Forskjellige MVA satser i den samme MVA kontoen er funnet;"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr "Må ha kontantkonto i parti"
@@ -5171,15 +4714,6 @@ msgstr "Må ha kontantkonto i parti"
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5198,7 +4732,6 @@ msgstr "Navn"
 msgid "Name:"
 msgstr "Navn:"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr "Netto bokført verdi"
@@ -5249,8 +4782,6 @@ msgstr "Neste dato"
 msgid "Next Number"
 msgstr "Neste nr"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5272,12 +4803,10 @@ msgstr "Nitten"
 msgid "Ninety"
 msgstr "Nitti"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Nei"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr "Ingen Kundekonto eller Leverandørkonto er valgt"
@@ -5286,7 +4815,7 @@ msgstr "Ingen Kundekonto eller Leverandørkonto er valgt"
 msgid "No Account id for [_1]"
 msgstr "Ingen Konto id for [_1] "
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr "Ingen Fil Klasse Spesifisert"
 
@@ -5294,11 +4823,11 @@ msgstr "Ingen Fil Klasse Spesifisert"
 msgid "No ID Set"
 msgstr "Ingen ID satt inn"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr "Ingen NULL Beløp"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr "Ingen NULL Annsattnummer"
 
@@ -5306,7 +4835,6 @@ msgstr "Ingen NULL Annsattnummer"
 msgid "No Old Password"
 msgstr "Ikke noe gammelt passord"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr "Ingen forandringer"
@@ -5315,11 +4843,11 @@ msgstr "Ingen forandringer"
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr "Ingen valutakurser satt. Gjør dette i System/Standard"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr "Ingen Duplikate meta-nummer"
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr "Ingen fil lastet opp"
 
@@ -5327,21 +4855,18 @@ msgstr "Ingen fil lastet opp"
 msgid "No open Projects!"
 msgstr "Ignen åpne prosjekter!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr "Ingen for mye betalt konto valgt. Finnes det noen?"
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr "Ingen referanse nøkkel satt og ingen overskrivning gitt"
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr "Ingen Rapport Spesifisert"
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr "Ingen MVA fra valgte"
@@ -5360,12 +4885,10 @@ msgstr "Ikke avgiftspliktig"
 msgid "Non-cash"
 msgstr "Ingen eksisterende kunde prisgruppe i part kunde"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr "Ingen eksisterende kunde prisgruppe i part kunde"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr "Ingen eksisterende leverandør prisgruppe i part leverandør"
@@ -5374,12 +4897,10 @@ msgstr "Ingen eksisterende leverandør prisgruppe i part leverandør"
 msgid "Non-tracking Items"
 msgstr "Ikke sporbare artikler"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr "Ikke unike fakturanummer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr "Ikke unike fakturanummer oppdaget"
@@ -5419,11 +4940,6 @@ msgstr ""
 "Legg merke til at prosessen som startes ved å trykke på knappen nedenfor, kan "
 "være"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5469,23 +4985,18 @@ msgstr "Ingenting å overføre!"
 msgid "Nov"
 msgstr "nov"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "november"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr "Null ansattnummer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr "Null lag nummer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr "Null modell nummer"
@@ -5516,7 +5027,7 @@ msgstr "Null modell nummer"
 msgid "Number"
 msgstr "Nummer"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Numerisk format"
 
@@ -5537,13 +5048,11 @@ msgstr "OH"
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr "OVERBETALT / FORHÅNDSBETALT / BETALT"
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Foreldet"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr "Foreldet ved"
@@ -5552,8 +5061,7 @@ msgstr "Foreldet ved"
 msgid "Oct"
 msgstr "okt"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "oktober"
 
@@ -5565,9 +5073,6 @@ msgstr "Av vent"
 msgid "Old Password"
 msgstr "Gammelt Passord"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5617,7 +5122,6 @@ msgstr "Bare for ansatte"
 msgid "Open"
 msgstr "Åpne"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5640,9 +5144,6 @@ msgstr "Eller"
 msgid "Or Add To Batch"
 msgstr "Eller legg til parti"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5688,7 +5189,6 @@ msgstr "Ordredato mangler!"
 msgid "Order Entry"
 msgstr "Ordrer"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5710,7 +5210,6 @@ msgstr "Ordre slettet!"
 msgid "Order generation failed!"
 msgstr "Ordre opprettelse feilet"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr "Ordre/Faktura"
@@ -5732,7 +5231,7 @@ msgstr "Ordre Generert"
 msgid "Other Actions"
 msgstr "Andre handlinger"
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr "Vår balanse"
 
@@ -5778,7 +5277,6 @@ msgstr "Overbetaling"
 msgid "Overpayment Account"
 msgstr "Overbetalingkonto"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr "Overbetaling"
@@ -5797,10 +5295,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr "PO #"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5844,11 +5338,6 @@ msgstr "Nummer for følgeseddel mangler!"
 msgid "Packing list"
 msgstr "Følgeseddel"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5866,12 +5355,10 @@ msgstr "Betalt"
 msgid "Parent"
 msgstr "Forelder"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Varegruppe"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr "Varebeskrivelse"
@@ -5881,14 +5368,6 @@ msgstr "Varebeskrivelse"
 msgid "Part Group"
 msgstr "Varegruppe"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5920,14 +5399,10 @@ msgstr "Detaljer"
 msgid "Partial"
 msgstr "Begrensett"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr "Begrenset Salgs Rapport [_1] på dato [_2]"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5943,15 +5418,12 @@ msgstr "Varenummer"
 msgid "Parts"
 msgstr "Varegruppe"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr "Varegruppe"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr "Varegruppe"
@@ -5961,7 +5433,6 @@ msgstr "Varegruppe"
 msgid "Password"
 msgstr "Passord"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr "Passord varighet (dager)"
@@ -5974,7 +5445,6 @@ msgstr "Passordet må stemme"
 msgid "Pay From"
 msgstr "Betal Fra"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5988,7 +5458,6 @@ msgstr "Betal på vegne av"
 msgid "Payables"
 msgstr "Utbetalinger"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5997,7 +5466,6 @@ msgstr "Utbetalinger"
 msgid "Payment"
 msgstr "Betaling"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr "Betalings Beløp"
@@ -6010,7 +5478,6 @@ msgstr "Betaling Ordre Nummer [_1]"
 msgid "Payment Processing"
 msgstr "Betalings Behandling"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr "Betalings Resultat"
@@ -6027,7 +5494,6 @@ msgstr "Betalingsbetingelser"
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6063,15 +5529,15 @@ msgstr "Betalinger"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr "Betalinger koblet ti annullerte fakturaer trenge å bli reversert. "
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr "Prosent"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr "Prosent Fordelt"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr "Prosent gjenværende"
 
@@ -6090,7 +5556,6 @@ msgstr "Valgt periode"
 msgid "Periods"
 msgstr "Perioder"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr "Person"
@@ -6121,7 +5586,6 @@ msgstr "Plukkliste"
 msgid "Pick list"
 msgstr "Plukkliste"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
@@ -6130,7 +5594,6 @@ msgstr ""
 "Vennligst legg til en header på kontoplanen som sorterer før de oppførte "
 "kontoene (\"0000\" fungerer vanligvis) (i standard SL UI)"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
@@ -6139,31 +5602,27 @@ msgstr ""
 "Vennligst legg til minst en header på kontoplanen som sorterer før de "
 "oppførte kontoene (\"0000\" fungerer vanligvis) (i standard SL UI)"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr "Legg til manglende kontoer i næringsoppgaven"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr "Korriger tomme leverandør kontoer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr "Endre tomme kunde kontoer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr "Forandre radene til enten \"H\" eller \"A\""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr "Fiks prisgruppe data i din varekunde tabell (ingen UI tilgjengelig)."
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
@@ -6171,9 +5630,7 @@ msgstr ""
 "Fiks prisgruppe data i din vareleverandør tabell (ingen brukergensesnitt "
 "tilgjengelig)."
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
@@ -6181,31 +5638,23 @@ msgstr ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr "Alle Fakturanummer må være unike"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr "Alle kundenummer må være unike"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr "Alle Ansattnummer må være unike"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr "Alle Leverandørnummer må være unike"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
@@ -6213,26 +5662,22 @@ msgstr ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr "Alle ansatte må må ha et Ansattnummer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr "Pass på at alle nummer som genereres ikke er tomme"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr "Pass på at alle modellnummer som ikke er tomme"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr "Kontroller at det ikke er noen tomme Kundenummer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr "Kontroller at det ikke er noen tomme Leverandørnummer"
@@ -6248,7 +5693,6 @@ msgstr "Gi pris og leveringstid for følgende produkter:"
 msgid "Please select a customer with unused overpayments"
 msgstr "Velg en kunde med ubrukt overbetalte fakturaer"
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr "Velg en gyldig overskrift"
@@ -6257,24 +5701,22 @@ msgstr "Velg en gyldig overskrift"
 msgid "Please select a vendor with unused overpayments"
 msgstr "Velg leverandør med ubrukte overbetalinger."
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr "Vennligst sett en start/slutt tid eller et antall"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr "Bruk pgAdmin3 eller psql for å fjerne duplikatene"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr "Bruk v. 1.2 UI for å legge til SRU kontoer."
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr "Bruk v. 1.3/1.4 UI for å legge til SRU kontoer."
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6283,13 +5725,11 @@ msgstr "Bruk v. 1.3/1.4 UI for å legge til SRU kontoer."
 msgid "Post"
 msgstr "Bokfør"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr "Bokfør Batch"
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr "Bokfør Dato"
 
@@ -6330,7 +5770,6 @@ msgstr "Bokført Inngående Faktura"
 msgid "Postscript"
 msgstr "Postscript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 #, fuzzy
 msgid ""
@@ -6372,20 +5811,16 @@ msgstr "Prefix"
 msgid "Price"
 msgstr "Pris"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr "Prisgruppe"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr "Prisgrupper"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6421,8 +5856,6 @@ msgstr "Prisliste for [_1]"
 msgid "Primary Phone"
 msgstr "Sentralbord tlf"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6432,7 +5865,6 @@ msgstr "Sentralbord tlf"
 msgid "Print"
 msgstr "Skriv ut"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr "Skriv Batch"
@@ -6449,7 +5881,7 @@ msgstr "Skriv ut og lagre som ny"
 msgid "Printed"
 msgstr "Skrevet ut"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Skriver"
 
@@ -6493,17 +5925,15 @@ msgstr "Skriver Postering [_1]"
 msgid "Printing Work Order [_1]"
 msgstr "Skrive Arbeidsordre [_1]"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr "Prioritert Dep."
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr "Prioritert gjennom"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr "Fortsettelser"
 
@@ -6533,7 +5963,6 @@ msgstr "Fortjeneste og Tap"
 msgid "Profit/Loss"
 msgstr "Fortjeneste/tap"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr "Fortjeneste/Tap på lagersalg"
@@ -6552,7 +5981,6 @@ msgstr "Oversettelser av prosjektbeskrivelser"
 msgid "Project Number"
 msgstr "Prosjektnummer"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr "Prosjekt-/Departmentnummer"
@@ -6561,9 +5989,6 @@ msgstr "Prosjekt-/Departmentnummer"
 msgid "Projects"
 msgstr "Prosjekter"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6573,7 +5998,6 @@ msgstr "Innkjøpsdato"
 msgid "Purchase Date:"
 msgstr "Innkjøpsdato:"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6591,22 +6015,16 @@ msgstr "Innkjøpshistorikk"
 msgid "Purchase Order"
 msgstr "Innkjøpsordre"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "Innkjøpsordrenummer"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Innkjøpsordrer"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6621,14 +6039,10 @@ msgstr "Innkjøpsverdi:"
 msgid "Purchase order"
 msgstr "Innkjøpsordre"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr "Kjøpt"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6659,7 +6073,6 @@ msgstr "Kjøpt"
 msgid "Qty"
 msgstr "Antall"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr "Antall"
@@ -6673,8 +6086,6 @@ msgstr "Antallet overstiger tilgjengelig varebeholdning"
 msgid "Quarter"
 msgstr "Kvartal"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6711,9 +6122,7 @@ msgstr "Mangler tilbudsnummer"
 msgid "Quotation deleted!"
 msgstr "Tilbud slettet!"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6734,25 +6143,20 @@ msgstr "Tilbudsforespørsel"
 msgid "RFQ #"
 msgstr "Tilbudsforespørsel #"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "Tilbudsforespørslelsnummer"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "Tilbudsforespørsler"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "Etterbestill ved"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6764,7 +6168,6 @@ msgstr "Rate"
 msgid "Rate (%)"
 msgstr "Rate (%)"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6787,13 +6190,9 @@ msgstr "Reåpne Bøker"
 msgid "Re-open Period"
 msgstr "Gjenåpne periode"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr "Rebygg/Oppgrader?"
 
@@ -6811,7 +6210,6 @@ msgstr "Kvittering"
 msgid "Receipt Date"
 msgstr "Kvitterinsdato"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr "Kviteringsresultat"
@@ -6825,8 +6223,7 @@ msgstr "Kvitteringer"
 msgid "Receivables"
 msgstr "Innbetalinger"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Motta"
 
@@ -6834,7 +6231,6 @@ msgstr "Motta"
 msgid "Receive Merchandise"
 msgstr "Motta varer"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr "Mottatt"
@@ -6855,7 +6251,6 @@ msgstr "Avstemning"
 msgid "Reconciliation Report"
 msgstr "Avstemnings Rapport"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr "Avstemningsrapporter"
@@ -6876,13 +6271,6 @@ msgstr "Gjentagende Posteringer for [_1]"
 msgid "Recurring Transactions"
 msgstr "Gjentagende Posteringer"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6921,12 +6309,10 @@ msgstr "Registrering [_1]"
 msgid "Regular"
 msgstr "Regelmessig"
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr "Avvist"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr "Resterende Levetid"
@@ -6964,7 +6350,7 @@ msgstr ""
 msgid "Report Name"
 msgstr "Rapportnavn"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr "Rapportresultat"
 
@@ -6976,7 +6362,7 @@ msgstr "Innsendt Rapport"
 msgid "Report Type"
 msgstr "Rapport Type"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr "Rapport [_1] på dato [_2]"
 
@@ -6989,7 +6375,6 @@ msgstr "Rapport i"
 msgid "Report type"
 msgstr "Rapport type"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr "Basisrapport"
@@ -7039,7 +6424,7 @@ msgstr "Tilbud les svar"
 msgid "Required By"
 msgstr "Nødvendig ved"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr "Nødvendig Dato"
 
@@ -7059,13 +6444,10 @@ msgstr "Nødvendig Dato"
 msgid "Required by"
 msgstr "Leveringsdato"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr "Obligatorisk inntasting ikke utført"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7095,7 +6477,6 @@ msgstr "Retturner til Logg inn skjerm"
 msgid "Returns"
 msgstr "Inntekt"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr "Inntekter"
@@ -7104,7 +6485,6 @@ msgstr "Inntekter"
 msgid "Reversal Information"
 msgstr "Omgjøre Informasjon"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr "Reverser"
@@ -7121,7 +6501,6 @@ msgstr "Omgjøre Overbetalt"
 msgid "Reverse Payment"
 msgstr "Omgjøre Betaling"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr "Omgjøre Betalinger"
@@ -7171,11 +6550,11 @@ msgstr "SKU"
 msgid "SO Number"
 msgstr "SO Number"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr "SQL-Ledger 3.0 database funnet."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr "SQL-Ledger database funnet."
 
@@ -7201,7 +6580,6 @@ msgstr "Salg"
 msgid "Sales Invoice"
 msgstr "Utgående Faktura"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Utgående Faktura Posterings nummer"
@@ -7217,20 +6595,17 @@ msgstr "Utgående Faktura Posterings nummer"
 msgid "Sales Order"
 msgstr "Salgsordre"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "Salgsordrenummer"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Salgsordrer"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "Salg Tilbudsnummer"
@@ -7253,9 +6628,6 @@ msgstr "Hilsen"
 msgid "Sales:"
 msgstr "Salg:"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7279,13 +6651,10 @@ msgstr "Hilsen"
 msgid "Salvage Value:"
 msgstr "Bergings verdi"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr "Lør"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7305,7 +6674,7 @@ msgstr "Lør"
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7315,7 +6684,6 @@ msgstr "Lagre"
 msgid "Save As New"
 msgstr "Lagre som Ny"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr "Lagre Batch"
@@ -7374,11 +6742,10 @@ msgstr "Lagre som ny"
 msgid "Save as new"
 msgstr "Lagre som ny"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr "Lagre de gitte endringene og forsøk å fortsette overføringen."
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr "Lageret nr [_1]"
@@ -7401,10 +6768,8 @@ msgstr "Planlagt"
 msgid "Scheduled"
 msgstr "Planlagt"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Skjerm"
 
@@ -7424,7 +6789,6 @@ msgstr "Skjerm"
 msgid "Search"
 msgstr "Søk"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr "Søk Leverandør"
@@ -7433,7 +6797,6 @@ msgstr "Søk Leverandør"
 msgid "Search AP Invoices"
 msgstr "Søk Inngående faktura"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr "Søk Kunde"
@@ -7486,11 +6849,11 @@ msgstr "Søk Prisgrupper"
 msgid "Search Pricegroups"
 msgstr "Søk Prisgrupper"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr "Søk Innkjøpsordrer"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr "Søk Tilbudsordre"
 
@@ -7502,11 +6865,11 @@ msgstr "Søk Kvitteringer"
 msgid "Search Reconciliation Reports"
 msgstr "Søk avstemnings Rapport"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr "Søk forespørsel på Tilbud"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr "Søk Salgsordre"
 
@@ -7518,7 +6881,7 @@ msgstr "Søk Ikke godkjente Posteringer"
 msgid "Search and GL"
 msgstr "Søk og Hovedboksrapport"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr "Søk etter Rapporter"
 
@@ -7526,7 +6889,6 @@ msgstr "Søk etter Rapporter"
 msgid "Secondary Phone"
 msgstr "Andre valg Telefon"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr "Sikkerhets Instillinger"
@@ -7582,7 +6944,6 @@ msgstr "Velg txt, postscript eller PDF!"
 msgid "Select using"
 msgstr "Velg å bruke"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr "Valgt"
@@ -7591,9 +6952,6 @@ msgstr "Valgt"
 msgid "Sell"
 msgstr "Selg"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7647,13 +7005,11 @@ msgstr "Sende Arbeidsordre [_1]"
 msgid "Sep"
 msgstr "sep"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr "Saperate Plikter"
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "september"
 
@@ -7674,9 +7030,6 @@ msgstr "Serie #"
 msgid "Serial No."
 msgstr "Serienummer"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7706,7 +7059,6 @@ msgstr "Tjeneste kode"
 msgid "Services"
 msgstr "Tjeneste"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 #, fuzzy
 msgid "Session Timeout (e.g. \"90 minutes\")"
@@ -7720,7 +7072,7 @@ msgstr "Sesjon"
 msgid "Setting"
 msgstr "Innstilling"
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr "Innstillinger"
 
@@ -7740,10 +7092,10 @@ msgstr "Sytten"
 msgid "Seventy"
 msgstr "Sytti"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Send"
 
@@ -7770,10 +7122,6 @@ msgstr "Send til"
 msgid "Ship To:"
 msgstr "Send til:"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7834,10 +7182,6 @@ msgstr "Mangler leveringsdato"
 msgid "Shipping Label"
 msgstr "Sendings Etikett"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7879,7 +7223,6 @@ msgstr "Sendings Etikett"
 msgid "Short"
 msgstr "Kort"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr "Vis kreditt limit"
@@ -7921,7 +7264,6 @@ msgstr "Seksti"
 msgid "Skip"
 msgstr "Hopp over"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr "Solgt"
@@ -7934,12 +7276,6 @@ msgstr "Noen"
 msgid "Sort by"
 msgstr "Sortert av"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7966,7 +7302,6 @@ msgstr "Bilag"
 msgid "Source documentation"
 msgstr "Kilde dokumentasjon"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr "Bilag starter med"
@@ -7988,21 +7323,10 @@ msgstr "Spesial ordre varer kan ikke kanselleres uten en avgift på 10%"
 msgid "Standard"
 msgstr "Standard"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "Standard industrikoder (SIC)"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -8034,8 +7358,6 @@ msgstr "Start å bruke LedgerSMB"
 msgid "Startdate"
 msgstr "Startdato"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8072,13 +7394,11 @@ msgstr "Delstat/område"
 msgid "Statement"
 msgstr "Oppgjør"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Balanseoppgjør"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8109,7 +7429,7 @@ msgstr "Lagermontering"
 msgid "Strength"
 msgstr "Styrke"
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Stílark"
 
@@ -8134,7 +7454,6 @@ msgstr "Anførsel status"
 msgid "Submit"
 msgstr "Avgi"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8177,7 +7496,6 @@ msgstr "Oppsummert"
 msgid "Summary account for"
 msgstr "Oppsummert konto for"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr "Sol"
@@ -8210,12 +7528,6 @@ msgstr "Systemdiagnostikk"
 msgid "TOTAL"
 msgstr "TOTAL"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8227,9 +7539,6 @@ msgstr "Merkelappapp"
 msgid "Tag:"
 msgstr "Merkelappapp"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8248,8 +7557,6 @@ msgstr "MVA konto"
 msgid "Tax Code"
 msgstr "MVA kode"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8260,17 +7567,14 @@ msgstr "MVA Skjema"
 msgid "Tax Form Applied"
 msgstr "MVA Skjema Brukt"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr "MVA Skjema Detaljrapport"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr "MVA Skjema Liste"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr "MVA Skjema Rapport"
@@ -8414,7 +7718,6 @@ msgstr "Tel: [_1]"
 msgid "Template"
 msgstr "Maler"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr "Mal  Oversikt"
@@ -8423,7 +7726,6 @@ msgstr "Mal  Oversikt"
 msgid "Template Saved!"
 msgstr "Mal  lagret"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr "Mal  posteringer"
@@ -8476,7 +7778,7 @@ msgstr "Takk for handelen!"
 msgid "The amount of"
 msgstr "Summen av"
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr "Balanse"
 
@@ -8488,7 +7790,7 @@ msgstr "Deres Gjeld"
 msgid "Their Debits"
 msgstr "Deres Tilgodehavende"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8545,19 +7847,16 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr "Dette dokumentet er godkjent av"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 "Denne hovedbok forandringen, er et resultat av overbetaling i en Postering."
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 "Denne hovedbok forandringen, er et resultat av overbetaling i en Postering."
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
@@ -8566,7 +7865,7 @@ msgstr ""
 "Dette vil <b>beholde</b> transaksjonene, men vil <b>hoppe over</b> de "
 "uaktuelle avstemmingene"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8591,14 +7890,10 @@ msgstr "Begynne"
 msgid "Through date"
 msgstr "Gjennom Dato"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr "Tors"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8642,7 +7937,6 @@ msgstr "Timekort"
 msgid "Timecard Criteria"
 msgstr "Timekort Kriterier"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr "Timekort"
@@ -8672,19 +7966,10 @@ msgstr ""
 msgid "To"
 msgstr "Til"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr "Til Beløp"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8721,7 +8006,6 @@ msgstr "Til E-mail"
 msgid "To my browser"
 msgstr "Til min Browser"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr "Å betale"
@@ -8746,16 +8030,7 @@ msgstr "Veksle alle fjernings avmerkingsboksene"
 msgid "Top-level"
 msgstr "Topplan"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8798,7 +8073,7 @@ msgstr "Topplan"
 msgid "Total"
 msgstr "I alt"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr "Total akkumulert  inskudd"
 
@@ -8806,7 +8081,6 @@ msgstr "Total akkumulert  inskudd"
 msgid "Total Outstanding"
 msgstr "Totalt Utestående"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr "Totalt Betalt"
@@ -8827,7 +8101,6 @@ msgstr "Postering"
 msgid "Transaction Approval"
 msgstr "Godkjenne Postering"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8843,14 +8116,12 @@ msgstr "Posterings dato mangler!"
 msgid "Transaction Dates"
 msgstr "Posterings datoer"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr "Posterings type"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8889,7 +8160,6 @@ msgstr "Oversettelser"
 msgid "Translations saved!"
 msgstr "Oversettelser lagret!"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Foreløpig balanse"
@@ -8898,7 +8168,6 @@ msgstr "Foreløpig balanse"
 msgid "Trillion"
 msgstr "Trillion"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr "Tirs"
@@ -8955,10 +8224,6 @@ msgstr "Tjueto"
 msgid "Two"
 msgstr "To"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8993,7 +8258,7 @@ msgstr "Ikke godkjent"
 msgid "Uncheck to remove entry from payment"
 msgstr "Fjern markeringen for å fjerne oppføringen fra betaling"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
@@ -9003,32 +8268,26 @@ msgstr ""
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr "Uventet fil navn, forventet [_1], fikk [_2]"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr "Unike Fakturanummer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr "Unike Kundenummer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr "Unike Leverandørnummer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr "Unike ikke foreldete varenummer"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -9047,12 +8306,10 @@ msgstr "Enhet"
 msgid "Unit Price"
 msgstr "Enhets Pris"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr "Ukjent"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
@@ -9061,31 +8318,27 @@ msgstr ""
 "Ukjent konto kategori (Skal være A(sset)/L(iability)/E(xpense)/I(nntekt)/"
 "(e)Q(uity))"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr "Ukjent diagram type; skulle være H(Overskrift)/A(Konto)"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr "Ukjent database funnet"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr "Låsopp"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr "Lås opp gruppe"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr "Unødvendige avstemminger"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr "Ikke støttet LedgerSMB versjon oppdaget."
 
@@ -9093,23 +8346,18 @@ msgstr "Ikke støttet LedgerSMB versjon oppdaget."
 msgid "Unsupported Number"
 msgstr "Ikke understøttet Nummer"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr "Ikke understøttet SQL-Ledger versjon oppdaget."
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr "Ikke understøttet konto kategorier"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr "Ikke understøttet konto link kombinasjoner"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr "Ikke understøttet konto type"
@@ -9126,7 +8374,6 @@ msgstr "Ikke i bruk"
 msgid "Up"
 msgstr "Opp"
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9154,21 +8401,16 @@ msgstr "Oppgradert Info"
 msgid "Upload"
 msgstr "Opplast"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr "Laste opp ved"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr "Lastet opp av"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9177,7 +8419,6 @@ msgstr ""
 msgid "Url"
 msgstr "URL"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9195,24 +8436,19 @@ msgstr "Bruk Overbetaling"
 msgid "Use Shipto"
 msgstr "Bruk send til"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr "Bruk overbetaling/forhånsbetaling"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr "Brukt"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9222,7 +8458,6 @@ msgstr "Bruker"
 msgid "User Name"
 msgstr "Bruker Navn"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr "Bruker eksisterer allerede. Importer?"
@@ -9243,7 +8478,6 @@ msgstr "Brukenavn"
 msgid "Users"
 msgstr "Brukere"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9269,8 +8503,6 @@ msgstr "Gyldig til"
 msgid "Valuation"
 msgstr "verdivurdering"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9280,11 +8512,7 @@ msgstr "Forandring"
 msgid "Variance:"
 msgstr "Forandring:"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9300,7 +8528,6 @@ msgstr "Forandring:"
 msgid "Vendor"
 msgstr "Leverandør"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr "Leverandørkonto"
@@ -9314,7 +8541,6 @@ msgstr "Leverandørhistorikk"
 msgid "Vendor Invoice"
 msgstr "Inngående Faktura"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr "Inngående Faktura/Leverandørens Posterings Nummer"
@@ -9324,9 +8550,6 @@ msgstr "Inngående Faktura/Leverandørens Posterings Nummer"
 msgid "Vendor Name"
 msgstr "Leverandør Navn"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9356,9 +8579,7 @@ msgstr "Leverandør søk"
 msgid "Vendor missing!"
 msgstr "Leverandør mangler!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr "Leverandør mangler i en bedrift!"
 
@@ -9366,8 +8587,6 @@ msgstr "Leverandør mangler i en bedrift!"
 msgid "Vendor not on file!"
 msgstr "Leverandør mangler i database!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9382,7 +8601,6 @@ msgstr "Bekrefte"
 msgid "Void"
 msgstr "Annullert"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr "Kupong Liste"
@@ -9395,7 +8613,6 @@ msgstr "Kuponger"
 msgid "Wages and Deductions"
 msgstr "Lønninger og Skattekort"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr "Lønninger/Skatt"
@@ -9418,7 +8635,6 @@ msgstr "Lager slettet!"
 msgid "Warehouse saved!"
 msgstr "Lager lagret!"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Lager"
@@ -9427,11 +8643,31 @@ msgstr "Lager"
 msgid "Warning!"
 msgstr "Advarsel"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+#, fuzzy
+msgid "Warning: Your password will expire in [_1] days"
 msgstr "Advarsel: Passordet ditt går ut om [_1]"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+#, fuzzy
+msgid "Warning: Your password will expire in [_1] months"
+msgstr "Advarsel: Passordet ditt går ut om [_1]"
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+#, fuzzy
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr "Advarsel: Passordet ditt går ut om [_1]"
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+#, fuzzy
+msgid "Warning: Your password will expire in [_1] years"
+msgstr "Advarsel: Passordet ditt går ut om [_1]"
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+#, fuzzy
+msgid "Warning: Your password will expire today"
+msgstr "Advarsel: Passordet ditt går ut om [_1]"
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr "Ons"
@@ -9441,7 +8677,6 @@ msgstr "Ons"
 msgid "Week"
 msgstr "Uke"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr "Uke start"
@@ -9458,13 +8693,11 @@ msgstr "Ukentlig Tid og Vare Ankomst"
 msgid "Weeks"
 msgstr "Uker"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Vekt"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Vektenhet"
@@ -9481,7 +8714,6 @@ msgstr "Hvor skal vi sende sikkerhetskopien?"
 msgid "Whole Month Straight Line"
 msgstr "Hele Måneden i rett linje"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr "Widgit Themes"
@@ -9499,11 +8731,11 @@ msgstr "Arbeidsordre"
 msgid "Work order"
 msgstr "Arbeidsordre"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr "Vil du migrere databasen"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr "Vil du oppgradere databasen?"
 
@@ -9546,16 +8778,10 @@ msgstr "Årsavslutning avsluttet"
 msgid "Years"
 msgstr "År"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Ja"
-
-#: UI/users/preferences.html:52
-#, fuzzy
-msgid "Your password will expire in [_1]"
-msgstr "Passordet ditt går ut om "
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9582,7 +8808,7 @@ msgstr "Postnummer:"
 msgid "Zip/Postal Code"
 msgstr "Postnummer"
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9648,17 +8874,12 @@ msgstr "dager"
 msgid "debits"
 msgstr "tilgode"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr "slett"
 
@@ -9675,7 +8896,7 @@ msgstr "disposisjon"
 msgid "done"
 msgstr "gjort"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr "e"
 
@@ -9703,8 +8924,6 @@ msgstr "import"
 msgid "in months"
 msgstr "i måneder"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9713,22 +8932,18 @@ msgstr ""
 msgid "in years"
 msgstr "i år"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr "er større enn tilgjengelig beløp"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr "er mindre enn 0"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr "er mindre en beløpet som skal betales"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr "er null"
@@ -9753,7 +8968,6 @@ msgstr "produksjon"
 msgid "sent"
 msgstr "sendt"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 #, fuzzy
 msgid "system type"
@@ -9779,8 +8993,6 @@ msgstr "til_dato"
 msgid "unexpected error!"
 msgstr "uventet feil!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr "bruk en overbetaling"
@@ -9885,6 +9097,13 @@ msgstr "bruk en overbetaling"
 
 #~ msgid "Version"
 #~ msgstr "Versjon"
+
+#~ msgid "Warning:  Your password will expire in [_1]"
+#~ msgstr "Advarsel: Passordet ditt går ut om [_1]"
+
+#, fuzzy
+#~ msgid "Your password will expire in [_1]"
+#~ msgstr "Passordet ditt går ut om "
 
 #~ msgid "[_1]:[_2]:[_3]: Invalid Redirect"
 #~ msgstr "[_1]:[_2]:[_3]: Kan ikke videresende"

--- a/locale/po/nl.po
+++ b/locale/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Dutch (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -18,27 +18,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr "# Facturen"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr "% Afschr."
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr "(+) Rest waarde"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr "(-) Cum. afschr."
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr "(=) NBW"
@@ -51,12 +46,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -106,7 +97,6 @@ msgstr "Crediteuren"
 msgid "AP Aging"
 msgstr "Ouderdomsoverzicht Crediteuren"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr "Inkoopfactuur"
@@ -115,7 +105,6 @@ msgstr "Inkoopfactuur"
 msgid "AP Invoices"
 msgstr "Inkoopfacturen"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -130,7 +119,6 @@ msgstr "Openstaande Crediteuren"
 msgid "AP Transaction"
 msgstr "Crediteurenboeking"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Crediteurenboekingen"
@@ -143,9 +131,7 @@ msgstr "Inkoop Voucher"
 msgid "AP account"
 msgstr "Crediteurenrekening"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -164,7 +150,6 @@ msgstr "Debiteuren"
 msgid "AR Aging"
 msgstr "Ouderdomsoverzicht Debiteuren"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr "Verkoopfactuur"
@@ -173,7 +158,6 @@ msgstr "Verkoopfactuur"
 msgid "AR Invoices"
 msgstr "Verkoopfacturen"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -188,7 +172,6 @@ msgstr "Openstaande Debiteuren"
 msgid "AR Transaction"
 msgstr "Debiteurenboeking"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Debiteurenboekingen"
@@ -201,9 +184,7 @@ msgstr "Verkoop Voucher"
 msgid "AR account"
 msgstr "Debiteurenrekening"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -212,8 +193,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Debiteurenboeking"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -223,16 +202,11 @@ msgstr "Debiteuren/Crediteuren/Grootboek Bedrag"
 msgid "Abandonment"
 msgstr "Afschrijving"
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr "Toegang geweigerd"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -258,38 +232,20 @@ msgstr "Toegang geweigerd"
 msgid "Account"
 msgstr "Rekening"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr "Omschrijving grootboekrekening"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr "Rekeninglabel"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr "Rekeninghouder"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -310,23 +266,18 @@ msgstr "Rekeninghouder"
 msgid "Account Number"
 msgstr "Rekeningnummer"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr "Rekeningnummer Einde"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr "Rekeningnummer Begin"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr "Rekeningtitel"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -366,17 +317,15 @@ msgstr "Rekeningen vanaf"
 msgid "Accounts To"
 msgstr "Rekeningen tot"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr "Rekeningen zonder groep"
 
@@ -388,7 +337,7 @@ msgstr "Aangegroeid"
 msgid "Accrual Basis:"
 msgstr "Aangroeibasis:"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr "Cum. Afschrijving"
 
@@ -416,12 +365,10 @@ msgstr "Actief"
 msgid "Active On"
 msgstr "Actief op"
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr "Actieve sessies"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -444,11 +391,11 @@ msgstr "Rekeningen Toevoegen"
 msgid "Add Assembly"
 msgstr "Assemblage Toevoegen"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr "Activa Toevoegen"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr "Vaste activa soort Toevoegen"
 
@@ -573,7 +520,6 @@ msgstr "Verkooporder Toevoegen"
 msgid "Add Service"
 msgstr "Dienst Toevoegen"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr "Belastingformulier Toevoegen"
@@ -640,7 +586,6 @@ msgstr "Loon aanpassen/toevoegen"
 msgid "Add/Update"
 msgstr "Bijwerken"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr "Toegevoegde id [_1]"
@@ -665,7 +610,6 @@ msgstr "Adres:"
 msgid "Address: [_1]"
 msgstr "Adres: [_1]"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -675,12 +619,11 @@ msgstr "Adressen"
 msgid "Adj"
 msgstr "Aanp."
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr "Aangepaste basis"
 
@@ -700,8 +643,7 @@ msgstr "Details van aanpassing"
 msgid "Aged"
 msgstr "Verlopen"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr "Verouderingsrapportage"
 
@@ -754,7 +696,6 @@ msgstr "Alle prijzen in [_1]"
 msgid "All prices in [_1]."
 msgstr "Alle prijzen in [_1]."
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr "Toegewezen"
@@ -763,11 +704,6 @@ msgstr "Toegewezen"
 msgid "Allow Input"
 msgstr "Invoer toestaan"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -801,14 +737,10 @@ msgstr "Invoer toestaan"
 msgid "Amount"
 msgstr "Bedrag"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr "Gebudgetteerd Bedrag"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -817,27 +749,21 @@ msgstr "Gebudgetteerd Bedrag"
 msgid "Amount Due"
 msgstr "Verschuldigd Bedrag"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr "Bedrag vanaf"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr "Bedrag groter dan"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr "Bedrag kleiner dan"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -855,14 +781,14 @@ msgstr "Te betalen bedrag"
 msgid "Amount/Rate"
 msgstr "Bedrag/tarief"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -881,17 +807,14 @@ msgstr "Lineaire afschrijving, per maand"
 msgid "Any"
 msgstr "Elk(e)"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr "Toegepaste korting"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr "Korting bij een vooruitbetaling"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr "Toepassen korting"
@@ -900,13 +823,6 @@ msgstr "Toepassen korting"
 msgid "Approval Status"
 msgstr "Goedkeuringsstatus"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -915,7 +831,6 @@ msgstr "Goedkeuringsstatus"
 msgid "Approve"
 msgstr "Goedkeuren"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -924,14 +839,12 @@ msgstr "Goedkeuren"
 msgid "Approved"
 msgstr "Goedgekeurd"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr "Goedgekeurd door"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr "Goedgekeurd op"
 
@@ -943,19 +856,16 @@ msgstr "Goedkeuringshandtekening"
 msgid "Apr"
 msgstr "apr"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "april"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr "Verkregen prijs bij verkoop"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr "Verkregen restwaarde"
 
@@ -971,7 +881,6 @@ msgstr "Weet u zeker dat u dit offertenummer wilt verwijderen?"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -990,19 +899,17 @@ msgstr "Assemblage Aangevuld!"
 msgid "Asset"
 msgstr "Activa"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr "Activa rekening"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr "Activa soort"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr "Activasoortenlijst"
@@ -1015,29 +922,26 @@ msgstr "Activa soort:"
 msgid "Asset Classes"
 msgstr "Activa soorten"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr "Activa afschrijvingsrapport"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr "Activa verwijderingsrapport"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr "Activalijst"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr "Activa gedeeltelijke verwijderingsrapport"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr "Activa code"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1053,7 +957,6 @@ msgstr "Activa naar Eigen vermogen"
 msgid "Assets to Liabilities"
 msgstr "Activa naar Passiva"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1151,8 +1054,7 @@ msgstr "Aan: [_1]"
 msgid "Aug"
 msgstr "aug"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "augustus"
 
@@ -1164,7 +1066,6 @@ msgstr "Auteur: [_1]"
 msgid "Automatic"
 msgstr "Automatisch"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1178,7 +1079,6 @@ msgstr "Beschikbare databases"
 msgid "Available Users"
 msgstr "Beschikbare gebruikers"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1191,7 +1091,6 @@ msgstr "Beschikbare vooruitbetalingen"
 msgid "Average Cost"
 msgstr "Gemiddelde Kostprijs"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr "Gem. kostprijs"
@@ -1225,8 +1124,6 @@ msgstr "Backup DB"
 msgid "Backup Roles"
 msgstr "Backup rollen"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1241,7 +1138,6 @@ msgstr "Saldo"
 msgid "Balance Sheet"
 msgstr "Balans"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr "Balans"
@@ -1262,7 +1158,6 @@ msgstr "Bankrekening"
 msgid "Bank Account:"
 msgstr "Bankrekening:"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1273,7 +1168,6 @@ msgstr "Bankrekeningen"
 msgid "Bar Code"
 msgstr "Barcode"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1283,18 +1177,15 @@ msgstr "Valuta"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr "Basis"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr "Groep"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr "Groep soort"
@@ -1307,12 +1198,10 @@ msgstr "Groep nummer"
 msgid "Batch Date"
 msgstr "Batch Datum"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr "Groep omschrijving"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr "Groep ID"
@@ -1329,13 +1218,11 @@ msgstr "Groep informatie"
 msgid "Batch Name"
 msgstr "Groep naam"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr "Batch Nummer"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr "Groep zoeken"
@@ -1376,8 +1263,6 @@ msgstr "Facturatie e-mail"
 msgid "Billion"
 msgstr "miljard"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1424,17 +1309,14 @@ msgstr "Boeken afgesloten tot"
 msgid "Budget"
 msgstr "Begroting"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr "Begrotingnummer"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr "Begroting Zoek Resultaten"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr "Begroting verschil rapport"
@@ -1447,12 +1329,10 @@ msgstr "Begrotingen"
 msgid "Business"
 msgstr "Bedrijf"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "KvK-nummer"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1462,12 +1342,10 @@ msgstr "Bedrijfstype"
 msgid "Business Type:"
 msgstr "Bedrijfstype:"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr "Bedrijfsonderdelenlijst"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr "Bedrijfsonderdeelnummer"
@@ -1489,7 +1367,6 @@ msgstr "Bedrijf opgeslagen!"
 msgid "CC"
 msgstr "CC"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1521,18 +1398,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr "Teruggedraaide factuur niet terugdraaibaar!"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr "Annuleren?"
 
@@ -1660,12 +1535,11 @@ msgstr "Wachtwoord aanpassen"
 msgid "Chargeable"
 msgstr "Belastbaar"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr "Chart ID"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Rekeningstelsel"
 
@@ -1685,7 +1559,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "Voorraad controleren"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr "Chequenummer voorvoegsel"
@@ -1714,7 +1587,7 @@ msgstr "(Woon)plaats:"
 msgid "Class"
 msgstr "Class"
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr "Afhandelingsdatum"
 
@@ -1726,9 +1599,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "Afgehandeld"
 
@@ -1756,15 +1629,13 @@ msgstr "Jaar afsluiten"
 msgid "Close books"
 msgstr "Boeken afsluiten"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Afgesloten"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1779,8 +1650,6 @@ msgstr "Jaarafsluitinggegevens"
 msgid "Closing data"
 msgstr "Jaarafsluitinggegevens"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1795,22 +1664,18 @@ msgstr "Code ontbreekt!"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr "Samenvoegen"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr "Inkooporders combineren"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr "Verkooporders combineren"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1822,39 +1687,31 @@ msgstr "Verkooporders combineren"
 msgid "Company"
 msgstr "Bedrijf"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr "Firma adres"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr "Firma Fax"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr "Bedrijfsinformatie"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr "K.v.K. Nummer"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Firmanaam"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr "Bedrijfstelefoon"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr "Firma BTW Nummer"
@@ -1875,7 +1732,7 @@ msgstr "Bevestig bewerking"
 msgid "Confirm!"
 msgstr "Bevestig!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr "Conflicteert met bestaande gegevens. Misschien heeft u het al ingevoerd"
 
@@ -1893,7 +1750,6 @@ msgstr "Conflicteert met bestaande gegevens. Misschien heeft u het al ingevoerd"
 msgid "Contact"
 msgstr "Contact"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1909,7 +1765,6 @@ msgstr "Contact informatie:"
 msgid "Contact Information"
 msgstr "Contact informatie"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1927,9 +1782,6 @@ msgstr "Contacten"
 msgid "Content"
 msgstr "Inhoud"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1959,7 +1811,6 @@ msgstr "Verder met vorige verwerking"
 msgid "Contra"
 msgstr "Contra"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1967,10 +1818,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -2001,20 +1848,16 @@ msgstr "Kopiëer naar nieuw"
 msgid "Copy to New Name"
 msgstr "Kopiëer naar nieuwe naam"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Kostprijs"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr "Kostprijs van verkochte goederen"
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr "Kon sjabloon niet uit DB ophalen"
 
@@ -2030,26 +1873,20 @@ msgstr "Kon niet opslaan!"
 msgid "Could not transfer Inventory!"
 msgstr "Kon geen Inventaris overboeken!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr "Geteld (aanwezig)"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr "Tegenpartij"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr "Tegenpartij code"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2061,7 +1898,6 @@ msgstr "Tegenpartij code"
 msgid "Country"
 msgstr "Land"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr "Landnaam"
@@ -2074,7 +1910,7 @@ msgstr "Land:"
 msgid "Create"
 msgstr "Aanmaken"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2082,11 +1918,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr "Groep maken"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr "Database maken?"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2114,8 +1950,6 @@ msgstr "Gemaakt door"
 msgid "Created On"
 msgstr "Gemaakt op"
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2123,17 +1957,14 @@ msgstr "Gemaakt op"
 msgid "Credit"
 msgstr "Credit"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr "Crediteurenrekening"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr "Nummer crediteurenrekening"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr "Crediteurenrekeningen"
@@ -2158,29 +1989,19 @@ msgstr "Kredietlimiet:"
 msgid "Credit Note"
 msgstr "Creditmemo"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr "Credit"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Val."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2203,18 +2024,14 @@ msgstr "Val."
 msgid "Currency"
 msgstr "Valuta"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Huidig"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2224,11 +2041,7 @@ msgstr "Resultaat"
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2243,7 +2056,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Klant"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr "Klant Rekening"
@@ -2262,9 +2074,6 @@ msgstr "Klant bestaat niet!"
 msgid "Customer Name"
 msgstr "Klantnaam"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2284,9 +2093,7 @@ msgstr "Klant zoeken"
 msgid "Customer missing!"
 msgstr "Klant ontbreekt!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2298,7 +2105,7 @@ msgstr "Klant bestaat niet!"
 msgid "Customer/Vendor Accounts"
 msgstr "Klanten-/leveranciersrekeningen"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr "Dag Maand"
 
@@ -2322,12 +2129,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr "Gegevens niet opgeslagen Probeer opnieuw"
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr "Gegevens niet opgeslagen. Probeer opnieuw"
 
@@ -2360,28 +2166,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr "Database bestaat niet."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr "Database bestaat al."
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2428,19 +2222,14 @@ msgstr "Database bestaat al."
 msgid "Date"
 msgstr "Datum"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr "Datum formaat"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr "Datum vanaf"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2462,7 +2251,6 @@ msgstr "Datum ontvangen"
 msgid "Date Reversed"
 msgstr "Datum teruggedraaid"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr "Datum tot"
@@ -2526,8 +2314,6 @@ msgstr "Dag(en)"
 msgid "Days"
 msgstr "Dagen"
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2543,10 +2329,8 @@ msgstr "Debitfactuur"
 msgid "Debit Note"
 msgstr "Debetmemo"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2556,17 +2340,14 @@ msgstr "Debet"
 msgid "Dec"
 msgstr "dec"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "december"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr "Decimale posities voor geldbedragen"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2576,7 +2357,6 @@ msgstr "Aftrek klasse"
 msgid "Deduction Type"
 msgstr "Aftrek type"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr "Aftrek typen"
@@ -2589,47 +2369,38 @@ msgstr "Standaard crediteuren"
 msgid "Default AR"
 msgstr "Standaard debiteuren"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr "Standaard Rekeningen "
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr "Standaard land"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr "Standaard Email BCC"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr "Standaard Kopie Email aan"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr "Standaard Email Van"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr "Standaard Email aan"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr "Standaard formaat"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr "Standaard Taal "
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr "Standaard rapportage"
@@ -2642,21 +2413,14 @@ msgstr "Standaard bedrag"
 msgid "Defaults"
 msgstr "Standaardinstellingen"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2674,7 +2438,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Verwijder"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr "Groep verwijderen"
@@ -2687,7 +2450,6 @@ msgstr "Taal Verwijderen"
 msgid "Delete Schedule"
 msgstr "Inplanning Verwijderen"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr "Vouchers Verwijderen"
@@ -2702,37 +2464,33 @@ msgstr ""
 msgid "Delivery"
 msgstr "Bezorging"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Leverdatum"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr "Afschr. Basis"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr "Afschr. methode"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr "Afschr. begint"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr "Afschr. tot"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr "Afschr. dit jr"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr "Afschr. dit rapport"
 
@@ -2754,20 +2512,17 @@ msgstr "Afschrijven"
 msgid "Depreciate Through"
 msgstr "Afschrijvingen door"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr "Afschrijving"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr "Afschrijvingsrekening"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2778,46 +2533,7 @@ msgstr "Afschrijvingsmethode"
 msgid "Depreciation Starts"
 msgstr "Afschrijving begint"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2928,12 +2644,10 @@ msgstr "Detail"
 msgid "Details"
 msgstr "Details"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr "Uitzetten \"Back\" knop"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr "Korting"
@@ -2946,7 +2660,6 @@ msgstr "Korting"
 msgid "Disc %"
 msgstr "Kort. %"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2955,7 +2668,6 @@ msgstr "Kort. %"
 msgid "Discount"
 msgstr "Korting"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr "Korting (%)"
@@ -2964,28 +2676,28 @@ msgstr "Korting (%)"
 msgid "Discount:"
 msgstr "Korting:"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr "Verkregen restwaarde afschrijving"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr "Verwijdering"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr "Verwijderingsdatum"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr "Verwijderingsmethode"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr "Verwijderingsrapport [_1] op datum [_2]"
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr "Delen door 0 kan niet! Onmodelijk!"
 
@@ -2993,7 +2705,6 @@ msgstr "Delen door 0 kan niet! Onmodelijk!"
 msgid "Do not keep field empty [_1]"
 msgstr "Laat dit veld niet leeg [_1]"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr "Document"
@@ -3002,7 +2713,7 @@ msgstr "Document"
 msgid "Document Type"
 msgstr "Document Type"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr "Onbekend welke aktie met backup"
 
@@ -3010,12 +2721,10 @@ msgstr "Onbekend welke aktie met backup"
 msgid "Done"
 msgstr "Klaar"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr "Dubbele klantnummers"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr "Dubbele leveranciersnummers"
@@ -3028,12 +2737,10 @@ msgstr "Dr."
 msgid "Draft Posted"
 msgstr "Concept geboekt"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr "Concept zoeken"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr "Concept type"
@@ -3042,19 +2749,16 @@ msgstr "Concept type"
 msgid "Drafts"
 msgstr "Concepten"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Tekening"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr "Selectielijsten"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3070,10 +2774,6 @@ msgstr "Selectielijsten"
 msgid "Due"
 msgstr "Verschuldigd op"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3092,7 +2792,7 @@ msgstr "Vervaldatum ontbreekt!"
 msgid "Duplicate User Found: Importing User"
 msgstr "Dubbele gebruiker gevonden: gebruiker geïmporteerd"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr "Werknemer Nummer"
 
@@ -3118,7 +2818,7 @@ msgstr "E-mailbericht"
 msgid "E-mailed"
 msgstr "Gemaild"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr "ECA inkomensverklaring"
 
@@ -3148,7 +2848,7 @@ msgstr "Debiteurenboeking Wijzigen"
 msgid "Edit Assembly"
 msgstr "Assemblage Wijzigen"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr "Activa soort bewerken"
 
@@ -3292,8 +2992,6 @@ msgstr "Elf"
 msgid "Email"
 msgstr "E-mail"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3307,7 +3005,6 @@ msgstr "E-mail"
 msgid "Employee"
 msgstr "Werknemer"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3317,14 +3014,13 @@ msgstr "Werknemer Nummer"
 msgid "Employee Search"
 msgstr "Medewerker Zoeken"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 "Medewerkernaam voldoet niet aan minimale criteria (alfanumerieke karakters en "
 "niet-leeg)"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3334,37 +3030,26 @@ msgstr "Werknemer Nummer"
 msgid "Employees"
 msgstr "Werknemers"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr "Lege crediteurenrekening"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr "Lege debiteurenrekening"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr "Niet-gevulde klantnummers"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr "Niet-gevulde leveranciersnummers"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3388,7 +3073,6 @@ msgstr "Einddatum:"
 msgid "Ending"
 msgstr "Einde"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr "Eindsaldo"
@@ -3413,12 +3097,10 @@ msgstr "Voer voorraad in"
 msgid "Enter User"
 msgstr "Voer gebruiker in"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr "Voer personeelsnummers in waar deze missen"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3428,7 +3110,7 @@ msgstr "Registratie door"
 msgid "Entered For"
 msgstr "Ingevoerd voor"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr "Ingeboekt op"
 
@@ -3436,7 +3118,6 @@ msgstr "Ingeboekt op"
 msgid "Entered at: [_1]"
 msgstr "Ingevoerd op: [_1]"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr "Bedrijfseenheid"
@@ -3462,7 +3143,7 @@ msgstr "Entiteit crediteurenrekening"
 msgid "Entity Name"
 msgstr "Bedrijfseenheid code"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr "Invoer ID"
 
@@ -3474,14 +3155,11 @@ msgstr "Enveloppe"
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Actief vermogen"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr "Eigenvermogen & passiva"
@@ -3495,16 +3173,15 @@ msgstr "Eigenvermogen (Tijdelijk)"
 msgid "Equity to Liabilities"
 msgstr "Eigen vermogen naar passiva"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr "Fout in aanmaken backup bestand"
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr "Fout in aanmaken groep. Probeer opniew."
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr "Functionele fout"
 
@@ -3512,7 +3189,7 @@ msgstr "Functionele fout"
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr "Fout: Samenvattingsrekening niet combineerbaar met selectielijsten"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr "Verw. Levensduur"
 
@@ -3525,8 +3202,6 @@ msgstr "Elke"
 msgid "Exch"
 msgstr "Wissel"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3541,7 +3216,6 @@ msgstr "Wisselkoers"
 msgid "Exchange rate for payment missing!"
 msgstr "Wisselkoers voor betaling ontbreekt!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr "Wisselkoers is niet gedefinieerd!"
@@ -3550,7 +3224,6 @@ msgstr "Wisselkoers is niet gedefinieerd!"
 msgid "Exchange rate missing!"
 msgstr "Wisselkoers ontbreekt!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr "Verwacht"
@@ -3568,13 +3241,10 @@ msgstr "Kostenrekening"
 msgid "Expense/Asset"
 msgstr "Uitgaven/Activa"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr "Kosten"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3652,8 +3322,7 @@ msgstr "Fax: [_1]"
 msgid "Feb"
 msgstr "feb"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "februari"
 
@@ -3669,14 +3338,10 @@ msgstr "Vijftig"
 msgid "File"
 msgstr "Bestand"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr "Bestand geimporteerd"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3687,11 +3352,11 @@ msgstr "Bestandsnaam"
 msgid "File Type"
 msgstr "Bestandstype"
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr "Bestandsnaam"
 
@@ -3702,7 +3367,6 @@ msgstr "Bestandsnaam"
 msgid "File type"
 msgstr "Bestandstype"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr "Bestanden"
@@ -3760,12 +3424,10 @@ msgstr "Vaste Activa"
 msgid "For"
 msgstr "Gedurende"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Wisselkoerswinst"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Wisselkoersverlies"
@@ -3774,12 +3436,10 @@ msgstr "Wisselkoersverlies"
 msgid "Form"
 msgstr "Formulier"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr "Formuliernaam"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr "Formaat"
@@ -3796,7 +3456,6 @@ msgstr "vier"
 msgid "Fourteen"
 msgstr "Veertien"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr "Vrij"
@@ -3815,18 +3474,10 @@ msgstr "Vrij"
 msgid "From"
 msgstr "Van"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr "Vanaf bedrag"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3847,7 +3498,6 @@ msgstr "Vanuit bestand"
 msgid "From Warehouse"
 msgstr "Van Magazijn"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr "Vanaf datum"
@@ -3858,15 +3508,10 @@ msgstr "Vanaf datum"
 msgid "Full"
 msgstr "Volledig"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr "Systeem administrateur"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3880,10 +3525,8 @@ msgstr "Systeem administrateur"
 msgid "GIFI"
 msgstr "GIFI"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr "GIFI rekeningen niet in de \"gifi\" tabel"
 
@@ -3904,7 +3547,6 @@ msgstr "GIFI opgeslagen!"
 msgid "GL"
 msgstr "Memoriaal"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr "Memoriaal Referentiecode"
@@ -3913,7 +3555,7 @@ msgstr "Memoriaal Referentiecode"
 msgid "Gain"
 msgstr "Winst"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr "Winst  (Verlies)"
 
@@ -3921,12 +3563,11 @@ msgstr "Winst  (Verlies)"
 msgid "Gain Account"
 msgstr "Winstrekening"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 #, fuzzy
 msgid "Gain/Loss"
 msgstr "Winst  (Verlies)"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr "Opvolgende verkoopfactuurnummers"
@@ -3935,7 +3576,7 @@ msgstr "Opvolgende verkoopfactuurnummers"
 msgid "General Journal"
 msgstr "Grootboek journaal"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr "Grootboekrapport"
 
@@ -3943,9 +3584,8 @@ msgstr "Grootboekrapport"
 msgid "General Ledger Reports"
 msgstr "Grootboekrapportages"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr "Genereer"
 
@@ -3961,7 +3601,7 @@ msgstr "Genereer Orders"
 msgid "Generate Purchase Orders"
 msgstr "Genereer Aankooporders"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr "Genereer Aankooporders uit verkooporders"
 
@@ -3969,7 +3609,7 @@ msgstr "Genereer Aankooporders uit verkooporders"
 msgid "Generate Sales Orders"
 msgstr "Genereer Verkooporders"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr "Genereer verkooporders uit aankooporders"
 
@@ -3985,12 +3625,10 @@ msgstr "Voornaam"
 msgid "Goods & Services"
 msgstr "Goederen & diensten"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr "Goederen en diensten"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr "Goederen en diensten geschiedenis"
@@ -3999,7 +3637,6 @@ msgstr "Goederen en diensten geschiedenis"
 msgid "Grand Total"
 msgstr "Totaal generaal"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4073,21 +3710,6 @@ msgstr "Uren"
 msgid "Hundred"
 msgstr "honderd"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4118,7 +3740,6 @@ msgstr "IRC"
 msgid "Identification"
 msgstr "Identificatie"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4128,13 +3749,11 @@ msgstr "Negeer jaarafsluitingen"
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Plaatje"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr "Plaatjes in sjablonen"
@@ -4177,7 +3796,6 @@ msgstr ""
 msgid "In"
 msgstr "In"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4211,14 +3829,10 @@ msgstr "Toevoegen aan drop-down menu's"
 msgid "Includes Part"
 msgstr "Bevat artikel"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr "Inclusief artikelnummer"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4226,12 +3840,10 @@ msgstr "Inclusief artikelnummer"
 msgid "Income"
 msgstr "Inkomsten"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr "Loonsoort"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4242,7 +3854,6 @@ msgstr "Resultatenrekening"
 msgid "Income Type"
 msgstr "Loontype"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr "Loontypen"
@@ -4252,7 +3863,6 @@ msgstr "Loontypen"
 msgid "Income statement"
 msgstr "Resultatenrekening"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr "Binnenkomende bestanden"
@@ -4275,11 +3885,10 @@ msgstr ""
 "[_1] totdat er volledig is betaald. Voor geretourneerde items wordt 10% "
 "terugnamekosten in rekening gebracht."
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr "Interne database fout"
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr "Interne bestanden"
@@ -4289,30 +3898,26 @@ msgstr "Interne bestanden"
 msgid "Internal Notes"
 msgstr "Interne Opmerkingen"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr "Geen geldige rapportage basis"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr "Ongeldige backup verzoek"
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr "Ongeldige datum/tijd ingevoerd"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr "Onjuist rekeningafschriftsaldo. Hint: voer een getal in"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4322,17 +3927,14 @@ msgstr "Voorraad"
 msgid "Inventory Activity"
 msgstr "Voorraadactiviteit"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr "Voorraadactiviteitrapportage"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr "Inventaris details wijzigingen"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr "Voorraad aanpassingen"
@@ -4362,11 +3964,7 @@ msgstr "Voorraad opgeslagen!"
 msgid "Inventory transferred!"
 msgstr "Voorraad overgeheveld!"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4408,8 +4006,6 @@ msgstr "Factuur aangemaakt"
 msgid "Invoice Created Date missing!"
 msgstr "Factuur aanmaakdatum mist!"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4425,11 +4021,6 @@ msgstr "Factuurdatum ontbreekt!"
 msgid "Invoice No."
 msgstr "Factuurnr"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4448,7 +4039,6 @@ msgstr "Factuurcode"
 msgid "Invoice Number missing!"
 msgstr "Factuurcode ontbreekt!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr "Verlies en Winst Rekening"
@@ -4478,12 +4068,10 @@ msgstr "Factuur verschuldigd"
 msgid "Invoice not found"
 msgstr "Factuur niet gevonden"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4546,8 +4134,7 @@ msgstr ""
 msgid "Jan"
 msgstr "jan"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "januari"
 
@@ -4576,8 +4163,7 @@ msgstr "Journaalregels"
 msgid "Jul"
 msgstr "jul"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "juli"
 
@@ -4585,8 +4171,8 @@ msgstr "juli"
 msgid "Jun"
 msgstr "jun"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "juni"
 
@@ -4599,10 +4185,6 @@ msgstr "KPI's"
 msgid "LaTeX Templates"
 msgstr "LaTeX Sjablonen"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4624,15 +4206,12 @@ msgstr "Arbeids-/Overheadkosten"
 msgid "Labor/Service Code"
 msgstr "Arbeid-/dienstcode"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Taal"
@@ -4653,7 +4232,6 @@ msgstr "Talen niet gedefinieerd!"
 msgid "Last"
 msgstr "Laatste"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4664,7 +4242,6 @@ msgstr "Laaste Kostprijs"
 msgid "Last Name"
 msgstr "Achternaam"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr "Laatst bijgewerkt"
@@ -4686,41 +4263,40 @@ msgstr "Levertijd"
 msgid "Leadtime"
 msgstr "Levertijd"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr "LedgerSMB 1.2 database aangetroffen."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr "LedgerSMB 1.3 database aangetroffen."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr "LedgerSMB 1.4 database aangetroffen."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr "LedgerSMB 1.5 database aangetroffen."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 #, fuzzy
 msgid "LedgerSMB 1.8 db found."
 msgstr "LedgerSMB 1.2 database aangetroffen."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 #, fuzzy
 msgid "LedgerSMB 1.9 db found."
 msgstr "LedgerSMB 1.2 database aangetroffen."
@@ -4733,9 +4309,7 @@ msgstr "LedgerSMB database statistieken"
 msgid "LedgerSMB [_1]"
 msgstr "LedgerSMB [_1]"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4757,9 +4331,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4773,8 +4345,6 @@ msgstr "Minus nog aan te sluiten bedragen"
 msgid "Letterhead"
 msgstr "Briefhoofd"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr "Passiva"
@@ -4791,7 +4361,6 @@ msgstr "K.v.K. nummer"
 msgid "Lifetime Measured In"
 msgstr "Levensduur gemeten in"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr "Regel kostprijs verkopen rapport"
@@ -4828,7 +4397,6 @@ msgstr "Talen Weergeven"
 msgid "List Overpayments"
 msgstr "Voorschotbetalingenlijst"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4854,7 +4422,6 @@ msgstr "Gebruikerslijst"
 msgid "List Warehouse"
 msgstr "Magazijnenlijst"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr "Lijst van businesstypen"
@@ -4872,7 +4439,6 @@ msgstr "Plaats"
 msgid "Locations"
 msgstr "Locaties"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr "Vergrendel item omschrijving"
@@ -4893,7 +4459,7 @@ msgstr "Inloggen..."
 msgid "Login"
 msgstr "Aanmelden"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr "Inloggen?"
 
@@ -4921,32 +4487,29 @@ msgstr "MSN"
 msgid "Mailing"
 msgstr "Mailing"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Fabrikant"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr "Maak personeelsnummers uniek"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr "Maak factuurnummers uniek"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr "Maak courante artikelnummers uniek"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr "Maak alle metanummers uniek."
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
@@ -4954,14 +4517,10 @@ msgstr ""
 "Controleer dat iedere naam alleen bestaat uit alfanumerieke karakters (en "
 "lage streep) en minimaal een karakter lang is"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr "Toekennen bevoegdheden aan gebruikers"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4983,40 +4542,34 @@ msgstr "Handmatig"
 msgid "Mar"
 msgstr "mrt"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "maart"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Bruto marge"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr "Max. facturen per cheque"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr "Max per dropdown"
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "mei"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Memo"
@@ -5033,7 +4586,6 @@ msgstr "Boodschap"
 msgid "Message: "
 msgstr "Boodschap: "
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Gebruikt Stelsel"
@@ -5042,7 +4594,6 @@ msgstr "Gebruikt Stelsel"
 msgid "Method Default"
 msgstr "Standaardmethode"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5061,14 +4612,11 @@ msgstr "Tussenvoegsel"
 msgid "Million"
 msgstr "Miljoen"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr "MIME-type"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr "Min. lege regels"
@@ -5082,7 +4630,6 @@ msgstr "Min Hoev."
 msgid "Min Taxable"
 msgstr "Min. belastbaar"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr "Overige instellingen"
@@ -5095,14 +4642,12 @@ msgstr "Niet overeenkomende transacties (vanuit upload)"
 msgid "Miss."
 msgstr "Mejuffrouw"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Type"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr "Maa"
@@ -5120,7 +4665,7 @@ msgstr "Maand(en)"
 msgid "Months"
 msgstr "Maanden"
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr "Meer informatie is te zien in de \"error logs\""
 
@@ -5145,7 +4690,6 @@ msgstr "Meerdere datums"
 msgid "Multiple dates"
 msgstr "Meerdere datums"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
@@ -5154,7 +4698,6 @@ msgstr ""
 "Meerdere belasting tarieven met dezelfde einddatum voor dezelfde "
 "belastinggrootboekrekening;"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr "Kasrekening noodzakelijk in transactiegroep"
@@ -5163,15 +4706,6 @@ msgstr "Kasrekening noodzakelijk in transactiegroep"
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5190,7 +4724,6 @@ msgstr "Naam"
 msgid "Name:"
 msgstr "Naam:"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr "Netto Boekingswaarde"
@@ -5241,8 +4774,6 @@ msgstr "Volgende Datum"
 msgid "Next Number"
 msgstr "Volgende Nummer"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5264,12 +4795,10 @@ msgstr "Negentien"
 msgid "Ninety"
 msgstr "Negentig"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Nee"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr "Geen crediteuren- of debiteurenrekening geselecteerd"
@@ -5278,7 +4807,7 @@ msgstr "Geen crediteuren- of debiteurenrekening geselecteerd"
 msgid "No Account id for [_1]"
 msgstr "Geen rekening-id voor [_1]"
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr "Geen bestandssoort aangegeven"
 
@@ -5286,11 +4815,11 @@ msgstr "Geen bestandssoort aangegeven"
 msgid "No ID Set"
 msgstr "Geen ID ingegeven"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr "Bedragen moeten groter zijn dan 0"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr "Werknemer NUMMER (moet ingevuld worden!)"
 
@@ -5298,7 +4827,6 @@ msgstr "Werknemer NUMMER (moet ingevuld worden!)"
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr "Geen veranderingen"
@@ -5309,11 +4837,11 @@ msgstr ""
 "Geen valuta gedefinieerd   Ga naar Systeem Standaar en maak daar tenminste "
 "een valuta aan"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr "Geen dubbele meta nummers"
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr "Geen bestand uploaded"
 
@@ -5321,21 +4849,18 @@ msgstr "Geen bestand uploaded"
 msgid "No open Projects!"
 msgstr "Geen open Projecten!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr "Geen voorschotrekening geselecteerd  Een aanmaken?"
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr "Geen referentiesleutel en geen vervanging beschikbaar "
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr "Geen specificatie rapport aangegeven"
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr "Geen belastingformulier geselecteerd"
@@ -5354,12 +4879,10 @@ msgstr "Niet belastbaar"
 msgid "Non-cash"
 msgstr "Niet-kas"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr "Niet-bestaande verkoopprijsgroep in tabel partscustomer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr "Niet-bestaande inkoopprijsgroep in tabel partsvendor"
@@ -5368,12 +4891,10 @@ msgstr "Niet-bestaande inkoopprijsgroep in tabel partsvendor"
 msgid "Non-tracking Items"
 msgstr "Inventarisgoederen"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr "Niet-unieke factuurnummers"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5413,11 +4934,6 @@ msgstr "Notitie soort"
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5463,23 +4979,18 @@ msgstr "Niets over te boeken!"
 msgid "Nov"
 msgstr "nov"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "november"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr "NULL personeelsnummers"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr "NULL typenummers"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr "NULL modelnummers"
@@ -5510,7 +5021,7 @@ msgstr "NULL modelnummers"
 msgid "Number"
 msgstr "Nummer"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Nummeraanduiding"
 
@@ -5531,13 +5042,11 @@ msgstr "Op Voorraad"
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Niet actief"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr "Incourant door"
@@ -5546,8 +5055,7 @@ msgstr "Incourant door"
 msgid "Oct"
 msgstr "okt"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "oktober"
 
@@ -5559,9 +5067,6 @@ msgstr "Uit de wacht"
 msgid "Old Password"
 msgstr "Oud wachtwoord"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5611,7 +5116,6 @@ msgstr "Alleen voor Medewerkers"
 msgid "Open"
 msgstr "Open"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5634,9 +5138,6 @@ msgstr "Of"
 msgid "Or Add To Batch"
 msgstr "Of Voeg toe aan Groep"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5682,7 +5183,6 @@ msgstr "Orderdatum ontbreekt!"
 msgid "Order Entry"
 msgstr "Orderinvoer"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5704,7 +5204,6 @@ msgstr "Order verwijderd!"
 msgid "Order generation failed!"
 msgstr "Genereren order mislukt!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr "Order/Factuur"
@@ -5726,7 +5225,7 @@ msgstr "Orders gegenereerd!"
 msgid "Other Actions"
 msgstr "Overige acties"
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr "Ons saldo"
 
@@ -5772,7 +5271,6 @@ msgstr "Overschotbetaling"
 msgid "Overpayment Account"
 msgstr "Rekening overschot bedragen"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr "Overschot bedragen"
@@ -5791,10 +5289,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr "PO #"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5838,11 +5332,6 @@ msgstr "Nummer ontbreekt op de pakbon!"
 msgid "Packing list"
 msgstr "Pakbon"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5860,12 +5349,10 @@ msgstr "Betaald"
 msgid "Parent"
 msgstr "Parent"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Artikel"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr "Artikelomschrijving"
@@ -5875,14 +5362,6 @@ msgstr "Artikelomschrijving"
 msgid "Part Group"
 msgstr "Artikelgroep"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5914,14 +5393,10 @@ msgstr "Details"
 msgid "Partial"
 msgstr "Gedeeltelijk"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr "Gedeeltelijk afschrijvingsrapportage [_1] op datum [_2]"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5937,15 +5412,12 @@ msgstr "Artikel Nummer"
 msgid "Parts"
 msgstr "Artikel"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr "Artikelgroep"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr "Artikelgroep"
@@ -5955,7 +5427,6 @@ msgstr "Artikelgroep"
 msgid "Password"
 msgstr "Wachtwoord"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5968,7 +5439,6 @@ msgstr "Wachtwoorden moeten gelijk zijn."
 msgid "Pay From"
 msgstr "Betalen van"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5982,7 +5452,6 @@ msgstr "Betalen namens"
 msgid "Payables"
 msgstr "Betalingen"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5991,7 +5460,6 @@ msgstr "Betalingen"
 msgid "Payment"
 msgstr "Betaling"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr "Betalingsbedrag"
@@ -6004,7 +5472,6 @@ msgstr "Betaalopdrachtnummer [_1]"
 msgid "Payment Processing"
 msgstr "Betalingsverwerking"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr "Betaalresultaat"
@@ -6021,7 +5488,6 @@ msgstr "Betaalcondities"
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6057,15 +5523,15 @@ msgstr "Betalingen"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr "Betalingen m.b.t. niet geldige facturen moeten worden teruggeboekt"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr "procent"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr "Percentage verwijderd"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr "Resterend Percentage"
 
@@ -6084,7 +5550,6 @@ msgstr ""
 msgid "Periods"
 msgstr "Perioden"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr "Individu"
@@ -6115,7 +5580,6 @@ msgstr "Uitsorteerbon"
 msgid "Pick list"
 msgstr "Uitsorteerbon"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
@@ -6124,7 +5588,6 @@ msgstr ""
 "Voeg een kopregel toe aan het rekeningschema die de weergegeven rekeningen "
 "sorteert (meestal werkt \"0000\"). (in de standaard gebruikersinterface)"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
@@ -6134,25 +5597,22 @@ msgstr ""
 "sorteert voor alle andere rekeningnummers. (in de standaard "
 "gebruikersinterface)"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr "Voeg a.u.b. de ontbrekende GIFI-rekeningen toe"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr "Corrigeer a.u.b. the lege crediteurenrekeningen"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr "Corrigeer a.u.b. the lege debiteurenrekeningen"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr "Pas de weergegeven rijen aan zodat ze of \"H\" of \"A\" bevatten."
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
@@ -6160,70 +5620,55 @@ msgstr ""
 "Corrigeer a.u.b. de prijsgroepdata in the \"partscustomer\" tabel (helaas "
 "geen gebruikersinterface aanwezig voor deze actie)."
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr "Maak alle verkoopfactuurnummers uniek"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr "Maak alle klantnummers uniek"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr "Maak alle personeelsnummers uniek"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr "Maak alle leveranciersnummers uniek"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr "Geef alle medewerkers een personeelsnummer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr "Geef alle artikelen een type-nummer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr "Geef alle artikelen een modelnummer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr "Geef alle klanten een klantnummer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr "Geef alle leveranciers een leveranciersnummer"
@@ -6239,7 +5684,6 @@ msgstr "Graag ontvangen wij prijzen en leverdatums voor:"
 msgid "Please select a customer with unused overpayments"
 msgstr "Kies een klant met beschikbaar overschotsaldo"
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr "Kies een geldig groepshoofd"
@@ -6248,28 +5692,26 @@ msgstr "Kies een geldig groepshoofd"
 msgid "Please select a vendor with unused overpayments"
 msgstr "Kies een leverancier met beschikbaar overschotsaldo"
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 "Maakt u gebruik van het 1.2 gebruikersinterface om de volgende GIFI accounts "
 "toe te voegen"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 "Maakt u gebruik van het 1.3/1.4 gebruikersinterface om de volgende GIFI "
 "accounts toe te voegen"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6278,13 +5720,11 @@ msgstr ""
 msgid "Post"
 msgstr "Inboeken"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr "Boek transactiegroep"
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr "Boekdatum"
 
@@ -6325,7 +5765,6 @@ msgstr "Boeken inkoopfactuur [_1]"
 msgid "Postscript"
 msgstr "Postscript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6363,20 +5802,16 @@ msgstr "Voorvoegsel"
 msgid "Price"
 msgstr "Prijs"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr "Prijsgroep"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr "Prijsgroepen"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6412,8 +5847,6 @@ msgstr "Prijslijst voor [_1]"
 msgid "Primary Phone"
 msgstr "Eerste telefoonnummer"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6423,7 +5856,6 @@ msgstr "Eerste telefoonnummer"
 msgid "Print"
 msgstr "Afdrukken"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr "Print groep"
@@ -6440,7 +5872,7 @@ msgstr "Afdrukken en Sla op als nieuw"
 msgid "Printed"
 msgstr "Afgedrukt"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Printer"
 
@@ -6484,17 +5916,15 @@ msgstr "Afdrukken transactie [_1]"
 msgid "Printing Work Order [_1]"
 msgstr "Afdrukken werkbon [_1]"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr "Eerdere Afschr."
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr "Voorafgaand aan"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr "vervolgt"
 
@@ -6524,7 +5954,6 @@ msgstr "Winst en verlies"
 msgid "Profit/Loss"
 msgstr "Verlies/Winst"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr "Verlies en Winst op Verkoop Voorraad Goederen"
@@ -6543,7 +5972,6 @@ msgstr "Vertalingen Projectomschrijving"
 msgid "Project Number"
 msgstr "Projectcode"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr "Project/Afdelingsnummer"
@@ -6552,9 +5980,6 @@ msgstr "Project/Afdelingsnummer"
 msgid "Projects"
 msgstr "Projecten"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6564,7 +5989,6 @@ msgstr "Inkoop datum"
 msgid "Purchase Date:"
 msgstr "Datum Inkoop"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6582,22 +6006,16 @@ msgstr "Inkoophistorie"
 msgid "Purchase Order"
 msgstr "Inkooporder"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "Inkoopordercode"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Inkooporders"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6612,14 +6030,10 @@ msgstr "Inkoop Waarde"
 msgid "Purchase order"
 msgstr "Inkooporder"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr "Gekocht"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6650,7 +6064,6 @@ msgstr "Gekocht"
 msgid "Qty"
 msgstr "Aantal"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr "Hoeveelheid"
@@ -6664,8 +6077,6 @@ msgstr "Aantal is hoger dan de aanwezige voorraad!"
 msgid "Quarter"
 msgstr "Kwartaal"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6702,9 +6113,7 @@ msgstr "Offertecode ontbreekt!"
 msgid "Quotation deleted!"
 msgstr "Offerte verwijderd!"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6725,25 +6134,20 @@ msgstr "Prijsaanvraag"
 msgid "RFQ #"
 msgstr "Offerteaanvraag #"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "Prijsaanvraagcode"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "Prijsaanvragen"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "Minimum voorraad"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6755,7 +6159,6 @@ msgstr "Tarief"
 msgid "Rate (%)"
 msgstr "Tarief (%)"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6778,13 +6181,9 @@ msgstr "Heropen boeken"
 msgid "Re-open Period"
 msgstr "Heropen periode"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr "Herbouwen/upgraden?"
 
@@ -6802,7 +6201,6 @@ msgstr "Ontvangstbewijs"
 msgid "Receipt Date"
 msgstr "Ontvangstdatum"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr "Ontvangstresultaat"
@@ -6816,8 +6214,7 @@ msgstr "Ontvangstbewijzen"
 msgid "Receivables"
 msgstr "Vorderingen"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Ontvangen"
 
@@ -6825,7 +6222,6 @@ msgstr "Ontvangen"
 msgid "Receive Merchandise"
 msgstr "Goederen Ontvangen"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr "Ontvangen"
@@ -6846,7 +6242,6 @@ msgstr "Boekingen Verwerken"
 msgid "Reconciliation Report"
 msgstr "Aansluitrapport"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr "Aansluitrapporten"
@@ -6867,13 +6262,6 @@ msgstr "Herhalende Transactie voor [_1]"
 msgid "Recurring Transactions"
 msgstr "Geplande Transacties"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6912,12 +6300,10 @@ msgstr "Registratie [_1]"
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr "Afwijzen"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr "Verwachte resterende levensduur"
@@ -6955,7 +6341,7 @@ msgstr ""
 msgid "Report Name"
 msgstr "Rapportnaam"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr "Rapportresultaat"
 
@@ -6967,7 +6353,7 @@ msgstr "Rapport ingediend"
 msgid "Report Type"
 msgstr "Rapportsoort"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr "Rapport [_1] op datum [_2]"
 
@@ -6980,7 +6366,6 @@ msgstr "Rapporteer in"
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr "Rapporterings Basis"
@@ -7030,7 +6415,7 @@ msgstr "Verzoek leesbevestiging"
 msgid "Required By"
 msgstr "Uiterlijke levering"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr "Uiterlijke leverdatum"
 
@@ -7050,13 +6435,10 @@ msgstr "Uiterlijke leverdatum"
 msgid "Required by"
 msgstr "Nodig voor"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr "Niet voorzien van de benodigde input"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7086,7 +6468,6 @@ msgstr "Keer terug naar login scherm."
 msgid "Returns"
 msgstr "Retouren"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7095,7 +6476,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr "Terugdraai informatie"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr "Draai terug"
@@ -7112,7 +6492,6 @@ msgstr "Draai oversch.bet. terug"
 msgid "Reverse Payment"
 msgstr "Draai betaling terug"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr "Terug Betalingen"
@@ -7162,11 +6541,11 @@ msgstr "SKU"
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr "SQL-Ledger 3.0 database aangetroffen."
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr "SQL-Ledger database aangetroffen."
 
@@ -7192,7 +6571,6 @@ msgstr "Verkoop"
 msgid "Sales Invoice"
 msgstr "Verkoopfactuur"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Verkoopfactuur/Transactienummer Debiteuren"
@@ -7208,20 +6586,17 @@ msgstr "Verkoopfactuur/Transactienummer Debiteuren"
 msgid "Sales Order"
 msgstr "Verkooporder"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "Verkooporder Nummer"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Verkooporders"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "Verkoopofferte Nummer"
@@ -7244,9 +6619,6 @@ msgstr "Titulatuur"
 msgid "Sales:"
 msgstr "Verkoop:"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7270,13 +6642,10 @@ msgstr "Titulatuur"
 msgid "Salvage Value:"
 msgstr "Restwaarde:"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr "Zater"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7296,7 +6665,7 @@ msgstr "Zater"
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7306,7 +6675,6 @@ msgstr "Opslaan"
 msgid "Save As New"
 msgstr "Opslaan als Nieuw"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr "Groep opslaan"
@@ -7365,11 +6733,10 @@ msgstr "Opslaan als nieuw"
 msgid "Save as new"
 msgstr "Opslaan als nieuw"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7392,10 +6759,8 @@ msgstr "Inplannen"
 msgid "Scheduled"
 msgstr "Ingepland"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Scherm"
 
@@ -7415,7 +6780,6 @@ msgstr "Scherm"
 msgid "Search"
 msgstr "Zoek"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr "Zoek Inkoopfactuur"
@@ -7424,7 +6788,6 @@ msgstr "Zoek Inkoopfactuur"
 msgid "Search AP Invoices"
 msgstr "Zoek inkoopfacturen"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr "Zoek Verkoopfactuur"
@@ -7477,11 +6840,11 @@ msgstr "Zoek prijsgroep"
 msgid "Search Pricegroups"
 msgstr "Zoek prijsgroep"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr "Zoek Inkooporders"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr "Zoek Offertes"
 
@@ -7493,11 +6856,11 @@ msgstr "Zoek ontvangsten"
 msgid "Search Reconciliation Reports"
 msgstr "Zoek aansluitrapport"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr "Zoek Prijsaanvraag"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr "Zoek Verkooporders"
 
@@ -7509,7 +6872,7 @@ msgstr "Zoek niet-goedgekeurde transacties"
 msgid "Search and GL"
 msgstr "Zoek en grootboekkaart"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr "Zoek rapport"
 
@@ -7517,7 +6880,6 @@ msgstr "Zoek rapport"
 msgid "Secondary Phone"
 msgstr "Secundair telefoonnummer"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr "Veiligheids Instellingen"
@@ -7573,7 +6935,6 @@ msgstr "Kiest txt, postscript of PDF!"
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr "Gekozen"
@@ -7582,9 +6943,6 @@ msgstr "Gekozen"
 msgid "Sell"
 msgstr "Verkopen"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7638,13 +6996,11 @@ msgstr "Verzenden opdrachtbon [_1]"
 msgid "Sep"
 msgstr "sep"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr "Afzonderlijke Taken"
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "september"
 
@@ -7665,9 +7021,6 @@ msgstr "Serie#"
 msgid "Serial No."
 msgstr "Serienr"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7697,7 +7050,6 @@ msgstr "Dienstcode"
 msgid "Services"
 msgstr "Dienst"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 #, fuzzy
 msgid "Session Timeout (e.g. \"90 minutes\")"
@@ -7711,7 +7063,7 @@ msgstr "Sessies"
 msgid "Setting"
 msgstr "Instelling"
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr "Instellingen"
 
@@ -7731,10 +7083,10 @@ msgstr "Zeventien"
 msgid "Seventy"
 msgstr "Zeventig"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Verzenden"
 
@@ -7761,10 +7113,6 @@ msgstr "Verzenden aan:"
 msgid "Ship To:"
 msgstr "Verzenden aan:"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7825,10 +7173,6 @@ msgstr "Verzenddatum ontbreekt!"
 msgid "Shipping Label"
 msgstr "Verzendlabel"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7870,7 +7214,6 @@ msgstr "Verzendlabel"
 msgid "Short"
 msgstr "Kort"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr "Toon kredietlimiet"
@@ -7912,7 +7255,6 @@ msgstr "Zestig"
 msgid "Skip"
 msgstr "Overslaan"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr "Verkocht"
@@ -7925,12 +7267,6 @@ msgstr "Sommige"
 msgid "Sort by"
 msgstr "Sorteer op"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7957,7 +7293,6 @@ msgstr "Herkomst"
 msgid "Source documentation"
 msgstr "Brondocumentatie"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr "Bron vanaf"
@@ -7980,21 +7315,10 @@ msgstr "Speciale onderdelen zijn onderworpen aan een 10\\% annuleringstoeslag."
 msgid "Standard"
 msgstr "Standaard"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "Standaard Industiële Codes"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -8026,8 +7350,6 @@ msgstr "Start LedgerSMB"
 msgid "Startdate"
 msgstr "Begindatum"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8064,13 +7386,11 @@ msgstr "Staat/Provincie:"
 msgid "Statement"
 msgstr "Overzicht"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Saldo Overzicht"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8101,7 +7421,7 @@ msgstr "Assemblagevoorraad"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Stylesheet"
 
@@ -8126,7 +7446,6 @@ msgstr "Indieningsstatus"
 msgid "Submit"
 msgstr "Indienen"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8169,7 +7488,6 @@ msgstr "Overzicht"
 msgid "Summary account for"
 msgstr "Samenvattingsrekening voor"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr "Zon"
@@ -8202,12 +7520,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr "TOTAAL"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8219,9 +7531,6 @@ msgstr "Label"
 msgid "Tag:"
 msgstr "Label:"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8240,8 +7549,6 @@ msgstr "Belastingrekening"
 msgid "Tax Code"
 msgstr "BTW Code"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8252,17 +7559,14 @@ msgstr "Belastingformulier"
 msgid "Tax Form Applied"
 msgstr "Belasting formulier toegepast"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr "Detailoverzicht belastingformulier"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr "Lijst Belastingformulieren"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr "Belastingformulierrapportage"
@@ -8406,7 +7710,6 @@ msgstr "Tel: [_1]"
 msgid "Template"
 msgstr "Sjablonen"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr "Sjablonenlijst"
@@ -8415,7 +7718,6 @@ msgstr "Sjablonenlijst"
 msgid "Template Saved!"
 msgstr "Sjabloon opgeslagen!"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr "Sjabloon Transacties"
@@ -8468,7 +7770,7 @@ msgstr "Bedankt voor uw aankoop!"
 msgid "The amount of"
 msgstr "Het bedrag van"
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr "Banksaldo"
 
@@ -8480,7 +7782,7 @@ msgstr "Bankcredits"
 msgid "Their Debits"
 msgstr "Bankdebets"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8533,24 +7835,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr "Dit document is goedgekeurd door"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr "Deze journaalboeking is een gevolg van een betalingstransactie"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr "Deze journaalboeking is het gevolg van vooruitbetaling transactie"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8573,14 +7872,10 @@ msgstr "Grenswaarde"
 msgid "Through date"
 msgstr "Per datum"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr "Donder"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8624,7 +7919,6 @@ msgstr "Tijdkaart"
 msgid "Timecard Criteria"
 msgstr "Tijdkaartcriteria"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr "Tijdkaarten"
@@ -8654,19 +7948,10 @@ msgstr ""
 msgid "To"
 msgstr "Tot"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr "Tot bedrag"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8703,7 +7988,6 @@ msgstr "Naar e-mail adres"
 msgid "To my browser"
 msgstr "Naar mijn browser"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr "Betalen"
@@ -8728,16 +8012,7 @@ msgstr "Vink alle verwijder-aankruisvakjes aan"
 msgid "Top-level"
 msgstr "Hoogste Niveau"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8780,7 +8055,7 @@ msgstr "Hoogste Niveau"
 msgid "Total"
 msgstr "Totaal"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr "Totaal afschrijvingen"
 
@@ -8788,7 +8063,6 @@ msgstr "Totaal afschrijvingen"
 msgid "Total Outstanding"
 msgstr "Totaal openstaand"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr "Totaal betaald"
@@ -8809,7 +8083,6 @@ msgstr "Boeking"
 msgid "Transaction Approval"
 msgstr "Transactiegoedkeuring"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8825,14 +8098,12 @@ msgstr "Boekingsdatum ontbreekt!"
 msgid "Transaction Dates"
 msgstr "Transactiedatums"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr "Boekingtype"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8871,7 +8142,6 @@ msgstr "Vertalingen"
 msgid "Translations saved!"
 msgstr "Vertalingen opgeslagen!"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Proefbalans"
@@ -8880,7 +8150,6 @@ msgstr "Proefbalans"
 msgid "Trillion"
 msgstr "biljoen"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr "Dins"
@@ -8937,10 +8206,6 @@ msgstr "Tweeëntwintig"
 msgid "Two"
 msgstr "Twee"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8975,39 +8240,33 @@ msgstr "Niet-goedgekeurd"
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr "Onverwachte bestandsnaam; verwachtte [_1], vond [_2]"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr "Factuurnummer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr "Uniek klantnummer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr "Leverancier Nummer"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr "Unieke geldige artikelnummers"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -9026,12 +8285,10 @@ msgstr "Eenheid"
 msgid "Unit Price"
 msgstr "Eenheidsprijs"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr "Onbekend"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
@@ -9040,31 +8297,27 @@ msgstr ""
 "Onbekende rekeningcategorie (moet A(activa)/L(passiva)/E(kosten)/I(inkomsten)/"
 "Q(eigenvermogen) zijn)"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr "Onbekend rekeningtype; moet een header (H) of rekening (A) zijn"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr "Onbekende database aangetroffen"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr "Ontgrendel"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr "Batch ontgrendelen"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr "Niet-ondersteunde LedgerSMB-versie aangetroffen."
 
@@ -9072,23 +8325,18 @@ msgstr "Niet-ondersteunde LedgerSMB-versie aangetroffen."
 msgid "Unsupported Number"
 msgstr "Niet-ondersteund nummer"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr "Niet-ondersteunde SQL-Ledgerversie aangetroffen."
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr "Niet-ondersteunde rekeningcategorie"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr "Niet-ondersteunde rekening-link-combinatie"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr "Niet-ondersteund account type"
@@ -9105,7 +8353,6 @@ msgstr "Ongebruikt"
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9133,21 +8380,16 @@ msgstr "Upgrade Info"
 msgid "Upload"
 msgstr "Upload"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr "Ge-upload op"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr "Ge-upload door"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9156,7 +8398,6 @@ msgstr ""
 msgid "Url"
 msgstr "Url"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9174,24 +8415,19 @@ msgstr "Gebruik voorschot"
 msgid "Use Shipto"
 msgstr "Gebruik verzendadres"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr "Gebruik meerbetaling/vooruitbetaling"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr "al in gebruik"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9201,7 +8437,6 @@ msgstr "Gebruiker"
 msgid "User Name"
 msgstr "Gebruikersnaam"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr "Gebruiker bestaat al    Importeer?"
@@ -9222,7 +8457,6 @@ msgstr "Gebruikersnaam"
 msgid "Users"
 msgstr "Gebruikers"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9248,8 +8482,6 @@ msgstr "Geldig tot"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9259,11 +8491,7 @@ msgstr "Verschil"
 msgid "Variance:"
 msgstr "Afwijking:"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9279,7 +8507,6 @@ msgstr "Afwijking:"
 msgid "Vendor"
 msgstr "Leverancier"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr "Leveranciers Rekening "
@@ -9293,7 +8520,6 @@ msgstr "Leverancierhistorie"
 msgid "Vendor Invoice"
 msgstr "Inkoopfactuur"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr "Inkoopfactuur/Transactienummer Crediteuren"
@@ -9303,9 +8529,6 @@ msgstr "Inkoopfactuur/Transactienummer Crediteuren"
 msgid "Vendor Name"
 msgstr "Leveranciernaam"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9335,9 +8558,7 @@ msgstr "Leverancier zoeken"
 msgid "Vendor missing!"
 msgstr "Leverancier ontbreekt!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9345,8 +8566,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Leverancier bestaat niet!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9361,7 +8580,6 @@ msgstr ""
 msgid "Void"
 msgstr "Maak ongeldig"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr "Tegoedbonnenlijst"
@@ -9374,7 +8592,6 @@ msgstr "Tegoed Bon"
 msgid "Wages and Deductions"
 msgstr "Lonen en inhoudingen"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr "Lonen/Inhoudingen"
@@ -9397,7 +8614,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Magazijnen"
@@ -9406,11 +8622,31 @@ msgstr "Magazijnen"
 msgid "Warning!"
 msgstr "Waarschuwing!"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+#, fuzzy
+msgid "Warning: Your password will expire in [_1] days"
 msgstr "Waarschuwing: Uw wachtwoord verloopt over [_1]"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+#, fuzzy
+msgid "Warning: Your password will expire in [_1] months"
+msgstr "Waarschuwing: Uw wachtwoord verloopt over [_1]"
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+#, fuzzy
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr "Waarschuwing: Uw wachtwoord verloopt over [_1]"
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+#, fuzzy
+msgid "Warning: Your password will expire in [_1] years"
+msgstr "Waarschuwing: Uw wachtwoord verloopt over [_1]"
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+#, fuzzy
+msgid "Warning: Your password will expire today"
+msgstr "Waarschuwing: Uw wachtwoord verloopt over [_1]"
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr "Woens"
@@ -9420,7 +8656,6 @@ msgstr "Woens"
 msgid "Week"
 msgstr "Week"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr "Week beginnend"
@@ -9437,13 +8672,11 @@ msgstr "Weekelijkse tijd- en materiaalinvoer"
 msgid "Weeks"
 msgstr "Weken"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Gewicht"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Gewichtseenheid"
@@ -9460,7 +8693,6 @@ msgstr "Waarheen sturen wij de backup?"
 msgid "Whole Month Straight Line"
 msgstr "Maandelijks lineair"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9478,11 +8710,11 @@ msgstr "Werkorder"
 msgid "Work order"
 msgstr "Werkorder"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr "Wilt u de database migreren?"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr "Wilt u de database upgraden?"
 
@@ -9525,16 +8757,10 @@ msgstr "Jaarafsluiting afgerond"
 msgid "Years"
 msgstr "jaren"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Ja"
-
-#: UI/users/preferences.html:52
-#, fuzzy
-msgid "Your password will expire in [_1]"
-msgstr "Wachtwoord verloopt in"
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9561,7 +8787,7 @@ msgstr "Postcode:"
 msgid "Zip/Postal Code"
 msgstr "Postcode"
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9627,17 +8853,12 @@ msgstr "dagen"
 msgid "debits"
 msgstr "debet bedragen"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr "verwijderen"
 
@@ -9654,7 +8875,7 @@ msgstr "verwijdering"
 msgid "done"
 msgstr "gebeurd"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9682,8 +8903,6 @@ msgstr "importeren"
 msgid "in months"
 msgstr "in maanden"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9692,22 +8911,18 @@ msgstr ""
 msgid "in years"
 msgstr "in jaren"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr "Saldo is ontoereikend"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr "Is minder dan 0"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr "het bedrag is minder dan uiteindelijk moet worden betaald"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr "is nihiel"
@@ -9732,7 +8947,6 @@ msgstr "productie"
 msgid "sent"
 msgstr "verzonden"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 #, fuzzy
 msgid "system type"
@@ -9758,8 +8972,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr "onverwachte fout!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr "Gebruik van een vooruitbetaling"
@@ -9842,6 +9054,13 @@ msgstr "Gebruik van een vooruitbetaling"
 
 #~ msgid "Version"
 #~ msgstr "Versie"
+
+#~ msgid "Warning:  Your password will expire in [_1]"
+#~ msgstr "Waarschuwing: Uw wachtwoord verloopt over [_1]"
+
+#, fuzzy
+#~ msgid "Your password will expire in [_1]"
+#~ msgstr "Wachtwoord verloopt in"
 
 #~ msgid "[_1]:[_2]:[_3]: Invalid Redirect"
 #~ msgstr "[_1]:[_2]:[_3]: Ongeldige verwijzing"

--- a/locale/po/nl_BE.po
+++ b/locale/po/nl_BE.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Dutch (Belgium) (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,27 +15,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -48,12 +43,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -99,7 +90,6 @@ msgstr "Crediteuren"
 msgid "AP Aging"
 msgstr "Crediteuren Ouderdomsoverzicht"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -108,7 +98,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -123,7 +112,6 @@ msgstr "Openstaande Crediteuren"
 msgid "AP Transaction"
 msgstr "Crediteurenboeking"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Crediteurenboekingen"
@@ -136,9 +124,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -157,7 +143,6 @@ msgstr "Debiteuren"
 msgid "AR Aging"
 msgstr "Debiteuren Ouderdomsoverzicht"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -166,7 +151,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -181,7 +165,6 @@ msgstr "Openstaande Debiteuren"
 msgid "AR Transaction"
 msgstr "Debiteurenboeking"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Debiteurenboekingen"
@@ -194,9 +177,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -205,8 +186,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Debiteurenboeking"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -216,16 +195,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -251,38 +225,20 @@ msgstr ""
 msgid "Account"
 msgstr "Rekening"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -303,23 +259,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Rekeningnummer"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -359,17 +310,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -381,7 +330,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -409,12 +358,10 @@ msgstr "Actief"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -437,11 +384,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr "Assemblage toevoegen"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -566,7 +513,6 @@ msgstr "Verkooporder toevoegen"
 msgid "Add Service"
 msgstr "Dienst toevoegen"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -633,7 +579,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Bijwerken"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -658,7 +603,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -668,12 +612,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -693,8 +636,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -747,7 +689,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -756,11 +697,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -794,14 +730,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Bedrag"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -810,27 +742,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Verschuldigd bedrag"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -848,14 +774,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -874,17 +800,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -893,13 +816,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -908,7 +824,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -917,14 +832,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -936,19 +849,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Apr"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "April"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -964,7 +874,6 @@ msgstr "Weet u zeker dat u dit offertenummer wilt verwijderen?"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -983,19 +892,17 @@ msgstr "Assemblage naar voorraad geboekt"
 msgid "Asset"
 msgstr "Activa (bezittingen)"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1008,29 +915,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1046,7 +950,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1144,8 +1047,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Aug"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Augustus"
 
@@ -1157,7 +1059,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1171,7 +1072,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1184,7 +1084,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1218,8 +1117,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1234,7 +1131,6 @@ msgstr "Saldo"
 msgid "Balance Sheet"
 msgstr "Balans"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1255,7 +1151,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1266,7 +1161,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1276,18 +1170,15 @@ msgstr "Valuta"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1300,12 +1191,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1322,13 +1211,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1369,8 +1256,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1417,17 +1302,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1440,12 +1322,10 @@ msgstr ""
 msgid "Business"
 msgstr "Zaaktype"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Kamer van Koophandel nummer"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1455,12 +1335,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1482,7 +1360,6 @@ msgstr "Zaaktype opgeslagen"
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1514,18 +1391,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1651,12 +1526,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Rekeningstelsel"
 
@@ -1676,7 +1550,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "Inventaris controleren"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1705,7 +1578,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1717,9 +1590,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "Opgeschoond"
 
@@ -1747,15 +1620,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Afgesloten"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1769,8 +1640,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1785,22 +1654,18 @@ msgstr "Code ontbreekt!"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1812,39 +1677,31 @@ msgstr ""
 msgid "Company"
 msgstr "Bedrijf"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Bedrijfsnaam"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1865,7 +1722,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Bevestig!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1883,7 +1740,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Contact"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1899,7 +1755,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1917,9 +1772,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1949,7 +1801,6 @@ msgstr ""
 msgid "Contra"
 msgstr "Tegen"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1957,10 +1808,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1991,20 +1838,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Kost"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2020,26 +1863,20 @@ msgstr "Kon niet opslaan!"
 msgid "Could not transfer Inventory!"
 msgstr "Kon geen inventaris overboeken!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2051,7 +1888,6 @@ msgstr ""
 msgid "Country"
 msgstr "Land"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2064,7 +1900,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2072,11 +1908,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2104,8 +1940,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2113,17 +1947,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Credit"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2148,29 +1979,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Val."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2193,18 +2014,14 @@ msgstr "Val."
 msgid "Currency"
 msgstr "Valuta"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Huidig"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2214,11 +2031,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2233,7 +2046,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Klant"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2252,9 +2064,6 @@ msgstr "Klant bestaat niet!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2274,9 +2083,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "Klant ontbreekt!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2288,7 +2095,7 @@ msgstr "Klant bestaat niet!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2312,12 +2119,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2350,28 +2156,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2418,19 +2212,14 @@ msgstr ""
 msgid "Date"
 msgstr "Datum"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2452,7 +2241,6 @@ msgstr "Ontvangstdatum"
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2516,8 +2304,6 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2533,10 +2319,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2546,17 +2330,14 @@ msgstr ""
 msgid "Dec"
 msgstr "Dec"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "December"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2566,7 +2347,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2579,47 +2359,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2632,21 +2403,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "Standaard"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2664,7 +2428,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Verwijder"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2677,7 +2440,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2691,37 +2453,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Leverdatum"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2743,20 +2501,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2767,46 +2522,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2917,12 +2633,10 @@ msgstr "Detail"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2935,7 +2649,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2944,7 +2657,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Korting"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2953,28 +2665,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2982,7 +2694,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2991,7 +2702,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -2999,12 +2710,10 @@ msgstr ""
 msgid "Done"
 msgstr "Klaar"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3017,12 +2726,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3031,19 +2738,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Tekening"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3059,10 +2763,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3081,7 +2781,7 @@ msgstr "Vervaldatum ontbreekt!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3107,7 +2807,7 @@ msgstr ""
 msgid "E-mailed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3137,7 +2837,7 @@ msgstr ""
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3281,8 +2981,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3296,7 +2994,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Werknemer"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3306,12 +3003,11 @@ msgstr ""
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3321,37 +3017,26 @@ msgstr "Werknemers"
 msgid "Employees"
 msgstr "Werknemers"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3375,7 +3060,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3400,12 +3084,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3415,7 +3097,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3423,7 +3105,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3449,7 +3130,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Bedrijfsnaam"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3461,14 +3142,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Passiva/Eigen Vermogen"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3482,16 +3160,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3499,7 +3176,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3512,8 +3189,6 @@ msgstr ""
 msgid "Exch"
 msgstr "Wisselkoers"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3528,7 +3203,6 @@ msgstr "Wisselkoers"
 msgid "Exchange rate for payment missing!"
 msgstr "Wisselkoers voor Betaling ontbreekt!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3537,7 +3211,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "Wisselkoers ontbreekt!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3555,13 +3228,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Uitgaven"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3639,8 +3309,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Februari"
 
@@ -3656,14 +3325,10 @@ msgstr "vijftig"
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3674,11 +3339,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3689,7 +3354,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3747,12 +3411,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Wisselkoers winst"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Wisselkoers verlies"
@@ -3761,12 +3423,10 @@ msgstr "Wisselkoers verlies"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3783,7 +3443,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr "veertien"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3802,18 +3461,10 @@ msgstr ""
 msgid "From"
 msgstr "Van"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3834,7 +3485,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3845,15 +3495,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3867,10 +3512,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "GIFI"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3891,7 +3534,6 @@ msgstr "GIFI opgeslagen!"
 msgid "GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3900,7 +3542,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3908,11 +3550,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3921,7 +3562,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3929,9 +3570,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3947,7 +3587,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3955,7 +3595,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3971,12 +3611,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3985,7 +3623,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4059,21 +3696,6 @@ msgstr ""
 msgid "Hundred"
 msgstr "honderd"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4104,7 +3726,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4114,13 +3735,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Plaatje"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4163,7 +3782,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4197,14 +3815,10 @@ msgstr "Toevoegen aan drop-down menus"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4212,12 +3826,10 @@ msgstr ""
 msgid "Income"
 msgstr "Inkomsten"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4228,7 +3840,6 @@ msgstr "Inkomstenoverzicht"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4238,7 +3849,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Inkomstenoverzicht"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4258,11 +3868,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4272,30 +3881,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "Interne notities"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4305,17 +3910,14 @@ msgstr "Voorraad"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4343,11 +3945,7 @@ msgstr "Voorraad opgeslagen"
 msgid "Inventory transferred!"
 msgstr "Voorraad overgeheveld"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4389,8 +3987,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4406,11 +4002,6 @@ msgstr "Factuurdatum ontbreekt!"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4429,7 +4020,6 @@ msgstr "Factuurnummer"
 msgid "Invoice Number missing!"
 msgstr "Factuurnummer ontbreekt!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4459,12 +4049,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4522,8 +4110,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Jan"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Januari"
 
@@ -4552,8 +4139,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Juli"
 
@@ -4561,8 +4147,8 @@ msgstr "Juli"
 msgid "Jun"
 msgstr "Jun"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Juni"
 
@@ -4575,10 +4161,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "Latex Sjablonen"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4600,15 +4182,12 @@ msgstr "Arbeid/Overheadskosten"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Taal"
@@ -4629,7 +4208,6 @@ msgstr "Taal niet gedefinieerd!"
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4640,7 +4218,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4662,40 +4239,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr "Levertijd"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4707,9 +4283,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4731,9 +4305,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4747,8 +4319,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4765,7 +4335,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4802,7 +4371,6 @@ msgstr "Talen weergeven"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4828,7 +4396,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4846,7 +4413,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4867,7 +4433,7 @@ msgstr ""
 msgid "Login"
 msgstr "Login"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4895,45 +4461,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Fabrikant"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4955,40 +4514,34 @@ msgstr ""
 msgid "Mar"
 msgstr "Mrt"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Maart"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Winstmarge"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "Mei"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Memo"
@@ -5005,7 +4558,6 @@ msgstr "Boodschap"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Methode"
@@ -5014,7 +4566,6 @@ msgstr "Methode"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5033,14 +4584,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5054,7 +4602,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5067,14 +4614,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Type"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5092,7 +4637,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5116,14 +4661,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5132,15 +4675,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5159,7 +4693,6 @@ msgstr "Naam"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5210,8 +4743,6 @@ msgstr ""
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5233,12 +4764,10 @@ msgstr "negentien"
 msgid "Ninety"
 msgstr "negentig"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Nee"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5247,7 +4776,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5255,11 +4784,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5267,7 +4796,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5276,11 +4804,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5288,21 +4816,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5321,12 +4846,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5335,12 +4858,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5378,11 +4899,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5428,23 +4944,18 @@ msgstr "Niets over te boeken!"
 msgid "Nov"
 msgstr "Nov"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "November"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5475,7 +4986,7 @@ msgstr ""
 msgid "Number"
 msgstr "Nummer"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Nummeraanduiding"
 
@@ -5496,13 +5007,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Niet actief"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5511,8 +5020,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Okt"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Oktober"
 
@@ -5524,9 +5032,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5576,7 +5081,6 @@ msgstr ""
 msgid "Open"
 msgstr "Open"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5598,9 +5102,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5646,7 +5147,6 @@ msgstr "Geen order datum aanwezig"
 msgid "Order Entry"
 msgstr "Order invoer"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5668,7 +5168,6 @@ msgstr "Order verwijderd!"
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5690,7 +5189,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5736,7 +5235,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5755,10 +5253,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5802,11 +5296,6 @@ msgstr "Pakbon nummer ontbreekt!"
 msgid "Packing list"
 msgstr "Pakbon"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5824,12 +5313,10 @@ msgstr "Betaald"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Artikel"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5839,14 +5326,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5876,14 +5355,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5899,15 +5374,12 @@ msgstr ""
 msgid "Parts"
 msgstr "Artikel"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5917,7 +5389,6 @@ msgstr ""
 msgid "Password"
 msgstr "Wachtwoord"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5930,7 +5401,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5944,7 +5414,6 @@ msgstr ""
 msgid "Payables"
 msgstr "Betalingen"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5953,7 +5422,6 @@ msgstr "Betalingen"
 msgid "Payment"
 msgstr "Betaling"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5966,7 +5434,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5983,7 +5450,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6019,15 +5485,15 @@ msgstr "Betalingen"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6046,7 +5512,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6077,108 +5542,88 @@ msgstr "Uitzoeklijst"
 msgid "Pick list"
 msgstr "Uitzoeklijst"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6194,7 +5639,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6203,24 +5647,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6229,13 +5671,11 @@ msgstr ""
 msgid "Post"
 msgstr "Boek"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6276,7 +5716,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Postscript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6314,20 +5753,16 @@ msgstr ""
 msgid "Price"
 msgstr "Prijs"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6363,8 +5798,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6374,7 +5807,6 @@ msgstr ""
 msgid "Print"
 msgstr "Afdrukken"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6391,7 +5823,7 @@ msgstr ""
 msgid "Printed"
 msgstr "Afgedrukt"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Printer"
 
@@ -6435,17 +5867,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6474,7 +5904,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6493,7 +5922,6 @@ msgstr "Project Omschrijving Vertaling"
 msgid "Project Number"
 msgstr "Projectnummer"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6502,9 +5930,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Projecten"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6514,7 +5939,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6532,22 +5956,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Inkooporder"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Inkooporders"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6562,14 +5980,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Inkooporder"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6600,7 +6014,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Aantal"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6614,8 +6027,6 @@ msgstr "Aantal is hoger dan de aanwezige voorraad!"
 msgid "Quarter"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6652,9 +6063,7 @@ msgstr "Offertenummer ontbreekt!"
 msgid "Quotation deleted!"
 msgstr "Offerte verwijderd!"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6675,25 +6084,20 @@ msgstr "Offerteaanvraag"
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "Offerteaanvraagnummer"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "Offerteaanvragen"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "Minimum voorraad"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6705,7 +6109,6 @@ msgstr "Percentage"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6728,13 +6131,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6752,7 +6151,6 @@ msgstr "Ontvangstbewijs"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6766,8 +6164,7 @@ msgstr "Ontvangstbewijzen"
 msgid "Receivables"
 msgstr "Vorderingen"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Inkomende zending"
 
@@ -6775,7 +6172,6 @@ msgstr "Inkomende zending"
 msgid "Receive Merchandise"
 msgstr "Goederen Ontvangen"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6796,7 +6192,6 @@ msgstr "Boekingen Verwerken"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6817,13 +6212,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6862,12 +6250,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6905,7 +6291,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6917,7 +6303,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6930,7 +6316,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6980,7 +6365,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -7000,13 +6385,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Nodig voor"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7036,7 +6418,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7045,7 +6426,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7062,7 +6442,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7112,11 +6491,11 @@ msgstr "SKU"
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7142,7 +6521,6 @@ msgstr "Verkoop"
 msgid "Sales Invoice"
 msgstr "Verkoopfactuur"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7158,20 +6536,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr "Verkooporder"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Verkooporders"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr ""
@@ -7194,9 +6569,6 @@ msgstr "Kan offerte niet verwijderen!"
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7220,13 +6592,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7246,7 +6615,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7256,7 +6625,6 @@ msgstr "Opslaan"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7315,11 +6683,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "Opslaan als nieuw"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7342,10 +6709,8 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Scherm"
 
@@ -7365,7 +6730,6 @@ msgstr "Scherm"
 msgid "Search"
 msgstr "Zoek"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7374,7 +6738,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7427,11 +6790,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7443,11 +6806,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7459,7 +6822,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7467,7 +6830,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7523,7 +6885,6 @@ msgstr ""
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7532,9 +6893,6 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7588,13 +6946,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Sep"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "September"
 
@@ -7615,9 +6971,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "Serienr"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7647,7 +7000,6 @@ msgstr ""
 msgid "Services"
 msgstr "Dienst"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 msgid "Session Timeout (e.g. \"90 minutes\")"
 msgstr ""
@@ -7660,7 +7012,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7680,10 +7032,10 @@ msgstr "zeventien"
 msgid "Seventy"
 msgstr "zeventig"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Verzenden"
 
@@ -7710,10 +7062,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7774,10 +7122,6 @@ msgstr "Verzenddatum ontbreekt!"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7819,7 +7163,6 @@ msgstr "Verzenddatum"
 msgid "Short"
 msgstr "Kort"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7860,7 +7203,6 @@ msgstr "zestig"
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7873,12 +7215,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7905,7 +7241,6 @@ msgstr "Herkomst"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7927,21 +7262,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Standaard"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "Standaard Industiële Codes"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7972,8 +7296,6 @@ msgstr ""
 msgid "Startdate"
 msgstr "Begindatum"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8010,13 +7332,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Overzicht"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Saldo Overzicht"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8046,7 +7366,7 @@ msgstr "Assemblage voorraad"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Stylesheet"
 
@@ -8071,7 +7391,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8114,7 +7433,6 @@ msgstr "Overzicht"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8147,12 +7465,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8164,9 +7476,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8185,8 +7494,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8197,17 +7504,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8351,7 +7655,6 @@ msgstr ""
 msgid "Template"
 msgstr "HTML Sjablonen"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8360,7 +7663,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8413,7 +7715,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8425,7 +7727,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8476,24 +7778,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8516,14 +7815,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8567,7 +7862,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8597,19 +7891,10 @@ msgstr ""
 msgid "To"
 msgstr "Tot"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8646,7 +7931,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8671,16 +7955,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8723,7 +7998,7 @@ msgstr ""
 msgid "Total"
 msgstr "Totaal"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8731,7 +8006,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8752,7 +8026,6 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8768,14 +8041,12 @@ msgstr "Boekingsdatum ontbreekt!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8814,7 +8085,6 @@ msgstr "Vertalingen"
 msgid "Translations saved!"
 msgstr "Vertalingen opgeslagen!"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Proefbalans"
@@ -8823,7 +8093,6 @@ msgstr "Proefbalans"
 msgid "Trillion"
 msgstr "biljoen"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8880,10 +8149,6 @@ msgstr ""
 msgid "Two"
 msgstr "twee"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8918,39 +8183,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8969,43 +8228,37 @@ msgstr "Eenheid"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9013,23 +8266,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9046,7 +8294,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9074,21 +8321,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9097,7 +8339,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9115,24 +8356,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9142,7 +8378,6 @@ msgstr "Gebruiker"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9163,7 +8398,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9189,8 +8423,6 @@ msgstr "Geldig tot"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9200,11 +8432,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9220,7 +8448,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Leverancier"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9234,7 +8461,6 @@ msgstr "Leverancier Historie"
 msgid "Vendor Invoice"
 msgstr "Inkoopfaktuur"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9244,9 +8470,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9276,9 +8499,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "Leverancier ontbreekt!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9286,8 +8507,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Leverancier bestaat niet!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9302,7 +8521,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9315,7 +8533,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9338,7 +8555,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Magazijnen"
@@ -9347,11 +8563,26 @@ msgstr "Magazijnen"
 msgid "Warning!"
 msgstr "Waarschuwing!"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9361,7 +8592,6 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9378,13 +8608,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Gewicht"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Gewichtseenheid"
@@ -9401,7 +8629,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9419,11 +8646,11 @@ msgstr "Bedrijfs order"
 msgid "Work order"
 msgstr "Bedrijfs order"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9466,15 +8693,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Ja"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9501,7 +8723,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9565,17 +8787,12 @@ msgstr "dagen"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9592,7 +8809,7 @@ msgstr ""
 msgid "done"
 msgstr "gebeurd"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9620,8 +8837,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9630,22 +8845,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9670,7 +8881,6 @@ msgstr ""
 msgid "sent"
 msgstr "verzonden"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9695,8 +8905,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/pl.po
+++ b/locale/po/pl.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Polish (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -17,27 +17,22 @@ msgstr ""
 "%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n"
 "%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -50,12 +45,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -101,7 +92,6 @@ msgstr "Księga Zobowiązań"
 msgid "AP Aging"
 msgstr "Plan Płatności Zobowiązań"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -110,7 +100,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -125,7 +114,6 @@ msgstr "Zobowiązania Nieuregulowane"
 msgid "AP Transaction"
 msgstr "Transakcja Zobowiązań"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Transakcje Zobowiązań"
@@ -138,9 +126,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -159,7 +145,6 @@ msgstr "Księga Należności"
 msgid "AR Aging"
 msgstr "Plan Płatności Należności"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -168,7 +153,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -183,7 +167,6 @@ msgstr "Należności Nieuregulowane"
 msgid "AR Transaction"
 msgstr "Transakcja Należności"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Transakcje Należności"
@@ -196,9 +179,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -207,8 +188,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Transakcja Należności"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -218,16 +197,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -253,38 +227,20 @@ msgstr ""
 msgid "Account"
 msgstr "Konto"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -305,23 +261,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Numer Konta"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -361,17 +312,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -383,7 +332,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -411,12 +360,10 @@ msgstr "Aktywne"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -439,11 +386,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr "Dodaj Zestaw"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -568,7 +515,6 @@ msgstr "Dodaj Zlecenie Sprzedaży"
 msgid "Add Service"
 msgstr "Dodaj Usługi"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -635,7 +581,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Uzupełnij"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -660,7 +605,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -670,12 +614,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -695,8 +638,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -749,7 +691,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -758,11 +699,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -796,14 +732,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Kwota"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -812,27 +744,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Kwota Należna"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -850,14 +776,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -876,17 +802,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -895,13 +818,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -910,7 +826,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -919,14 +834,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -938,19 +851,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Kwiecień"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "Kwiecień"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -966,7 +876,6 @@ msgstr "Czy chcesz usunąć Numer Oferty?"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -985,19 +894,17 @@ msgstr "Zestawy uzupełnione"
 msgid "Asset"
 msgstr "Aktywy"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1010,29 +917,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1048,7 +952,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1146,8 +1049,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Sierpień"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Sierpień"
 
@@ -1159,7 +1061,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1173,7 +1074,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1186,7 +1086,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1220,8 +1119,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1236,7 +1133,6 @@ msgstr "Saldo"
 msgid "Balance Sheet"
 msgstr "Bilans"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1257,7 +1153,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1268,7 +1163,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1278,18 +1172,15 @@ msgstr "Waluta"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1302,12 +1193,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1324,13 +1213,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1371,8 +1258,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1419,17 +1304,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1442,12 +1324,10 @@ msgstr ""
 msgid "Business"
 msgstr "Działalność"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "NIP"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1457,12 +1337,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1484,7 +1362,6 @@ msgstr "Działalność zapisana"
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1516,18 +1393,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1653,12 +1528,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Plan Kont"
 
@@ -1678,7 +1552,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "Kontrola Inwentarza"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1707,7 +1580,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1719,9 +1592,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "Rozliczone"
 
@@ -1749,15 +1622,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Zamknięto"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1771,8 +1642,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1787,22 +1656,18 @@ msgstr "Brak Kodu"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1814,39 +1679,31 @@ msgstr ""
 msgid "Company"
 msgstr "Firma"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Nazwa Firmy"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1867,7 +1724,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Potwierdż!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1885,7 +1742,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Kontakt"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1901,7 +1757,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1919,9 +1774,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1951,7 +1803,6 @@ msgstr ""
 msgid "Contra"
 msgstr "Konto Przeciwstawne"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1959,10 +1810,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1993,20 +1840,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Koszt"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2022,26 +1865,20 @@ msgstr "Nie może zapisać!"
 msgid "Could not transfer Inventory!"
 msgstr "Nie może przesunąć Inwentarza"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2053,7 +1890,6 @@ msgstr ""
 msgid "Country"
 msgstr "Kraj"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2066,7 +1902,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2074,11 +1910,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2106,8 +1942,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2115,17 +1949,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Kredyt"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2150,29 +1981,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Waluta"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2195,18 +2016,14 @@ msgstr "Waluta"
 msgid "Currency"
 msgstr "Waluta"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Bieżący"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2216,11 +2033,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2235,7 +2048,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Odbiorca"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2254,9 +2066,6 @@ msgstr "Brak Odbiorcy w bazie danych"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2276,9 +2085,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "Brak Odbiorcy"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2290,7 +2097,7 @@ msgstr "Brak Odbiorcy w bazie danych"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2314,12 +2121,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2352,28 +2158,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2420,19 +2214,14 @@ msgstr ""
 msgid "Date"
 msgstr "Data"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2454,7 +2243,6 @@ msgstr "Data Wpłaty"
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2518,8 +2306,6 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2535,10 +2321,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2548,17 +2332,14 @@ msgstr ""
 msgid "Dec"
 msgstr "Grudzień"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Grudzień"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2568,7 +2349,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2581,47 +2361,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2634,21 +2405,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "Ustawienia"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2666,7 +2430,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Usuń"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2679,7 +2442,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2693,37 +2455,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Data Dostawy"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2745,20 +2503,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2769,46 +2524,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2919,12 +2635,10 @@ msgstr "Wyszczególnienie"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2937,7 +2651,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2946,7 +2659,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Rabat"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2955,28 +2667,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2984,7 +2696,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2993,7 +2704,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -3001,12 +2712,10 @@ msgstr ""
 msgid "Done"
 msgstr "Zrobione"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3019,12 +2728,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3033,19 +2740,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Rysunek"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3061,10 +2765,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3083,7 +2783,7 @@ msgstr "Brak Terminu Płatności!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3109,7 +2809,7 @@ msgstr ""
 msgid "E-mailed"
 msgstr "Wysłano"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3139,7 +2839,7 @@ msgstr "Zmiany Transakcji Konta Należności"
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3283,8 +2983,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3298,7 +2996,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Pracownik"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3308,12 +3005,11 @@ msgstr "Numer Pracownika"
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3323,37 +3019,26 @@ msgstr "Numer Pracownika"
 msgid "Employees"
 msgstr "Pracownicy"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3377,7 +3062,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3402,12 +3086,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3417,7 +3099,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3425,7 +3107,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3451,7 +3132,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Nazwa Firmy"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3463,14 +3144,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Kapitał"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3484,16 +3162,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3501,7 +3178,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3514,8 +3191,6 @@ msgstr ""
 msgid "Exch"
 msgstr "Kurs Walut"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3530,7 +3205,6 @@ msgstr "Kurs Walut"
 msgid "Exchange rate for payment missing!"
 msgstr "Brakuje Kursu Walut dla płatności!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3539,7 +3213,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "Brakuje Kursu Walut"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3557,13 +3230,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Koszt/Aktywy"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3641,8 +3311,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Luty"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Luty"
 
@@ -3658,14 +3327,10 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3676,11 +3341,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3691,7 +3356,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3749,12 +3413,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Zysk przy Zamianie Walut"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Strata przy Zamianie Walut"
@@ -3763,12 +3425,10 @@ msgstr "Strata przy Zamianie Walut"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3785,7 +3445,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3804,18 +3463,10 @@ msgstr ""
 msgid "From"
 msgstr "Od"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3836,7 +3487,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3847,15 +3497,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3869,10 +3514,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "GIFI"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3893,7 +3536,6 @@ msgstr "GIFI zapisane"
 msgid "GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3902,7 +3544,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3910,11 +3552,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3923,7 +3564,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3931,9 +3572,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3949,7 +3589,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3957,7 +3597,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3973,12 +3613,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3987,7 +3625,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4061,21 +3698,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4106,7 +3728,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4116,13 +3737,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Grafika"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4165,7 +3784,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4199,14 +3817,10 @@ msgstr "Dołącz w menu rozwijanym"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4214,12 +3828,10 @@ msgstr ""
 msgid "Income"
 msgstr "Przychód"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4230,7 +3842,6 @@ msgstr "Rachunek Zysków i Strat"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4240,7 +3851,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Rachunek Zysków i Strat"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4260,11 +3870,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4274,30 +3883,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "Noty Wewnętrzne"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4307,17 +3912,14 @@ msgstr "Inwentarz"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4345,11 +3947,7 @@ msgstr "Inwentarz zapisany!"
 msgid "Inventory transferred!"
 msgstr "Inwentarz przeniesiony!"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4391,8 +3989,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4408,11 +4004,6 @@ msgstr "Brak Daty Wystawienia"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4431,7 +4022,6 @@ msgstr "Numer Faktury"
 msgid "Invoice Number missing!"
 msgstr "Brak Numeru Faktury"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4461,12 +4051,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4524,8 +4112,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Styczeń"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Styczeń"
 
@@ -4554,8 +4141,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Lipiec"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Lipiec"
 
@@ -4563,8 +4149,8 @@ msgstr "Lipiec"
 msgid "Jun"
 msgstr "Czerwiec"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Czerwiec"
 
@@ -4577,10 +4163,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "Szablony LaTeX"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4602,15 +4184,12 @@ msgstr "Koszty Pracownicze/Administracyjne"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Język"
@@ -4631,7 +4210,6 @@ msgstr "Język nie zdefiniowany!"
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4642,7 +4220,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4664,40 +4241,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr "Cykl"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4709,9 +4285,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4733,9 +4307,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4749,8 +4321,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4767,7 +4337,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4804,7 +4373,6 @@ msgstr "Wykaz Języków"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4830,7 +4398,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4848,7 +4415,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4869,7 +4435,7 @@ msgstr ""
 msgid "Login"
 msgstr "Zarejestrój się"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4897,45 +4463,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Marka"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4957,40 +4516,34 @@ msgstr ""
 msgid "Mar"
 msgstr "Marzec"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Marzec"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Marża"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "Maj"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Notatka"
@@ -5007,7 +4560,6 @@ msgstr "Wiadomość"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Metoda"
@@ -5016,7 +4568,6 @@ msgstr "Metoda"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5035,14 +4586,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5056,7 +4604,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5069,14 +4616,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Model"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5094,7 +4639,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5118,14 +4663,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5134,15 +4677,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5161,7 +4695,6 @@ msgstr "Nazwa"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5212,8 +4745,6 @@ msgstr ""
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5235,12 +4766,10 @@ msgstr ""
 msgid "Ninety"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Nie"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5249,7 +4778,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5257,11 +4786,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5269,7 +4798,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5278,11 +4806,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5290,21 +4818,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5323,12 +4848,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5337,12 +4860,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5380,11 +4901,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5430,23 +4946,18 @@ msgstr "Nie ma nic do przeniesienia!"
 msgid "Nov"
 msgstr "Listopad"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "Listopad"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5477,7 +4988,7 @@ msgstr ""
 msgid "Number"
 msgstr "Numer Katalogu"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Format Numeru"
 
@@ -5498,13 +5009,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Przestarzałe"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5513,8 +5022,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Pażdziernik"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Pażdziernik"
 
@@ -5526,9 +5034,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5578,7 +5083,6 @@ msgstr ""
 msgid "Open"
 msgstr "Otworzono"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5600,9 +5104,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5648,7 +5149,6 @@ msgstr "Brak Daty Zlecenia"
 msgid "Order Entry"
 msgstr "Wystawianie Zleceń"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5670,7 +5170,6 @@ msgstr "Zlecenie usunięte"
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5692,7 +5191,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5738,7 +5237,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5757,10 +5255,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5804,11 +5298,6 @@ msgstr "Brak Numeru Listy Pakunkowej"
 msgid "Packing list"
 msgstr "Lista Pakunkowa"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5826,12 +5315,10 @@ msgstr "Zapłacono"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Produkt"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5841,14 +5328,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5878,14 +5357,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5901,15 +5376,12 @@ msgstr "Symbol"
 msgid "Parts"
 msgstr "Produkt"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5919,7 +5391,6 @@ msgstr ""
 msgid "Password"
 msgstr "Hasło"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5932,7 +5403,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5946,7 +5416,6 @@ msgstr ""
 msgid "Payables"
 msgstr "Zobowiązania"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5955,7 +5424,6 @@ msgstr "Zobowiązania"
 msgid "Payment"
 msgstr "Kasa Wypłaci"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5968,7 +5436,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5985,7 +5452,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6021,15 +5487,15 @@ msgstr "Wypłaty"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6048,7 +5514,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6079,108 +5544,88 @@ msgstr "Lista Pobrania"
 msgid "Pick list"
 msgstr "Lista Pobrania"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6196,7 +5641,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6205,24 +5649,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6231,13 +5673,11 @@ msgstr ""
 msgid "Post"
 msgstr "Zatwierdż"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6278,7 +5718,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Postscript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6316,20 +5755,16 @@ msgstr ""
 msgid "Price"
 msgstr "Cena Netto"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6365,8 +5800,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6376,7 +5809,6 @@ msgstr ""
 msgid "Print"
 msgstr "Wydrukuj"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6393,7 +5825,7 @@ msgstr ""
 msgid "Printed"
 msgstr "Wydrukowane"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Drukarka"
 
@@ -6437,17 +5869,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6476,7 +5906,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6495,7 +5924,6 @@ msgstr "Tłumaczenie Opisu Projektu"
 msgid "Project Number"
 msgstr "Numer Projektu"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6504,9 +5932,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Projekty"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6516,7 +5941,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6534,22 +5958,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Zlecenie Zakupu"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "Numer Zlecenia Zakupu"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Zlecenia Zakupu"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6564,14 +5982,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Zlecenie Zakupu"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6602,7 +6016,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Ilość"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6616,8 +6029,6 @@ msgstr "Ilość przewyższa dostępne jednostki zasobów!"
 msgid "Quarter"
 msgstr "Kwartał"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6654,9 +6065,7 @@ msgstr "Brak Numeru Oferty"
 msgid "Quotation deleted!"
 msgstr "Oferta usunięta"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6677,25 +6086,20 @@ msgstr "Prośba o Ofertę"
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "Numer Prośby o Ofertę"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "Prośby o Ofertę"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "PPZ"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6707,7 +6111,6 @@ msgstr "Stawka"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6730,13 +6133,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6754,7 +6153,6 @@ msgstr "Kasa Przyjmie"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6768,8 +6166,7 @@ msgstr "Wpłaty"
 msgid "Receivables"
 msgstr "Należności"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Dostawy"
 
@@ -6777,7 +6174,6 @@ msgstr "Dostawy"
 msgid "Receive Merchandise"
 msgstr "Dostawy Towarów"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6798,7 +6194,6 @@ msgstr "Zbalansowanie Kont"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6819,13 +6214,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6864,12 +6252,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6907,7 +6293,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6919,7 +6305,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6932,7 +6318,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6982,7 +6367,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -7002,13 +6387,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Termin Dostawy"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7038,7 +6420,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7047,7 +6428,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7064,7 +6444,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7114,11 +6493,11 @@ msgstr "SWW"
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7144,7 +6523,6 @@ msgstr "Sprzedaż"
 msgid "Sales Invoice"
 msgstr "Faktura VAT Sprzedaży"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7160,20 +6538,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr "Zlecenie Sprzedaży"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "Numer Zlecenia Sprzedaży"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Zlecenia Sprzedaży"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "Numer Oferty Sprzedaży"
@@ -7196,9 +6571,6 @@ msgstr "Numer Oferty Sprzedaży"
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7222,13 +6594,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7248,7 +6617,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7258,7 +6627,6 @@ msgstr "Zapisz"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7317,11 +6685,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "Zapisz jako nowe"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7344,10 +6711,8 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Ekran"
 
@@ -7367,7 +6732,6 @@ msgstr "Ekran"
 msgid "Search"
 msgstr "Znajdż"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7376,7 +6740,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7429,11 +6792,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7445,11 +6808,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7461,7 +6824,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7469,7 +6832,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7525,7 +6887,6 @@ msgstr ""
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7534,9 +6895,6 @@ msgstr ""
 msgid "Sell"
 msgstr "Sprzedaż"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7590,13 +6948,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Wrzesień"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "Wrzesień"
 
@@ -7617,9 +6973,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "Nr. Sr."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7649,7 +7002,6 @@ msgstr ""
 msgid "Services"
 msgstr "Usługi"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 msgid "Session Timeout (e.g. \"90 minutes\")"
 msgstr ""
@@ -7662,7 +7014,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7682,10 +7034,10 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Wysyłka"
 
@@ -7712,10 +7064,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7776,10 +7124,6 @@ msgstr "Brak Dnia Dostawy!"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7821,7 +7165,6 @@ msgstr "Dzień Dostawy"
 msgid "Short"
 msgstr "Niedobór"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7862,7 +7205,6 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7875,12 +7217,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7907,7 +7243,6 @@ msgstr "Żródło"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7929,21 +7264,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Standartowe"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "Europejska Klasyfikacja Działalności"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7974,8 +7298,6 @@ msgstr ""
 msgid "Startdate"
 msgstr "Dzień Zatrudnienia"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8012,13 +7334,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Wykaz"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Wykaz Salda"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8049,7 +7369,7 @@ msgstr "Wstaw Zestaw"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Strona Stylowa"
 
@@ -8074,7 +7394,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8117,7 +7436,6 @@ msgstr "Skrót"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8150,12 +7468,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8167,9 +7479,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8188,8 +7497,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8200,17 +7507,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8354,7 +7658,6 @@ msgstr ""
 msgid "Template"
 msgstr "Szablony HTML"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8363,7 +7666,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8416,7 +7718,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8428,7 +7730,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8479,24 +7781,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8519,14 +7818,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8570,7 +7865,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8600,19 +7894,10 @@ msgstr ""
 msgid "To"
 msgstr "do"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8649,7 +7934,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8674,16 +7958,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8726,7 +8001,7 @@ msgstr ""
 msgid "Total"
 msgstr "Wartość Brutto"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8734,7 +8009,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8755,7 +8029,6 @@ msgstr "Transakcja"
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8771,14 +8044,12 @@ msgstr "Brak Daty Transakcji!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8817,7 +8088,6 @@ msgstr "Tłumaczenia"
 msgid "Translations saved!"
 msgstr "Tłumaczenia zapisane!"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Bilans Porównawczy"
@@ -8826,7 +8096,6 @@ msgstr "Bilans Porównawczy"
 msgid "Trillion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8883,10 +8152,6 @@ msgstr ""
 msgid "Two"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8921,39 +8186,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8972,43 +8231,37 @@ msgstr "Jednostka"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9016,23 +8269,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9049,7 +8297,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9077,21 +8324,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9100,7 +8342,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9118,24 +8359,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9145,7 +8381,6 @@ msgstr "Użytkownik"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9166,7 +8401,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9192,8 +8426,6 @@ msgstr "Ważne do"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9203,11 +8435,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9223,7 +8451,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Dostawca"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9237,7 +8464,6 @@ msgstr "Statystyka Dostaw"
 msgid "Vendor Invoice"
 msgstr "Faktura VAT Zakupu"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9247,9 +8473,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9279,9 +8502,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "Brak Dostawcy"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9289,8 +8510,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Brak Dostawcy w bazie danych"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9305,7 +8524,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9318,7 +8536,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9341,7 +8558,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Magazyny"
@@ -9350,11 +8566,26 @@ msgstr "Magazyny"
 msgid "Warning!"
 msgstr "Ostrzeżenie"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9364,7 +8595,6 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9381,13 +8611,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Waga"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Jednostka Wagi"
@@ -9404,7 +8632,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9422,11 +8649,11 @@ msgstr "Zlecenie Robocze"
 msgid "Work order"
 msgstr "Zlecenie Robocze"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9469,15 +8696,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Tak"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9504,7 +8726,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9568,17 +8790,12 @@ msgstr "dni"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9595,7 +8812,7 @@ msgstr ""
 msgid "done"
 msgstr "wykonane"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9623,8 +8840,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9633,22 +8848,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9673,7 +8884,6 @@ msgstr ""
 msgid "sent"
 msgstr "wysłane"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9698,8 +8908,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/pt.po
+++ b/locale/po/pt.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Portuguese (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,27 +15,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -48,12 +43,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -99,7 +90,6 @@ msgstr "Fornecedores"
 msgid "AP Aging"
 msgstr "Idade Saldos Fornecedores"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -108,7 +98,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -123,7 +112,6 @@ msgstr ""
 msgid "AP Transaction"
 msgstr "Transacção Fornecedores"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Transacções Fornecedores"
@@ -136,9 +124,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -157,7 +143,6 @@ msgstr "Clientes"
 msgid "AR Aging"
 msgstr "Idade Saldos Clientes"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -166,7 +151,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -181,7 +165,6 @@ msgstr ""
 msgid "AR Transaction"
 msgstr "Transacção Clientes"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Transacções Clientes"
@@ -194,9 +177,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -205,8 +186,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Transacção Clientes"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -216,16 +195,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -251,38 +225,20 @@ msgstr ""
 msgid "Account"
 msgstr "Conta"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -303,23 +259,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Número da Conta"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -359,17 +310,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -381,7 +330,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -409,12 +358,10 @@ msgstr "Activo"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -437,11 +384,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr "Novo Conjunto"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -566,7 +513,6 @@ msgstr "Nova Encomenda de Cliente"
 msgid "Add Service"
 msgstr "Novo Serviço"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -633,7 +579,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Actualizar"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -658,7 +603,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -668,12 +612,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -693,8 +636,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -747,7 +689,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -756,11 +697,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -794,14 +730,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Total"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -810,27 +742,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Total em dívida"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -848,14 +774,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -874,17 +800,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -893,13 +816,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -908,7 +824,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -917,14 +832,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -936,19 +849,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Abr"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "Abril"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -964,7 +874,6 @@ msgstr ""
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -983,19 +892,17 @@ msgstr ""
 msgid "Asset"
 msgstr "Activo"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1008,29 +915,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1046,7 +950,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1144,8 +1047,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Ago"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Agosto"
 
@@ -1157,7 +1059,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1171,7 +1072,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1184,7 +1084,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1218,8 +1117,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1234,7 +1131,6 @@ msgstr "Saldo"
 msgid "Balance Sheet"
 msgstr "Folha de Balanço"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1255,7 +1151,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1266,7 +1161,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1276,18 +1170,15 @@ msgstr "Moeda"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1300,12 +1191,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1322,13 +1211,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1369,8 +1256,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1416,17 +1301,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1439,12 +1321,10 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Número de negócio"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1454,12 +1334,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1481,7 +1359,6 @@ msgstr ""
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1513,18 +1390,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1650,12 +1525,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Plano de Contas"
 
@@ -1675,7 +1549,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1704,7 +1577,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1716,9 +1589,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr ""
 
@@ -1746,15 +1619,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Fechado"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1768,8 +1639,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1784,22 +1653,18 @@ msgstr ""
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1811,39 +1676,31 @@ msgstr ""
 msgid "Company"
 msgstr "Companhia"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1864,7 +1721,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Confirmar!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1882,7 +1739,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Contacto"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1898,7 +1754,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1916,9 +1771,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1948,7 +1800,6 @@ msgstr ""
 msgid "Contra"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1956,10 +1807,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1990,20 +1837,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2019,26 +1862,20 @@ msgstr ""
 msgid "Could not transfer Inventory!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2050,7 +1887,6 @@ msgstr ""
 msgid "Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2063,7 +1899,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2071,11 +1907,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2103,8 +1939,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2112,17 +1946,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Crédito"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2147,29 +1978,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Moeda"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2192,18 +2013,14 @@ msgstr "Moeda"
 msgid "Currency"
 msgstr "Moeda"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2213,11 +2030,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2232,7 +2045,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Cliente"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2251,9 +2063,6 @@ msgstr "Cliente inexistente!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2273,9 +2082,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "Falta cliente!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2287,7 +2094,7 @@ msgstr "Cliente inexistente!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2311,12 +2118,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2349,28 +2155,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2417,19 +2211,14 @@ msgstr ""
 msgid "Date"
 msgstr "Data"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2451,7 +2240,6 @@ msgstr ""
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2515,8 +2303,6 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2532,10 +2318,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2545,17 +2329,14 @@ msgstr ""
 msgid "Dec"
 msgstr "Dez"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Dezembro"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2565,7 +2346,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2578,47 +2358,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2631,21 +2402,14 @@ msgstr ""
 msgid "Defaults"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2663,7 +2427,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Remover"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2676,7 +2439,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2690,37 +2452,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Data de entrega"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2742,20 +2500,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2766,46 +2521,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2916,12 +2632,10 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2934,7 +2648,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2943,7 +2656,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Desconto"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2952,28 +2664,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2981,7 +2693,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2990,7 +2701,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -2998,12 +2709,10 @@ msgstr ""
 msgid "Done"
 msgstr "Pronto"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3016,12 +2725,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3030,19 +2737,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3058,10 +2762,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3080,7 +2780,7 @@ msgstr "Falta Data de Vencimento!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3106,7 +2806,7 @@ msgstr ""
 msgid "E-mailed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3136,7 +2836,7 @@ msgstr ""
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3280,8 +2980,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3295,7 +2993,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Funcionário"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3305,12 +3002,11 @@ msgstr ""
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 msgid "Employee wage screen"
 msgstr ""
@@ -3319,37 +3015,26 @@ msgstr ""
 msgid "Employees"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3373,7 +3058,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3398,12 +3082,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3413,7 +3095,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3421,7 +3103,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3446,7 +3127,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3458,14 +3139,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Capital"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3479,16 +3157,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3496,7 +3173,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3509,8 +3186,6 @@ msgstr ""
 msgid "Exch"
 msgstr "Câmbio"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3525,7 +3200,6 @@ msgstr "Taxa de Câmbio"
 msgid "Exchange rate for payment missing!"
 msgstr "Falta a taxa de câmbio para o pagamento!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3534,7 +3208,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "Falta a taxa de câmbio!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3552,13 +3225,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Despesa/Activo"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3636,8 +3306,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Fev"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Fevereiro"
 
@@ -3653,14 +3322,10 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3671,11 +3336,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3686,7 +3351,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3744,12 +3408,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Diferenças de Câmbio - Proveitos"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Diferenças de Câmbio - Prejuizos"
@@ -3758,12 +3420,10 @@ msgstr "Diferenças de Câmbio - Prejuizos"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3780,7 +3440,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3799,18 +3458,10 @@ msgstr ""
 msgid "From"
 msgstr "De"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3831,7 +3482,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3842,15 +3492,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3864,10 +3509,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "CFOP - Código Fiscal da Operação"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3888,7 +3531,6 @@ msgstr "CFOP guardado"
 msgid "GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3897,7 +3539,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3905,11 +3547,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3918,7 +3559,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3926,9 +3567,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3944,7 +3584,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3952,7 +3592,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3968,12 +3608,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3982,7 +3620,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4056,21 +3693,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4101,7 +3723,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4111,13 +3732,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Imagem"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4160,7 +3779,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4194,14 +3812,10 @@ msgstr "Incluir nos menus drop-down"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4209,12 +3823,10 @@ msgstr ""
 msgid "Income"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4225,7 +3837,6 @@ msgstr "Estado de Receitas"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4235,7 +3846,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Estado de Receitas"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4255,11 +3865,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4269,30 +3878,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4302,17 +3907,14 @@ msgstr "Inventário"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4340,11 +3942,7 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4386,8 +3984,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4403,11 +3999,6 @@ msgstr "Data de Factura não encontrada!"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4426,7 +4017,6 @@ msgstr "Número de Factura"
 msgid "Invoice Number missing!"
 msgstr "Número de Factura não encontrado!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4456,12 +4046,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4519,8 +4107,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Jan"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Janeiro"
 
@@ -4549,8 +4136,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Julho"
 
@@ -4558,8 +4144,8 @@ msgstr "Julho"
 msgid "Jun"
 msgstr "Jun"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Junho"
 
@@ -4572,10 +4158,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "Modelos LaTeX"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4597,15 +4179,12 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Língua"
@@ -4626,7 +4205,6 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4637,7 +4215,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4659,40 +4236,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4704,9 +4280,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4728,9 +4302,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4744,8 +4316,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4762,7 +4332,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4799,7 +4368,6 @@ msgstr ""
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4825,7 +4393,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4843,7 +4410,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4864,7 +4430,7 @@ msgstr ""
 msgid "Login"
 msgstr "Login"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4892,45 +4458,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Marca"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4952,40 +4511,34 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Março"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "Mai"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr ""
@@ -5002,7 +4555,6 @@ msgstr "Mensagem"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr ""
@@ -5011,7 +4563,6 @@ msgstr ""
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5030,14 +4581,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5051,7 +4599,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5064,14 +4611,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Modelo"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5089,7 +4634,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5113,14 +4658,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5129,15 +4672,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5156,7 +4690,6 @@ msgstr "Nome"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5207,8 +4740,6 @@ msgstr ""
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5230,12 +4761,10 @@ msgstr ""
 msgid "Ninety"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Não"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5244,7 +4773,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5252,11 +4781,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5264,7 +4793,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5273,11 +4801,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5285,21 +4813,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5318,12 +4843,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5332,12 +4855,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5375,11 +4896,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5425,23 +4941,18 @@ msgstr ""
 msgid "Nov"
 msgstr "Nov"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "Novembro"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5472,7 +4983,7 @@ msgstr ""
 msgid "Number"
 msgstr "Número"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Formato numérico"
 
@@ -5493,13 +5004,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Obsoleto"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5508,8 +5017,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Out"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Outubro"
 
@@ -5521,9 +5029,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5573,7 +5078,6 @@ msgstr ""
 msgid "Open"
 msgstr "Abrir"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5595,9 +5099,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5643,7 +5144,6 @@ msgstr "Falta data da Encomenda"
 msgid "Order Entry"
 msgstr "Encomendas de Clientes"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5665,7 +5165,6 @@ msgstr "Encomenda apagada"
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5687,7 +5186,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5732,7 +5231,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5751,10 +5249,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5798,11 +5292,6 @@ msgstr "Falta Numero de Lista de Expedição"
 msgid "Packing list"
 msgstr "Lista de Expedição"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5820,12 +5309,10 @@ msgstr "Total Pago"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Produto"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5835,14 +5322,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5872,14 +5351,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5895,15 +5370,12 @@ msgstr ""
 msgid "Parts"
 msgstr "Produto"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5913,7 +5385,6 @@ msgstr ""
 msgid "Password"
 msgstr "Password"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5926,7 +5397,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5940,7 +5410,6 @@ msgstr ""
 msgid "Payables"
 msgstr "Fornecedores"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5949,7 +5418,6 @@ msgstr "Fornecedores"
 msgid "Payment"
 msgstr "Pagamento"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5962,7 +5430,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5979,7 +5446,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6015,15 +5481,15 @@ msgstr "Pagamentos"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6042,7 +5508,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6072,108 +5537,88 @@ msgstr ""
 msgid "Pick list"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6189,7 +5634,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6198,24 +5642,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6224,13 +5666,11 @@ msgstr ""
 msgid "Post"
 msgstr "Processar"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6271,7 +5711,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "PostScript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6309,20 +5748,16 @@ msgstr ""
 msgid "Price"
 msgstr "Preço"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6358,8 +5793,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6369,7 +5802,6 @@ msgstr ""
 msgid "Print"
 msgstr "Imprimir"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6386,7 +5818,7 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Impressora"
 
@@ -6430,17 +5862,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6469,7 +5899,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6488,7 +5917,6 @@ msgstr ""
 msgid "Project Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6497,9 +5925,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Projectos"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6509,7 +5934,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6527,22 +5951,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Ordem de Compra"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Ordens de Compra"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6557,14 +5975,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Ordem de Compra"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6595,7 +6009,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Qtd"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6609,8 +6022,6 @@ msgstr ""
 msgid "Quarter"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6647,9 +6058,7 @@ msgstr ""
 msgid "Quotation deleted!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6670,25 +6079,20 @@ msgstr ""
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "Nível mínimo de stock"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6700,7 +6104,6 @@ msgstr "Taxa"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6723,13 +6126,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6747,7 +6146,6 @@ msgstr "Recibo"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6761,8 +6159,7 @@ msgstr "Recibos"
 msgid "Receivables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr ""
 
@@ -6770,7 +6167,6 @@ msgstr ""
 msgid "Receive Merchandise"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6791,7 +6187,6 @@ msgstr "Reconciliação"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6812,13 +6207,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6857,12 +6245,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6900,7 +6286,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6912,7 +6298,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6925,7 +6311,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6974,7 +6359,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -6994,13 +6379,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Requerido por"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7030,7 +6412,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7039,7 +6420,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7056,7 +6436,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7106,11 +6485,11 @@ msgstr ""
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7136,7 +6515,6 @@ msgstr "Vendas"
 msgid "Sales Invoice"
 msgstr "Factura de Venda"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7152,20 +6530,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr "Encomenda de Venda"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Encomendas de Venda"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr ""
@@ -7187,9 +6562,6 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7213,13 +6585,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7239,7 +6608,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7249,7 +6618,6 @@ msgstr "Guardar"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7308,11 +6676,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "Guardar como novo"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7335,10 +6702,8 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Ecran"
 
@@ -7358,7 +6723,6 @@ msgstr "Ecran"
 msgid "Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7367,7 +6731,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7420,11 +6783,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7436,11 +6799,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7452,7 +6815,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7460,7 +6823,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7516,7 +6878,6 @@ msgstr ""
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7525,9 +6886,6 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7581,13 +6939,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Set"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "Setembro"
 
@@ -7608,9 +6964,6 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7640,7 +6993,6 @@ msgstr ""
 msgid "Services"
 msgstr "Serviço"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 msgid "Session Timeout (e.g. \"90 minutes\")"
 msgstr ""
@@ -7653,7 +7005,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7673,10 +7025,10 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Expedir"
 
@@ -7703,10 +7055,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7767,10 +7115,6 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7811,7 +7155,6 @@ msgstr ""
 msgid "Short"
 msgstr "Curta"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7852,7 +7195,6 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7865,12 +7207,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7897,7 +7233,6 @@ msgstr "Origem"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7919,21 +7254,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Padrão"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7964,8 +7288,6 @@ msgstr ""
 msgid "Startdate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8002,13 +7324,11 @@ msgstr ""
 msgid "Statement"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8038,7 +7358,7 @@ msgstr "Conjunto em stock"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Stylesheet"
 
@@ -8063,7 +7383,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8106,7 +7425,6 @@ msgstr ""
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8139,12 +7457,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8156,9 +7468,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8177,8 +7486,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8189,17 +7496,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8343,7 +7647,6 @@ msgstr ""
 msgid "Template"
 msgstr "Templates HTML"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8352,7 +7655,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8405,7 +7707,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8417,7 +7719,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8468,24 +7770,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8508,14 +7807,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8559,7 +7854,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8589,19 +7883,10 @@ msgstr ""
 msgid "To"
 msgstr "Até"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8638,7 +7923,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8663,16 +7947,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8715,7 +7990,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8723,7 +7998,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8744,7 +8018,6 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8760,14 +8033,12 @@ msgstr "Falta Data de transacção!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8806,7 +8077,6 @@ msgstr ""
 msgid "Translations saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Balancete"
@@ -8815,7 +8085,6 @@ msgstr "Balancete"
 msgid "Trillion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8872,10 +8141,6 @@ msgstr ""
 msgid "Two"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8910,39 +8175,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8961,43 +8220,37 @@ msgstr "Unidade"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9005,23 +8258,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9038,7 +8286,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9066,21 +8313,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9089,7 +8331,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9107,24 +8348,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9134,7 +8370,6 @@ msgstr "Utilizador"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9155,7 +8390,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9181,8 +8415,6 @@ msgstr ""
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9192,11 +8424,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9212,7 +8440,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Fornecedor"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9226,7 +8453,6 @@ msgstr ""
 msgid "Vendor Invoice"
 msgstr "Factura de Compra"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9236,9 +8462,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9268,9 +8491,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "Falta fornecedor"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9278,8 +8499,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Fornecedor não existe"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9294,7 +8513,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9307,7 +8525,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9330,7 +8547,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr ""
@@ -9339,11 +8555,26 @@ msgstr ""
 msgid "Warning!"
 msgstr ""
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9353,7 +8584,6 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9370,13 +8600,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Peso"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Unidade de Peso"
@@ -9393,7 +8621,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9410,11 +8637,11 @@ msgstr ""
 msgid "Work order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9457,15 +8684,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Sim"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9492,7 +8714,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9556,17 +8778,12 @@ msgstr "dias"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9583,7 +8800,7 @@ msgstr ""
 msgid "done"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9611,8 +8828,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9621,22 +8836,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9661,7 +8872,6 @@ msgstr ""
 msgid "sent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9686,8 +8896,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/pt_BR.po
+++ b/locale/po/pt_BR.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/ledgersmb/"
@@ -16,27 +16,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr "# Faturas"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr "% Dep."
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr "(+) Valor Salvamento"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr "(-) Dep. Acum."
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr "(=) VCL"
@@ -49,12 +44,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -103,7 +94,6 @@ msgstr "Contas a Pagar"
 msgid "AP Aging"
 msgstr "Contas a Pagar Vencidas"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr "Fatura a pagar"
@@ -112,7 +102,6 @@ msgstr "Fatura a pagar"
 msgid "AP Invoices"
 msgstr "Faturas a pagar"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -127,7 +116,6 @@ msgstr "Contas a Pagar Pendentes"
 msgid "AP Transaction"
 msgstr "Transação - Contas a Pagar"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Transações - Contas a Pagar"
@@ -140,9 +128,7 @@ msgstr "Voucher a pagar"
 msgid "AP account"
 msgstr "Conta a pagar"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -161,7 +147,6 @@ msgstr "Contas a Receber"
 msgid "AR Aging"
 msgstr "Contas a Receber Vencidas"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr "Fatura a receber"
@@ -170,7 +155,6 @@ msgstr "Fatura a receber"
 msgid "AR Invoices"
 msgstr "Faturas a receber"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -185,7 +169,6 @@ msgstr "Contas a Receber Pendentes"
 msgid "AR Transaction"
 msgstr "Transação - Contas a Receber"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Transações - Contas a Receber"
@@ -198,9 +181,7 @@ msgstr "Voucher a receber"
 msgid "AR account"
 msgstr "Conta a receber"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -209,8 +190,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Transação - Contas a Receber"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -220,16 +199,11 @@ msgstr "Montante APagar/AReceber/Razão"
 msgid "Abandonment"
 msgstr "Abandono"
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr "Acesso não-permitido"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -255,38 +229,20 @@ msgstr "Acesso não-permitido"
 msgid "Account"
 msgstr "Conta"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr "Descrição da conta"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr "Etiqueta de Conta"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr "Nome da Conta"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -307,23 +263,18 @@ msgstr "Nome da Conta"
 msgid "Account Number"
 msgstr "Número da Conta"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr "Número final da Conta"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr "Número inicial da Conta"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr "Título da Conta"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -363,17 +314,15 @@ msgstr "Contas Para"
 msgid "Accounts To"
 msgstr "Contas Para"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -385,7 +334,7 @@ msgstr "Resultado final"
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -413,12 +362,10 @@ msgstr "Ativa"
 msgid "Active On"
 msgstr "Ativo No"
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr "Sessões Ativas"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -441,11 +388,11 @@ msgstr "Adicionar Contas"
 msgid "Add Assembly"
 msgstr "Adicionar Conjunto"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -570,7 +517,6 @@ msgstr "Adicionar Pedido de Venda"
 msgid "Add Service"
 msgstr "Adicionar Serviço"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -637,7 +583,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Atualizar"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -662,7 +607,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -672,12 +616,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -697,8 +640,7 @@ msgstr ""
 msgid "Aged"
 msgstr "Velho"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -751,7 +693,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr "Alocado"
@@ -760,11 +701,6 @@ msgstr "Alocado"
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -798,14 +734,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Total"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -814,27 +746,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Total Devido"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -852,14 +778,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -878,17 +804,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -897,13 +820,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -912,7 +828,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -921,14 +836,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -940,19 +853,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Abr"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "Abril"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -968,7 +878,6 @@ msgstr "Tem certeza que quer APAGAR tal número de Cotação?"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -987,19 +896,17 @@ msgstr "Conjuntos re estocados"
 msgid "Asset"
 msgstr "Ativo"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1012,29 +919,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1050,7 +954,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1148,8 +1051,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Ago"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Agosto"
 
@@ -1161,7 +1063,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1175,7 +1076,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1188,7 +1088,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr "Custo Médio"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1222,8 +1121,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1238,7 +1135,6 @@ msgstr "Balanço"
 msgid "Balance Sheet"
 msgstr "Folha de Balanço"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1259,7 +1155,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1270,7 +1165,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1280,18 +1174,15 @@ msgstr "Moeda"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1304,12 +1195,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1326,13 +1215,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1373,8 +1260,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1421,17 +1306,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1444,12 +1326,10 @@ msgstr ""
 msgid "Business"
 msgstr "Negócio"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Número de negócio"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1459,12 +1339,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1486,7 +1364,6 @@ msgstr "Negócio salvo"
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1518,18 +1395,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1657,12 +1532,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr "Faturáveis"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Plano de Contas"
 
@@ -1682,7 +1556,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "Inventário de cheques"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1711,7 +1584,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1723,9 +1596,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "Limpo"
 
@@ -1753,15 +1626,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Fechado"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1775,8 +1646,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1791,22 +1660,18 @@ msgstr "Código faltando!"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1818,39 +1683,31 @@ msgstr ""
 msgid "Company"
 msgstr "Empresa"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Nome da Empresa"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1871,7 +1728,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Confirmar!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1889,7 +1746,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Contato"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1905,7 +1761,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1923,9 +1778,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1955,7 +1807,6 @@ msgstr ""
 msgid "Contra"
 msgstr "Contra"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1963,10 +1814,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1997,20 +1844,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Custo"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2026,26 +1869,20 @@ msgstr "Não é possível salvar!"
 msgid "Could not transfer Inventory!"
 msgstr "Não é possível transferir inventário!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2057,7 +1894,6 @@ msgstr ""
 msgid "Country"
 msgstr "País"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2070,7 +1906,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2078,11 +1914,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2110,8 +1946,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2119,17 +1953,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Crédito"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2154,29 +1985,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Moeda"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2199,18 +2020,14 @@ msgstr "Moeda"
 msgid "Currency"
 msgstr "Moeda"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Corrente"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2220,11 +2037,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2239,7 +2052,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Cliente"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2258,9 +2070,6 @@ msgstr "Cliente não está no arquivo!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2280,9 +2089,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "Cliente faltando!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2294,7 +2101,7 @@ msgstr "Cliente não está no arquivo!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2318,12 +2125,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2356,28 +2162,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2424,19 +2218,14 @@ msgstr ""
 msgid "Date"
 msgstr "Data"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2458,7 +2247,6 @@ msgstr "Data de recebimento"
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2522,8 +2310,6 @@ msgstr "Dia(s)"
 msgid "Days"
 msgstr "Dias"
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2539,10 +2325,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2552,17 +2336,14 @@ msgstr ""
 msgid "Dec"
 msgstr "Dez"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Dezembro"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2572,7 +2353,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2585,47 +2365,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2638,21 +2409,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "Configurações padrão"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2670,7 +2434,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Apagar"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2683,7 +2446,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr "Apagar a Programação"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2697,37 +2459,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Data de entrega"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2749,20 +2507,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2773,46 +2528,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2923,12 +2639,10 @@ msgstr "Detalhe"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2941,7 +2655,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2950,7 +2663,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Desconto"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2959,28 +2671,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2988,7 +2700,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2997,7 +2708,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -3005,12 +2716,10 @@ msgstr ""
 msgid "Done"
 msgstr "Feito"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3023,12 +2732,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3037,19 +2744,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Desenho"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3065,10 +2769,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3087,7 +2787,7 @@ msgstr "Data de Vencimento faltando!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3113,7 +2813,7 @@ msgstr "Mensagem do e-mail"
 msgid "E-mailed"
 msgstr "Enviado por e-mail"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3143,7 +2843,7 @@ msgstr "Editar a Transação de CR"
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3287,8 +2987,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3302,7 +3000,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Empregado"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3312,12 +3009,11 @@ msgstr "Número do Empregado"
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3327,37 +3023,26 @@ msgstr "Número do Empregado"
 msgid "Employees"
 msgstr "Empregados"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3381,7 +3066,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3406,12 +3090,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3421,7 +3103,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3429,7 +3111,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3455,7 +3136,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Nome da Empresa"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3467,14 +3148,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Capital"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3488,16 +3166,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3505,7 +3182,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3518,8 +3195,6 @@ msgstr "Cada"
 msgid "Exch"
 msgstr "Câmbio"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3534,7 +3209,6 @@ msgstr "Taxa de câmbio"
 msgid "Exchange rate for payment missing!"
 msgstr "Falta a taxa de câmbio para o pagamento!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3543,7 +3217,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "Falta a taxa de câmbio!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3561,13 +3234,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Despesa/Ativo"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3645,8 +3315,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Fev"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Fevereiro"
 
@@ -3662,14 +3331,10 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3680,11 +3345,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3695,7 +3360,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3753,12 +3417,10 @@ msgstr ""
 msgid "For"
 msgstr "Para"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Ganho com câmbio estrangeiro"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Perda com câmbio estrangeiro"
@@ -3767,12 +3429,10 @@ msgstr "Perda com câmbio estrangeiro"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3789,7 +3449,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3808,18 +3467,10 @@ msgstr ""
 msgid "From"
 msgstr "De"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3840,7 +3491,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr "Do Almoxarifado"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3851,15 +3501,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3873,10 +3518,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "CFOP - Código Fiscal da Operação"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3897,7 +3540,6 @@ msgstr "CFOP salvo!"
 msgid "GL"
 msgstr "Conta"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr "Número de Referência da Conta"
@@ -3906,7 +3548,7 @@ msgstr "Número de Referência da Conta"
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3914,11 +3556,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3927,7 +3568,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3935,9 +3576,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr "Gerar"
 
@@ -3953,7 +3593,7 @@ msgstr "Gerar Pedidos"
 msgid "Generate Purchase Orders"
 msgstr "Gerar Ordens de Compra"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3961,7 +3601,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr "Pedidos de Venda"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3977,12 +3617,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3991,7 +3629,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4065,21 +3702,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4110,7 +3732,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4120,13 +3741,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Imagem"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4169,7 +3788,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4203,14 +3821,10 @@ msgstr "Incluir nos menus drop-down (tipo cortina)"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4218,12 +3832,10 @@ msgstr ""
 msgid "Income"
 msgstr "Receita"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4234,7 +3846,6 @@ msgstr "Apuração de L&P"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4244,7 +3855,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Apuração de L&P"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4264,11 +3874,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4278,30 +3887,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "Notas internas"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4311,17 +3916,14 @@ msgstr "Inventário"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4349,11 +3951,7 @@ msgstr "Inventário salvo!"
 msgid "Inventory transferred!"
 msgstr "Inventário transferido!"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4395,8 +3993,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4412,11 +4008,6 @@ msgstr "Data da Fatura não encontrada!"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4435,7 +4026,6 @@ msgstr "Número da Fatura"
 msgid "Invoice Number missing!"
 msgstr "Número da Fatura não encontrado!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4465,12 +4055,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4528,8 +4116,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Jan"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Janeiro"
 
@@ -4558,8 +4145,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Julho"
 
@@ -4567,8 +4153,8 @@ msgstr "Julho"
 msgid "Jun"
 msgstr "Jun"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Junho"
 
@@ -4581,10 +4167,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "Modelos LaTeX"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4606,15 +4188,12 @@ msgstr "Mão-de-Obra/Sobretaxa"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Idioma"
@@ -4635,7 +4214,6 @@ msgstr "Idiomas não definidos!"
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4646,7 +4224,6 @@ msgstr "Último Custo"
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4668,40 +4245,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr "Prazo Entrega"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4713,9 +4289,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4737,9 +4311,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4753,8 +4325,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4771,7 +4341,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4808,7 +4377,6 @@ msgstr "Listar Idiomas"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4834,7 +4402,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4852,7 +4419,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4873,7 +4439,7 @@ msgstr ""
 msgid "Login"
 msgstr "Entrar"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4901,45 +4467,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Marca"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4961,40 +4520,34 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Março"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Margem"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "Mai"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Memorando"
@@ -5011,7 +4564,6 @@ msgstr "Mensagem"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Método"
@@ -5020,7 +4572,6 @@ msgstr "Método"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5039,14 +4590,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5060,7 +4608,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5073,14 +4620,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Modelo"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5098,7 +4643,7 @@ msgstr "Mês(es)"
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5122,14 +4667,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5138,15 +4681,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5165,7 +4699,6 @@ msgstr "Nome"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5216,8 +4749,6 @@ msgstr "Próxima Data"
 msgid "Next Number"
 msgstr "Próximo Número"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5239,12 +4770,10 @@ msgstr ""
 msgid "Ninety"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Não"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5253,7 +4782,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5261,11 +4790,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5273,7 +4802,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5282,11 +4810,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5294,21 +4822,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr "Nenhum projeto aberto"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5327,12 +4852,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5341,12 +4864,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr "Itens não-rastreáveis"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5384,11 +4905,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5434,23 +4950,18 @@ msgstr "Nada a transferir!"
 msgid "Nov"
 msgstr "Nov"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "Novembro"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5481,7 +4992,7 @@ msgstr ""
 msgid "Number"
 msgstr "Número"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Formato de números"
 
@@ -5502,13 +5013,11 @@ msgstr "HE"
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Obsoleto"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5517,8 +5026,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Out"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Outubro"
 
@@ -5530,9 +5038,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5582,7 +5087,6 @@ msgstr ""
 msgid "Open"
 msgstr "Em Aberto"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5604,9 +5108,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5652,7 +5153,6 @@ msgstr "Data do Pedido Faltando"
 msgid "Order Entry"
 msgstr "Entrada de Pedido"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5674,7 +5174,6 @@ msgstr "Pedido apagado!"
 msgid "Order generation failed!"
 msgstr "A geração de pedidos falhou!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5696,7 +5195,7 @@ msgstr "Pedidos gerados!"
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5742,7 +5241,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5761,10 +5259,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5808,11 +5302,6 @@ msgstr "Número da lista de conteúdo faltando!"
 msgid "Packing list"
 msgstr "Lista de Conteúdo"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5830,12 +5319,10 @@ msgstr "Total Efetuado"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Item"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5845,14 +5332,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5882,14 +5361,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5905,15 +5380,12 @@ msgstr "NúmerodoItem"
 msgid "Parts"
 msgstr "Item"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5923,7 +5395,6 @@ msgstr ""
 msgid "Password"
 msgstr "Senha"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5936,7 +5407,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5950,7 +5420,6 @@ msgstr ""
 msgid "Payables"
 msgstr "A Pagar"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5959,7 +5428,6 @@ msgstr "A Pagar"
 msgid "Payment"
 msgstr "Pagamento"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5972,7 +5440,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5989,7 +5456,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6025,15 +5491,15 @@ msgstr "Pagamentos"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6052,7 +5518,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6083,108 +5548,88 @@ msgstr "Lista de Seleção"
 msgid "Pick list"
 msgstr "Lista de Seleção"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6200,7 +5645,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6209,24 +5653,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6235,13 +5677,11 @@ msgstr ""
 msgid "Post"
 msgstr "Lançar"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6282,7 +5722,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Postscript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6320,20 +5759,16 @@ msgstr ""
 msgid "Price"
 msgstr "Preço"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6369,8 +5804,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6380,7 +5813,6 @@ msgstr ""
 msgid "Print"
 msgstr "Imprimir"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6397,7 +5829,7 @@ msgstr "Imprimir e Salvar como Novo"
 msgid "Printed"
 msgstr "Impresso"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Impressora"
 
@@ -6441,17 +5873,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6480,7 +5910,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6499,7 +5928,6 @@ msgstr "Traduções de Descrição de Projeto"
 msgid "Project Number"
 msgstr "Número do Projeto"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6508,9 +5936,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Projetos"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6520,7 +5945,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6538,22 +5962,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Ordem de Compra"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "Número da Ordem de Compra"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Ordens de Compra"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6568,14 +5986,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Ordem de Compra"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6606,7 +6020,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Qtd"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6620,8 +6033,6 @@ msgstr "Quantidade excede unidades disponíveis para estocar!"
 msgid "Quarter"
 msgstr "Trimestre"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6658,9 +6069,7 @@ msgstr "Número da Cotação faltando!"
 msgid "Quotation deleted!"
 msgstr "Cotação apagada!"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6681,25 +6090,20 @@ msgstr "RDC"
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "Número da RDC"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "RDCs"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "PDR"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6711,7 +6115,6 @@ msgstr "Taxa"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6734,13 +6137,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6758,7 +6157,6 @@ msgstr "Recibimento"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6772,8 +6170,7 @@ msgstr "Recibimentos"
 msgid "Receivables"
 msgstr "A Receber"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Receber"
 
@@ -6781,7 +6178,6 @@ msgstr "Receber"
 msgid "Receive Merchandise"
 msgstr "Receber Mercadoria"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6802,7 +6198,6 @@ msgstr "Reconciliação"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6823,13 +6218,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Transações Recorrentes"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6868,12 +6256,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6911,7 +6297,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6923,7 +6309,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6936,7 +6322,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6986,7 +6371,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -7006,13 +6391,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Requerido por"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7042,7 +6424,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7051,7 +6432,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7068,7 +6448,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7118,11 +6497,11 @@ msgstr "SKU"
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7148,7 +6527,6 @@ msgstr "Vendas"
 msgid "Sales Invoice"
 msgstr "Fatura de Venda"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Fatura de Venda/Númenro da Transação de CR"
@@ -7164,20 +6542,17 @@ msgstr "Fatura de Venda/Númenro da Transação de CR"
 msgid "Sales Order"
 msgstr "Pedido de Venda"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "Número do Pedido de Venda"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Pedidos de Venda"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "Númenro da Cotação de Vendas"
@@ -7200,9 +6575,6 @@ msgstr "Númenro da Cotação de Vendas"
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7226,13 +6598,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7252,7 +6621,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7262,7 +6631,6 @@ msgstr "Salvar"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7321,11 +6689,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "Salvar como novo"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7348,10 +6715,8 @@ msgstr "Programação"
 msgid "Scheduled"
 msgstr "Programado"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Tela"
 
@@ -7371,7 +6736,6 @@ msgstr "Tela"
 msgid "Search"
 msgstr "Buscar"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7380,7 +6744,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7433,11 +6796,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7449,11 +6812,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7465,7 +6828,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7473,7 +6836,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7529,7 +6891,6 @@ msgstr "Selecionar txt, Postscript ou PDF!"
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7538,9 +6899,6 @@ msgstr ""
 msgid "Sell"
 msgstr "Vender"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7594,13 +6952,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Set"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "Setembro"
 
@@ -7621,9 +6977,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "Nº Série"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7653,7 +7006,6 @@ msgstr "Código do Serviço"
 msgid "Services"
 msgstr "Serviço"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 #, fuzzy
 msgid "Session Timeout (e.g. \"90 minutes\")"
@@ -7667,7 +7019,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7687,10 +7039,10 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Despachar"
 
@@ -7717,10 +7069,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7781,10 +7129,6 @@ msgstr "Data do Despacho faltando!"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7826,7 +7170,6 @@ msgstr "Data do Despacho"
 msgid "Short"
 msgstr "Em falta"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7867,7 +7210,6 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7880,12 +7222,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7912,7 +7248,6 @@ msgstr "Fonte"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7934,21 +7269,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Padrão"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "Códigos Industriais Padrão"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7979,8 +7303,6 @@ msgstr ""
 msgid "Startdate"
 msgstr "Data Inicial"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8017,13 +7339,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Declaração"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Declaração de Balanço"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8054,7 +7374,7 @@ msgstr "Estoque de Conjuntos"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Folha de estilos"
 
@@ -8079,7 +7399,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8122,7 +7441,6 @@ msgstr "Sumário"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8155,12 +7473,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8172,9 +7484,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8193,8 +7502,6 @@ msgstr "Conts de Imposto"
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8205,17 +7512,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8359,7 +7663,6 @@ msgstr ""
 msgid "Template"
 msgstr "Modelos HTML"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8368,7 +7671,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8421,7 +7723,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8433,7 +7735,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8484,24 +7786,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8524,14 +7823,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8575,7 +7870,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8605,19 +7899,10 @@ msgstr ""
 msgid "To"
 msgstr "Até"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8654,7 +7939,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8679,16 +7963,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8731,7 +8006,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8739,7 +8014,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8760,7 +8034,6 @@ msgstr "Transação"
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8776,14 +8049,12 @@ msgstr "Data de transação faltando!"
 msgid "Transaction Dates"
 msgstr "Datas das Transações"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8822,7 +8093,6 @@ msgstr "Traduções"
 msgid "Translations saved!"
 msgstr "Traduções salvas!"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Balanço de Verificação"
@@ -8831,7 +8101,6 @@ msgstr "Balanço de Verificação"
 msgid "Trillion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8888,10 +8157,6 @@ msgstr ""
 msgid "Two"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8926,39 +8191,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8977,43 +8236,37 @@ msgstr "Unidade"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9021,23 +8274,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9054,7 +8302,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9082,21 +8329,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9105,7 +8347,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9123,24 +8364,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9150,7 +8386,6 @@ msgstr "Usuário"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9171,7 +8406,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9197,8 +8431,6 @@ msgstr "Válido até"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9208,11 +8440,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9228,7 +8456,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Fornecedor"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9242,7 +8469,6 @@ msgstr "Histórico do Fornecedor"
 msgid "Vendor Invoice"
 msgstr "Fatura de Compra"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr "Fatura do Fornecedor/Número da Transação de CP"
@@ -9252,9 +8478,6 @@ msgstr "Fatura do Fornecedor/Número da Transação de CP"
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9284,9 +8507,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "Fornecedor faltando!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9294,8 +8515,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Fornecedor não está no arquivo!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9310,7 +8529,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9323,7 +8541,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9346,7 +8563,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Almoxarifados"
@@ -9355,11 +8571,26 @@ msgstr "Almoxarifados"
 msgid "Warning!"
 msgstr "Cuidado!"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9369,7 +8600,6 @@ msgstr ""
 msgid "Week"
 msgstr "Semana"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9386,13 +8616,11 @@ msgstr ""
 msgid "Weeks"
 msgstr "Semanas"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Peso"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Unidade de Peso"
@@ -9409,7 +8637,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9427,11 +8654,11 @@ msgstr "Ordem de Serviço"
 msgid "Work order"
 msgstr "Ordem de Serviço"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9474,15 +8701,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Sim"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9509,7 +8731,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9573,17 +8795,12 @@ msgstr "dias"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9600,7 +8817,7 @@ msgstr ""
 msgid "done"
 msgstr "feito"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9628,8 +8845,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9638,22 +8853,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9678,7 +8889,6 @@ msgstr ""
 msgid "sent"
 msgstr "enviado"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9703,8 +8913,6 @@ msgstr "para_data"
 msgid "unexpected error!"
 msgstr "erro não esperado"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/ru.po
+++ b/locale/po/ru.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Russian (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -19,27 +19,22 @@ msgstr ""
 "%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
 "%100>=11 && n%100<=14)? 2 : 3);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr "# Счета на оплату"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr "% Износ"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr "(+) Ликвидационная стоимость"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr "(-) Накопленный износ"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr "(=) Чистая балансовая стоимость"
@@ -52,12 +47,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -107,7 +98,6 @@ msgstr "Поступления"
 msgid "AP Aging"
 msgstr "Взаиморасчеты с поставщиками"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr "Счет-фактура КЗ"
@@ -116,7 +106,6 @@ msgstr "Счет-фактура КЗ"
 msgid "AP Invoices"
 msgstr "Счета-фактуры КЗ"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -131,7 +120,6 @@ msgstr "Задолженость поставщиков"
 msgid "AP Transaction"
 msgstr "Проводка закупки"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Проводки закупки"
@@ -144,9 +132,7 @@ msgstr "КЗ Ваучер"
 msgid "AP account"
 msgstr "Счет КЗ"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -165,7 +151,6 @@ msgstr "Продажи"
 msgid "AR Aging"
 msgstr "Взаиморасчеты с клиентами"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr "Счет-фактура ДЗ"
@@ -174,7 +159,6 @@ msgstr "Счет-фактура ДЗ"
 msgid "AR Invoices"
 msgstr "Счета-фактуры ДЗ"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -189,7 +173,6 @@ msgstr "Задолженость клиентов"
 msgid "AR Transaction"
 msgstr "Проводка продаж"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Проводки продаж"
@@ -202,9 +185,7 @@ msgstr "ДЗ Ваучер"
 msgid "AR account"
 msgstr "Счет ДЗ"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -213,8 +194,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Проводка продаж"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -224,16 +203,11 @@ msgstr "ДЗ/КЗ/ГК Amount"
 msgid "Abandonment"
 msgstr "Отказ"
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr "Доступ невозможен"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -259,38 +233,20 @@ msgstr "Доступ невозможен"
 msgid "Account"
 msgstr "Счет"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr "Описание счета"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr "Маркировка счета"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr "Название счета"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -311,23 +267,18 @@ msgstr "Название счета"
 msgid "Account Number"
 msgstr "Код счета"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr "Конечные цифры счета"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr "Начальные цифры счета"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr "Наименование счета"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -367,17 +318,15 @@ msgstr "Счета из"
 msgid "Accounts To"
 msgstr "Счета к"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr "Счета без названий"
 
@@ -389,7 +338,7 @@ msgstr "Начисление"
 msgid "Accrual Basis:"
 msgstr "База начисления"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr "Накопленный износ"
 
@@ -417,12 +366,10 @@ msgstr "Активный"
 msgid "Active On"
 msgstr "Активен"
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr "Действующие сессии"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -445,11 +392,11 @@ msgstr "Добавить счета"
 msgid "Add Assembly"
 msgstr "Новый комплект"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr "Добавить Актив"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr "Добавить класс актива"
 
@@ -574,7 +521,6 @@ msgstr "Новый заказ клиента"
 msgid "Add Service"
 msgstr "Новая услуга"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr "Добавить форму налогового учета"
@@ -641,7 +587,6 @@ msgstr "Добавить/Изменить  зарплату"
 msgid "Add/Update"
 msgstr "Обновить"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr "Добавленный id  [_1]"
@@ -666,7 +611,6 @@ msgstr "Адрес:"
 msgid "Address: [_1]"
 msgstr "Адрес:  [_1]"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -676,12 +620,11 @@ msgstr "Адреса"
 msgid "Adj"
 msgstr "Корректировка"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -701,8 +644,7 @@ msgstr "Детали корректировки"
 msgid "Aged"
 msgstr "Возраст определен"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr "Период определения возраста"
 
@@ -755,7 +697,6 @@ msgstr " Все цены в [_1] фонды"
 msgid "All prices in [_1]."
 msgstr "Все цены в  [_1]."
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr "Размещено"
@@ -764,11 +705,6 @@ msgstr "Размещено"
 msgid "Allow Input"
 msgstr "Разрешить ввод"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -802,14 +738,10 @@ msgstr "Разрешить ввод"
 msgid "Amount"
 msgstr "Сумма"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr "Сумма в бюджете"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -818,27 +750,21 @@ msgstr "Сумма в бюджете"
 msgid "Amount Due"
 msgstr "Сумма к получению"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr "Сумма из"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr "Сумма больше чем"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr "Сумма меньше чем"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -856,14 +782,14 @@ msgstr "Сумма к оплате"
 msgid "Amount/Rate"
 msgstr "Сумма/Курс"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -882,17 +808,14 @@ msgstr "Годовая прямолинейная амортизация еже�
 msgid "Any"
 msgstr "Любой"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr "Примененная скидка"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr "Примененная скидка при переплате"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr "Применить скидку"
@@ -901,13 +824,6 @@ msgstr "Применить скидку"
 msgid "Approval Status"
 msgstr "Статус для подтверждения"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -916,7 +832,6 @@ msgstr "Статус для подтверждения"
 msgid "Approve"
 msgstr "Подтвердить"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -925,14 +840,12 @@ msgstr "Подтвердить"
 msgid "Approved"
 msgstr "Подтверждено"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr "Подтверждено "
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr "Подтверждено в"
 
@@ -944,19 +857,16 @@ msgstr "Подтверждающая подпись"
 msgid "Apr"
 msgstr "апр"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "апрель"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -972,7 +882,6 @@ msgstr "Вы уверены, что хотите удалить резерв?"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -991,19 +900,17 @@ msgstr "Комплект заполнен!"
 msgid "Asset"
 msgstr "Актив"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1016,29 +923,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1054,7 +958,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1152,8 +1055,7 @@ msgstr ""
 msgid "Aug"
 msgstr "авг"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "август"
 
@@ -1165,7 +1067,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1179,7 +1080,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1192,7 +1092,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr "Средняя цена"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1226,8 +1125,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1242,7 +1139,6 @@ msgstr "Баланс"
 msgid "Balance Sheet"
 msgstr "Баланс"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1263,7 +1159,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1274,7 +1169,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1284,18 +1178,15 @@ msgstr "Валюта"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1308,12 +1199,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1330,13 +1219,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1377,8 +1264,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1425,17 +1310,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1448,12 +1330,10 @@ msgstr ""
 msgid "Business"
 msgstr "Бизнес"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Бизнес-код"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1463,12 +1343,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1490,7 +1368,6 @@ msgstr "Бизнес сохранен"
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1522,18 +1399,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1660,12 +1535,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr "Возмещаемый"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "План счетов"
 
@@ -1685,7 +1559,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "Проверить инвентарь"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1714,7 +1587,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1726,9 +1599,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "Очищено"
 
@@ -1756,15 +1629,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Закрыт"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1778,8 +1649,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1794,22 +1663,18 @@ msgstr "Пропущен код"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1821,39 +1686,31 @@ msgstr ""
 msgid "Company"
 msgstr "Организация"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Наименование организации"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1874,7 +1731,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Подтвердить!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1892,7 +1749,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Контактное лицо"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1908,7 +1764,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1926,9 +1781,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1958,7 +1810,6 @@ msgstr ""
 msgid "Contra"
 msgstr "Против"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1966,10 +1817,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -2000,20 +1847,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Цена"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2029,26 +1872,20 @@ msgstr "Невозможно сохранить!"
 msgid "Could not transfer Inventory!"
 msgstr "Невозможно пересестить инвентарь"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2060,7 +1897,6 @@ msgstr ""
 msgid "Country"
 msgstr "Страна"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2073,7 +1909,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2081,11 +1917,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2113,8 +1949,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2122,17 +1956,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Кредит"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2157,29 +1988,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Валюта"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2202,18 +2023,14 @@ msgstr "Валюта"
 msgid "Currency"
 msgstr "Валюта"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Текущий"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2223,11 +2040,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2242,7 +2055,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Клиент"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2261,9 +2073,6 @@ msgstr "Клиент отсутствует в справочнике!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2283,9 +2092,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "Пропущен клиент!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2297,7 +2104,7 @@ msgstr "Клиент отсутствует в справочнике!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2321,12 +2128,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2359,28 +2165,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2427,19 +2221,14 @@ msgstr ""
 msgid "Date"
 msgstr "Дата"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2461,7 +2250,6 @@ msgstr "Дата получена"
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2525,8 +2313,6 @@ msgstr "День"
 msgid "Days"
 msgstr "Дней"
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2542,10 +2328,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2555,17 +2339,14 @@ msgstr ""
 msgid "Dec"
 msgstr "дек"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "декабрь"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2575,7 +2356,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2588,47 +2368,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2641,21 +2412,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "Настройки по умолчании"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2673,7 +2437,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Удалить"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2686,7 +2449,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr "Удалить расписание"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2700,37 +2462,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Дата получения"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2752,20 +2510,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2776,46 +2531,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2926,12 +2642,10 @@ msgstr "Детализировать"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2944,7 +2658,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2953,7 +2666,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Скидка"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2962,28 +2674,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2991,7 +2703,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -3000,7 +2711,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -3008,12 +2719,10 @@ msgstr ""
 msgid "Done"
 msgstr "Выполнено"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3026,12 +2735,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3040,19 +2747,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Изображение"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3068,10 +2772,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3090,7 +2790,7 @@ msgstr "Не указан срок оплаты!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3116,7 +2816,7 @@ msgstr "E-mail сообщение"
 msgid "E-mailed"
 msgstr "Отправлено по e-mail"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3146,7 +2846,7 @@ msgstr "Редактировать проводку Продаж"
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3290,8 +2990,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3305,7 +3003,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Сотрудник"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3315,12 +3012,11 @@ msgstr "Код сотрудника"
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3330,37 +3026,26 @@ msgstr "Код сотрудника"
 msgid "Employees"
 msgstr "Сотрудники"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3384,7 +3069,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3409,12 +3093,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3424,7 +3106,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3432,7 +3114,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3458,7 +3139,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Наименование организации"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3470,14 +3151,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Капитал"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3491,16 +3169,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3508,7 +3185,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3521,8 +3198,6 @@ msgstr "каждый"
 msgid "Exch"
 msgstr "Курс"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3537,7 +3212,6 @@ msgstr "Курс валюты"
 msgid "Exchange rate for payment missing!"
 msgstr "Пропущен курс оплаты!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3546,7 +3220,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "Пропущен курс!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3564,13 +3237,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Расход/активы"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3648,8 +3318,7 @@ msgstr ""
 msgid "Feb"
 msgstr "фев"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "февраль"
 
@@ -3665,14 +3334,10 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3683,11 +3348,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3698,7 +3363,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3756,12 +3420,10 @@ msgstr ""
 msgid "For"
 msgstr "для"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Курсовая прибыль"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Курсовые потери"
@@ -3770,12 +3432,10 @@ msgstr "Курсовые потери"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3792,7 +3452,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3811,18 +3470,10 @@ msgstr ""
 msgid "From"
 msgstr "с"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3843,7 +3494,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr "со склада"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3854,15 +3504,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3876,10 +3521,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "GIFI"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3900,7 +3543,6 @@ msgstr "GIFI сохранен!"
 msgid "GL"
 msgstr "Главная книга"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr "Номер справочника Главной книги"
@@ -3909,7 +3551,7 @@ msgstr "Номер справочника Главной книги"
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3917,11 +3559,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3930,7 +3571,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3938,9 +3579,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr "Создать"
 
@@ -3956,7 +3596,7 @@ msgstr "Создать ордеры"
 msgid "Generate Purchase Orders"
 msgstr "Создать ордеры покупки"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3964,7 +3604,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr "Создать ордеры продажи"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3980,12 +3620,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3994,7 +3632,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4068,21 +3705,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4113,7 +3735,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4123,13 +3744,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Картинка"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4172,7 +3791,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4206,14 +3824,10 @@ msgstr "Включить в падающее меню"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4221,12 +3835,10 @@ msgstr ""
 msgid "Income"
 msgstr "Поступление"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4237,7 +3849,6 @@ msgstr "Отчет о прибыли/убытках"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4247,7 +3858,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Отчет о прибыли/убытках"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4267,11 +3877,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4281,30 +3890,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "Внутренние заметки"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4314,17 +3919,14 @@ msgstr "Инвентарный"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4352,11 +3954,7 @@ msgstr "Инвентарь сохранен!"
 msgid "Inventory transferred!"
 msgstr "Инвентарь перемещен!"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4398,8 +3996,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4415,11 +4011,6 @@ msgstr "Не указана дата выставления счета-факт�
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4438,7 +4029,6 @@ msgstr "Номер счета-фактуры"
 msgid "Invoice Number missing!"
 msgstr "Не указан номер счета-фактуры"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4468,12 +4058,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4531,8 +4119,7 @@ msgstr ""
 msgid "Jan"
 msgstr "янв"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "январь"
 
@@ -4561,8 +4148,7 @@ msgstr ""
 msgid "Jul"
 msgstr "июл"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "июль"
 
@@ -4570,8 +4156,8 @@ msgstr "июль"
 msgid "Jun"
 msgstr "июн"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "июнь"
 
@@ -4584,10 +4170,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "Шаблоны LaTeX"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4609,15 +4191,12 @@ msgstr "Работа/накладные расходы"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Язык"
@@ -4638,7 +4217,6 @@ msgstr "Языки не определены!"
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4649,7 +4227,6 @@ msgstr "Последняя цена"
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4671,40 +4248,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr "Основное время"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4716,9 +4292,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4740,9 +4314,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4756,8 +4328,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4774,7 +4344,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4811,7 +4380,6 @@ msgstr "Список языков"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4837,7 +4405,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4855,7 +4422,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4876,7 +4442,7 @@ msgstr ""
 msgid "Login"
 msgstr "Пользователь"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4904,45 +4470,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Создать"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4964,40 +4523,34 @@ msgstr ""
 msgid "Mar"
 msgstr "март"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "март"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Наценка"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "май"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Комментарий"
@@ -5014,7 +4567,6 @@ msgstr "Сообщение"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Метод"
@@ -5023,7 +4575,6 @@ msgstr "Метод"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5042,14 +4593,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5063,7 +4611,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5076,14 +4623,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Модель"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5101,7 +4646,7 @@ msgstr "месяц"
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5125,14 +4670,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5141,15 +4684,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5168,7 +4702,6 @@ msgstr "Наименование"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5219,8 +4752,6 @@ msgstr "Следующая дата"
 msgid "Next Number"
 msgstr "Следующий номер"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5242,12 +4773,10 @@ msgstr ""
 msgid "Ninety"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Нет"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5256,7 +4785,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5264,11 +4793,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5276,7 +4805,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5285,11 +4813,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5297,21 +4825,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr "Нет открытых проектов"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5330,12 +4855,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5344,12 +4867,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr "Нетрассируемые элементы"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5387,11 +4908,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5437,23 +4953,18 @@ msgstr "Ничего не перемещено!"
 msgid "Nov"
 msgstr "ноя"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "ноябрь"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5484,7 +4995,7 @@ msgstr ""
 msgid "Number"
 msgstr "код"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Числовой формат"
 
@@ -5505,13 +5016,11 @@ msgstr "OH"
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Устаревший"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5520,8 +5029,7 @@ msgstr ""
 msgid "Oct"
 msgstr "окт"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "октябрь"
 
@@ -5533,9 +5041,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5585,7 +5090,6 @@ msgstr ""
 msgid "Open"
 msgstr "Открыть"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5607,9 +5111,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5655,7 +5156,6 @@ msgstr "Пропущена дата заказа"
 msgid "Order Entry"
 msgstr "Заказы"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5677,7 +5177,6 @@ msgstr "Заказ удален!"
 msgid "Order generation failed!"
 msgstr "Ошибка создания ордера"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5699,7 +5198,7 @@ msgstr "Ордеры созданы"
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5745,7 +5244,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5764,10 +5262,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5811,11 +5305,6 @@ msgstr "Пропущен номер упаковочного списока!"
 msgid "Packing list"
 msgstr "Упаковочный список"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5833,12 +5322,10 @@ msgstr "Оплачено"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Товар"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5848,14 +5335,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5885,14 +5364,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5908,15 +5383,12 @@ msgstr "Код"
 msgid "Parts"
 msgstr "Товар"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5926,7 +5398,6 @@ msgstr ""
 msgid "Password"
 msgstr "Пароль"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5939,7 +5410,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5953,7 +5423,6 @@ msgstr ""
 msgid "Payables"
 msgstr "Подлежащий оплате"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5962,7 +5431,6 @@ msgstr "Подлежащий оплате"
 msgid "Payment"
 msgstr "Оплата"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5975,7 +5443,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5992,7 +5459,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6028,15 +5494,15 @@ msgstr "Оплаты"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6055,7 +5521,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6086,108 +5551,88 @@ msgstr "Список для выбора"
 msgid "Pick list"
 msgstr "Список для выбора"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6203,7 +5648,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6212,24 +5656,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6238,13 +5680,11 @@ msgstr ""
 msgid "Post"
 msgstr "Сохранить"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6285,7 +5725,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Postscript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6323,20 +5762,16 @@ msgstr ""
 msgid "Price"
 msgstr "Цена"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6372,8 +5807,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6383,7 +5816,6 @@ msgstr ""
 msgid "Print"
 msgstr "Печать"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6400,7 +5832,7 @@ msgstr "Напечатать и сохранить как новый"
 msgid "Printed"
 msgstr "Напечатано"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Принтер"
 
@@ -6444,17 +5876,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6483,7 +5913,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6502,7 +5931,6 @@ msgstr "Переводы описания проектов"
 msgid "Project Number"
 msgstr "Код проекта"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6511,9 +5939,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Проекты"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6523,7 +5948,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6541,22 +5965,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Заказ поставщику"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "Номер заказа поставщику"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Заказы поставщику"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6571,14 +5989,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Заказ поставщику"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6609,7 +6023,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Количество"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6623,8 +6036,6 @@ msgstr "Превышено количество единиц номенклат�
 msgid "Quarter"
 msgstr "Квартал"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6661,9 +6072,7 @@ msgstr "Пропущен номер резервирования!"
 msgid "Quotation deleted!"
 msgstr "Резервирование удалено"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6684,25 +6093,20 @@ msgstr "Запрос на резервирование"
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "Номер запроса на резервирование"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "Запросы на резервирование"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "ROP"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6714,7 +6118,6 @@ msgstr "Курс"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6737,13 +6140,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6761,7 +6160,6 @@ msgstr "Получение"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6775,8 +6173,7 @@ msgstr "Получения"
 msgid "Receivables"
 msgstr "Подлежащий получению"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Получить"
 
@@ -6784,7 +6181,6 @@ msgstr "Получить"
 msgid "Receive Merchandise"
 msgstr "Получить товары"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6805,7 +6201,6 @@ msgstr "Согласованность"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6826,13 +6221,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Повторяющиеся проводки"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6871,12 +6259,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6914,7 +6300,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6926,7 +6312,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6939,7 +6325,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6989,7 +6374,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -7009,13 +6394,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Запрошен"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7045,7 +6427,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7054,7 +6435,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7071,7 +6451,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7121,11 +6500,11 @@ msgstr "SKU"
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7151,7 +6530,6 @@ msgstr "Продажи"
 msgid "Sales Invoice"
 msgstr "Фактура клиента"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Номер проводки Фактуры клиента"
@@ -7167,20 +6545,17 @@ msgstr "Номер проводки Фактуры клиента"
 msgid "Sales Order"
 msgstr "Заказ клиента"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "Номер заказа клиента"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Заказы клиента"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "Номер продажи резерва"
@@ -7203,9 +6578,6 @@ msgstr "Номер продажи резерва"
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7229,13 +6601,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7255,7 +6624,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7265,7 +6634,6 @@ msgstr "Сохранить"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7324,11 +6692,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "Сохранить как новый"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7351,10 +6718,8 @@ msgstr "Расписание"
 msgid "Scheduled"
 msgstr "Назначено расписание"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Экран"
 
@@ -7374,7 +6739,6 @@ msgstr "Экран"
 msgid "Search"
 msgstr "Поиск"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7383,7 +6747,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7436,11 +6799,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7452,11 +6815,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7468,7 +6831,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7476,7 +6839,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7532,7 +6894,6 @@ msgstr "Выберите txt, postscript или PDF!"
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7541,9 +6902,6 @@ msgstr ""
 msgid "Sell"
 msgstr "Продажа"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7597,13 +6955,11 @@ msgstr ""
 msgid "Sep"
 msgstr "сен"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "сентябрь"
 
@@ -7624,9 +6980,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "Серийный ном."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7656,7 +7009,6 @@ msgstr "Код услуги"
 msgid "Services"
 msgstr "Услуга"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 #, fuzzy
 msgid "Session Timeout (e.g. \"90 minutes\")"
@@ -7670,7 +7022,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7690,10 +7042,10 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Доставить"
 
@@ -7720,10 +7072,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7784,10 +7132,6 @@ msgstr "Пропущена дата доставки"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7829,7 +7173,6 @@ msgstr "Дата доставки"
 msgid "Short"
 msgstr "Краткосрочный"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7870,7 +7213,6 @@ msgstr "Шестьдесят"
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7883,12 +7225,6 @@ msgstr ""
 msgid "Sort by"
 msgstr "Сортировать по"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7915,7 +7251,6 @@ msgstr "Источник"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7937,21 +7272,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Стандартные"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "Стандартный промышленный код"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7982,8 +7306,6 @@ msgstr ""
 msgid "Startdate"
 msgstr "Начальная дата"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8020,13 +7342,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Ведомость"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Балансовая ведомость"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8057,7 +7377,7 @@ msgstr "Сформировать комплект"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Оформление"
 
@@ -8082,7 +7402,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8125,7 +7444,6 @@ msgstr "Суммарно"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr "Вск"
@@ -8158,12 +7476,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr "ИТОГО"
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8175,9 +7487,6 @@ msgstr "Тег"
 msgid "Tag:"
 msgstr "Тег:"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8196,8 +7505,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8208,17 +7515,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8362,7 +7666,6 @@ msgstr "Тел: [_1]"
 msgid "Template"
 msgstr "Шаблоны HTML"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8371,7 +7674,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8424,7 +7726,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8436,7 +7738,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8487,24 +7789,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8527,14 +7826,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr "Чтв"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8578,7 +7873,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8608,19 +7902,10 @@ msgstr ""
 msgid "To"
 msgstr "по"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8657,7 +7942,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8682,16 +7966,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8734,7 +8009,7 @@ msgstr ""
 msgid "Total"
 msgstr "Итого"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8742,7 +8017,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8763,7 +8037,6 @@ msgstr "Проводка"
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8779,14 +8052,12 @@ msgstr "Пропущена Дата проводки!"
 msgid "Transaction Dates"
 msgstr "Дата проводки"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8825,7 +8096,6 @@ msgstr "Переводы"
 msgid "Translations saved!"
 msgstr "Переводы сохранены!"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Предварительный баланс"
@@ -8834,7 +8104,6 @@ msgstr "Предварительный баланс"
 msgid "Trillion"
 msgstr "Триллион"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr "Втр"
@@ -8891,10 +8160,6 @@ msgstr ""
 msgid "Two"
 msgstr "Два"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8929,39 +8194,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8980,43 +8239,37 @@ msgstr "Единица"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9024,23 +8277,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9057,7 +8305,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9085,21 +8332,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9108,7 +8350,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9126,24 +8367,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9153,7 +8389,6 @@ msgstr "Сотрудник"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9174,7 +8409,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9200,8 +8434,6 @@ msgstr "Действительно до"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9211,11 +8443,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9231,7 +8459,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Поставщик"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9245,7 +8472,6 @@ msgstr "История"
 msgid "Vendor Invoice"
 msgstr "Фактура поставщика"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr "Номер проводки фактуры поставщика"
@@ -9255,9 +8481,6 @@ msgstr "Номер проводки фактуры поставщика"
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9287,9 +8510,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "Пропущен поставщик!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9297,8 +8518,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Поставщика нет в справочнике!"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9313,7 +8532,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9326,7 +8544,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9349,7 +8566,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Склады"
@@ -9358,11 +8574,26 @@ msgstr "Склады"
 msgid "Warning!"
 msgstr "Внимание!"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9372,7 +8603,6 @@ msgstr ""
 msgid "Week"
 msgstr "Неделя"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9389,13 +8619,11 @@ msgstr ""
 msgid "Weeks"
 msgstr "Недели"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Вес"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Единица веса"
@@ -9412,7 +8640,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9430,11 +8657,11 @@ msgstr "Рабочий заказ"
 msgid "Work order"
 msgstr "Рабочий заказ"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9477,15 +8704,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Да"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9512,7 +8734,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9576,17 +8798,12 @@ msgstr "дней"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9603,7 +8820,7 @@ msgstr ""
 msgid "done"
 msgstr "выполнено"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9631,8 +8848,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9641,22 +8856,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9681,7 +8892,6 @@ msgstr ""
 msgid "sent"
 msgstr "отправлено"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9706,8 +8916,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr "неожиданная ошибка"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/sv.po
+++ b/locale/po/sv.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Swedish (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -15,27 +15,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -48,12 +43,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -99,7 +90,6 @@ msgstr "Utgifter"
 msgid "AP Aging"
 msgstr "Förfallna lev.fakturor"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -108,7 +98,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -123,7 +112,6 @@ msgstr "Leverantörsskulder"
 msgid "AP Transaction"
 msgstr "Betald kostnad"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Leverantörsfakturor"
@@ -136,9 +124,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -157,7 +143,6 @@ msgstr "Intäkter"
 msgid "AR Aging"
 msgstr "Förfallna kundfordringar"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -166,7 +151,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -181,7 +165,6 @@ msgstr "Kundfordringar"
 msgid "AR Transaction"
 msgstr "Betald fodran"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Kundfakturor"
@@ -194,9 +177,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -205,8 +186,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Betald fodran"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -216,16 +195,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -251,38 +225,20 @@ msgstr ""
 msgid "Account"
 msgstr "Konto"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -303,23 +259,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Kontonummer"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -359,17 +310,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -381,7 +330,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -409,12 +358,10 @@ msgstr "Aktiv"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -437,11 +384,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr "Ny produkt"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -566,7 +513,6 @@ msgstr "Ny säljorder"
 msgid "Add Service"
 msgstr "Lägg till tjänst"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -633,7 +579,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Uppdatera"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -658,7 +603,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -668,12 +612,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -693,8 +636,7 @@ msgstr ""
 msgid "Aged"
 msgstr "Utgången"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -747,7 +689,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr "Kopplad"
@@ -756,11 +697,6 @@ msgstr "Kopplad"
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -794,14 +730,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Belopp"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -810,27 +742,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Förfallet belopp"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -848,14 +774,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -874,17 +800,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -893,13 +816,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -908,7 +824,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -917,14 +832,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -936,19 +849,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Apr"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "April"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -964,7 +874,6 @@ msgstr "Är du säker på att du vill radera Offert Nummer"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -983,19 +892,17 @@ msgstr "Produkt åter i lager"
 msgid "Asset"
 msgstr "Tillgång"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1008,29 +915,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1046,7 +950,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1144,8 +1047,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Aug"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Augusti"
 
@@ -1157,7 +1059,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1171,7 +1072,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1184,7 +1084,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr "Medelvärdeskostnad"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1218,8 +1117,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1234,7 +1131,6 @@ msgstr "Balans"
 msgid "Balance Sheet"
 msgstr "Balansräkning"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1255,7 +1151,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1266,7 +1161,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1276,18 +1170,15 @@ msgstr "Valuta"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1300,12 +1191,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1322,13 +1211,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1369,8 +1256,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1417,17 +1302,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1440,12 +1322,10 @@ msgstr ""
 msgid "Business"
 msgstr "Verksamhet"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Organisationsnummer"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1455,12 +1335,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1482,7 +1360,6 @@ msgstr "Verksamhet sparad"
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1514,18 +1391,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1653,12 +1528,11 @@ msgstr "Ändra lösenord"
 msgid "Chargeable"
 msgstr "Debiterbar"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Kontoplan"
 
@@ -1678,7 +1552,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "Inventarielista"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1707,7 +1580,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1719,9 +1592,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "Rensad"
 
@@ -1749,15 +1622,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Avslutad"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1771,8 +1642,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1787,22 +1656,18 @@ msgstr "Kod saknas"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1814,39 +1679,31 @@ msgstr ""
 msgid "Company"
 msgstr "Företag"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Företags namn"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1867,7 +1724,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Bekräfta!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1885,7 +1742,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Kontakt"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1901,7 +1757,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1919,9 +1774,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1951,7 +1803,6 @@ msgstr ""
 msgid "Contra"
 msgstr "Avdrag"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1959,10 +1810,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1993,20 +1840,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Kostnader"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2022,26 +1865,20 @@ msgstr "Kan inte spara"
 msgid "Could not transfer Inventory!"
 msgstr "Kan inte överföra inventarier!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2053,7 +1890,6 @@ msgstr ""
 msgid "Country"
 msgstr "Land"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2066,7 +1902,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2074,11 +1910,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2106,8 +1942,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2115,17 +1949,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Kredit"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2150,29 +1981,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Valuta"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2195,18 +2016,14 @@ msgstr "Valuta"
 msgid "Currency"
 msgstr "Valuta"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Nuvarande"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2216,11 +2033,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2235,7 +2048,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Kund"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2254,9 +2066,6 @@ msgstr "Kund finns ej"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2276,9 +2085,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "Kund saknas"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2290,7 +2097,7 @@ msgstr "Kund finns ej"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2314,12 +2121,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2352,28 +2158,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2420,19 +2214,14 @@ msgstr ""
 msgid "Date"
 msgstr "Datum"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2454,7 +2243,6 @@ msgstr "Datum mottaget"
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2518,8 +2306,6 @@ msgstr "Dag(ar"
 msgid "Days"
 msgstr "Dagar"
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2535,10 +2321,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2548,17 +2332,14 @@ msgstr ""
 msgid "Dec"
 msgstr "Dec"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "December"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2568,7 +2349,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2581,47 +2361,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2634,21 +2405,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "Standard inställningar"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2666,7 +2430,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Radera"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2679,7 +2442,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr "Ta bort schemaläggning"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2693,37 +2455,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Leveransdatum"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2745,20 +2503,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2769,46 +2524,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2919,12 +2635,10 @@ msgstr "Detalj"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2937,7 +2651,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2946,7 +2659,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Rabatt"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2955,28 +2667,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2984,7 +2696,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2993,7 +2704,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -3001,12 +2712,10 @@ msgstr ""
 msgid "Done"
 msgstr "Klart"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3019,12 +2728,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3033,19 +2740,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Ritning"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3061,10 +2765,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3083,7 +2783,7 @@ msgstr "Förfallodatum saknas"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3109,7 +2809,7 @@ msgstr "E-post meddelande"
 msgid "E-mailed"
 msgstr "Skickad med e-post"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3139,7 +2839,7 @@ msgstr "Redigera intäkter"
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3283,8 +2983,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3298,7 +2996,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Anställd"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3308,12 +3005,11 @@ msgstr "Anställd nr"
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3323,37 +3019,26 @@ msgstr "Anställd nr"
 msgid "Employees"
 msgstr "Anställda"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3377,7 +3062,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3402,12 +3086,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3417,7 +3099,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3425,7 +3107,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3451,7 +3132,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Företags namn"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3463,14 +3144,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Eget kapital"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3484,16 +3162,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3501,7 +3178,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3514,8 +3191,6 @@ msgstr "Varje"
 msgid "Exch"
 msgstr "Vxl"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3530,7 +3205,6 @@ msgstr "Växlingskurs"
 msgid "Exchange rate for payment missing!"
 msgstr "Växlingskurs för saknad betalning"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3539,7 +3213,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "Växelkurs saknas"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3557,13 +3230,10 @@ msgstr "Utgiftskonto"
 msgid "Expense/Asset"
 msgstr "Utgift/Tillgång"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3641,8 +3311,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Februari"
 
@@ -3658,14 +3327,10 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3676,11 +3341,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3691,7 +3356,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3749,12 +3413,10 @@ msgstr ""
 msgid "For"
 msgstr "under"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Växelkurs vinst"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Växelkurs förlust"
@@ -3763,12 +3425,10 @@ msgstr "Växelkurs förlust"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3785,7 +3445,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3804,18 +3463,10 @@ msgstr ""
 msgid "From"
 msgstr "Från"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3836,7 +3487,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr "Från lager"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3847,15 +3497,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3869,10 +3514,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "SRU-kod"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3893,7 +3536,6 @@ msgstr "SRU-kod sparad"
 msgid "GL"
 msgstr "Huvudbok"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr "Huvudboks verifikat nr"
@@ -3902,7 +3544,7 @@ msgstr "Huvudboks verifikat nr"
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3910,11 +3552,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3923,7 +3564,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3931,9 +3572,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr "Skapa"
 
@@ -3949,7 +3589,7 @@ msgstr "Skapa order"
 msgid "Generate Purchase Orders"
 msgstr "Skapa inköpsorder"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3957,7 +3597,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr "Skapa försäljningsorder"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3973,12 +3613,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3987,7 +3625,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4061,21 +3698,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4106,7 +3728,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4116,13 +3737,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Bild"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4165,7 +3784,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4199,14 +3817,10 @@ msgstr "Inkludera i rullgardinsmenyer"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4214,12 +3828,10 @@ msgstr ""
 msgid "Income"
 msgstr "Vinst"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4230,7 +3842,6 @@ msgstr "Resultaträkning"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4240,7 +3851,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Resultaträkning"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4260,11 +3870,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4274,30 +3883,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "Egna anteckningar"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4307,17 +3912,14 @@ msgstr "Lager"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4344,11 +3946,7 @@ msgstr "Lager sparat"
 msgid "Inventory transferred!"
 msgstr "Lager överfört"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4390,8 +3988,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4407,11 +4003,6 @@ msgstr "Fakturadatum saknas"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4430,7 +4021,6 @@ msgstr "Fakturanummer"
 msgid "Invoice Number missing!"
 msgstr "Fakturanummer saknas"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4460,12 +4050,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4523,8 +4111,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Jan"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Januari"
 
@@ -4553,8 +4140,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Juli"
 
@@ -4562,8 +4148,8 @@ msgstr "Juli"
 msgid "Jun"
 msgstr "Jun"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Juni"
 
@@ -4576,10 +4162,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "LaTeX Mallar"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4601,15 +4183,12 @@ msgstr "Arbetskostnader"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Språk"
@@ -4630,7 +4209,6 @@ msgstr "Språk ej valt"
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4641,7 +4219,6 @@ msgstr "Senaste kostnad"
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4663,40 +4240,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr "Leveranstid"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4708,9 +4284,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4732,9 +4306,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4748,8 +4320,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4766,7 +4336,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4803,7 +4372,6 @@ msgstr "Lista språk"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4829,7 +4397,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4847,7 +4414,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4868,7 +4434,7 @@ msgstr ""
 msgid "Login"
 msgstr "Logga in"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4896,45 +4462,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Produkt"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4956,40 +4515,34 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Mars"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Prishöjning"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "Maj"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Anteckning"
@@ -5006,7 +4559,6 @@ msgstr "Meddelande"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Metod"
@@ -5015,7 +4567,6 @@ msgstr "Metod"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5034,14 +4585,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5055,7 +4603,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5068,14 +4615,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Modell"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5093,7 +4638,7 @@ msgstr "Månad(er)"
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5117,14 +4662,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5133,15 +4676,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5160,7 +4694,6 @@ msgstr "Namn"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5211,8 +4744,6 @@ msgstr "Nästa datum"
 msgid "Next Number"
 msgstr "Nästa nummer"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5234,12 +4765,10 @@ msgstr ""
 msgid "Ninety"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Inga"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5248,7 +4777,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5256,11 +4785,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5268,7 +4797,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5277,11 +4805,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5289,21 +4817,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr "Inga pågående projekt!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5322,12 +4847,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5336,12 +4859,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr "Icke-spårbara varor"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5379,11 +4900,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5429,23 +4945,18 @@ msgstr "Inget att överföra"
 msgid "Nov"
 msgstr "Nov"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "November"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5476,7 +4987,7 @@ msgstr ""
 msgid "Number"
 msgstr "Nummer"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Nummerformat"
 
@@ -5497,13 +5008,11 @@ msgstr "På lager"
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Utgången"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5512,8 +5021,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Okt"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Oktober"
 
@@ -5525,9 +5033,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5577,7 +5082,6 @@ msgstr ""
 msgid "Open"
 msgstr "Aktuell"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5599,9 +5103,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5647,7 +5148,6 @@ msgstr "Orderdatum saknas"
 msgid "Order Entry"
 msgstr "Beställningar"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5669,7 +5169,6 @@ msgstr "Order raderad"
 msgid "Order generation failed!"
 msgstr "Skapande av order misslyckades!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5691,7 +5190,7 @@ msgstr "Order skapad!"
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5737,7 +5236,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5756,10 +5254,6 @@ msgstr "Förtryckt blankett"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5803,11 +5297,6 @@ msgstr "Packsedelsnummer saknas"
 msgid "Packing list"
 msgstr "Packsedel"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5825,12 +5314,10 @@ msgstr "Betalt"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Artikel"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5840,14 +5327,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5877,14 +5356,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5900,15 +5375,12 @@ msgstr "Artikel nr"
 msgid "Parts"
 msgstr "Artikel"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5918,7 +5390,6 @@ msgstr ""
 msgid "Password"
 msgstr "Lösenord"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5931,7 +5402,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5945,7 +5415,6 @@ msgstr ""
 msgid "Payables"
 msgstr "Utbetalningar"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5954,7 +5423,6 @@ msgstr "Utbetalningar"
 msgid "Payment"
 msgstr "Bocka av utförd betalning"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5967,7 +5435,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5984,7 +5451,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6020,15 +5486,15 @@ msgstr "Utbetalningar"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6047,7 +5513,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6078,108 +5543,88 @@ msgstr "Plocklista"
 msgid "Pick list"
 msgstr "Plocklista"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6195,7 +5640,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6204,24 +5648,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6230,13 +5672,11 @@ msgstr ""
 msgid "Post"
 msgstr "Bokför"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6277,7 +5717,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Blankt papper"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6315,20 +5754,16 @@ msgstr ""
 msgid "Price"
 msgstr "Pris"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6364,8 +5799,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6375,7 +5808,6 @@ msgstr ""
 msgid "Print"
 msgstr "Skriv ut"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6392,7 +5824,7 @@ msgstr "Skriv ut och spara som ny"
 msgid "Printed"
 msgstr "Utskriven"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Skrivare"
 
@@ -6436,17 +5868,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6475,7 +5905,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6494,7 +5923,6 @@ msgstr "Översättning av projekt beskrivning"
 msgid "Project Number"
 msgstr "Projekt nr"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6503,9 +5931,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Projekt"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6515,7 +5940,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6533,22 +5957,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Inköpsorder"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "Inköpsorder nr"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Inköpsordrar"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6563,14 +5981,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Inköpsorder"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6601,7 +6015,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Antal"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6615,8 +6028,6 @@ msgstr "Kvantitet överskrider tillgängliga enheter i lager"
 msgid "Quarter"
 msgstr "Kvartal"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6653,9 +6064,7 @@ msgstr "Offert nummer saknas"
 msgid "Quotation deleted!"
 msgstr "Offert borttagen"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6676,25 +6085,20 @@ msgstr "Begäran om offert"
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "Begäran om offert nr"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "Begäran om offert"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "Beställ vid"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6706,7 +6110,6 @@ msgstr "Ränta"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6729,13 +6132,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6753,7 +6152,6 @@ msgstr "Bocka av ink.betalning"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6767,8 +6165,7 @@ msgstr "Inbetalningar"
 msgid "Receivables"
 msgstr "Inbetalningar"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Ta emot"
 
@@ -6776,7 +6173,6 @@ msgstr "Ta emot"
 msgid "Receive Merchandise"
 msgstr "Varumottagning"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6797,7 +6193,6 @@ msgstr "In/ut betalningar"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6818,13 +6213,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Återkommande transaktion"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6863,12 +6251,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6906,7 +6292,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6918,7 +6304,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6931,7 +6317,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6981,7 +6366,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -7001,13 +6386,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Beställt den"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7037,7 +6419,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7046,7 +6427,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7063,7 +6443,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7113,11 +6492,11 @@ msgstr "Lagernr"
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7143,7 +6522,6 @@ msgstr "Försäljning"
 msgid "Sales Invoice"
 msgstr "Kundfaktura"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Kundfaktura / Intäktsverifikat nr"
@@ -7159,20 +6537,17 @@ msgstr "Kundfaktura / Intäktsverifikat nr"
 msgid "Sales Order"
 msgstr "Säljorder"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "Säljorder nr"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Säljordrar"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "Säljoffert nr"
@@ -7195,9 +6570,6 @@ msgstr "Säljoffert nr"
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7221,13 +6593,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7247,7 +6616,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7257,7 +6626,6 @@ msgstr "Spara"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7316,11 +6684,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "Spara som ny"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7343,10 +6710,8 @@ msgstr "Schemalägg"
 msgid "Scheduled"
 msgstr "Schemalagd"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Skärm"
 
@@ -7366,7 +6731,6 @@ msgstr "Skärm"
 msgid "Search"
 msgstr "Sök"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7375,7 +6739,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7428,11 +6791,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7444,11 +6807,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7460,7 +6823,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7468,7 +6831,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7524,7 +6886,6 @@ msgstr "Välj text, postsript eller PDF!"
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7533,9 +6894,6 @@ msgstr ""
 msgid "Sell"
 msgstr "Sälj"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7589,13 +6947,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Sep"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "September"
 
@@ -7616,9 +6972,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "Serie nr."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7648,7 +7001,6 @@ msgstr "Servicekod"
 msgid "Services"
 msgstr "Tjänster"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 #, fuzzy
 msgid "Session Timeout (e.g. \"90 minutes\")"
@@ -7662,7 +7014,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7682,10 +7034,10 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Skicka"
 
@@ -7712,10 +7064,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7776,10 +7124,6 @@ msgstr "Leveransdatum saknas"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7821,7 +7165,6 @@ msgstr "Skickat datum"
 msgid "Short"
 msgstr "Kort"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7862,7 +7205,6 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7875,12 +7217,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7907,7 +7243,6 @@ msgstr "Källa"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7929,21 +7264,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Standard"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "Standard industrikoder"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7974,8 +7298,6 @@ msgstr ""
 msgid "Startdate"
 msgstr "Startdatum"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8012,13 +7334,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Redovisning"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Verkligt saldo"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8049,7 +7369,7 @@ msgstr "Lager produkter"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Stilmall"
 
@@ -8074,7 +7394,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8117,7 +7436,6 @@ msgstr "Summa"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8150,12 +7468,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8167,9 +7479,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8188,8 +7497,6 @@ msgstr "Momskonto"
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8200,17 +7507,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8354,7 +7658,6 @@ msgstr ""
 msgid "Template"
 msgstr "HTML mallar"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8363,7 +7666,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8416,7 +7718,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8428,7 +7730,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8479,24 +7781,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8519,14 +7818,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8570,7 +7865,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8600,19 +7894,10 @@ msgstr ""
 msgid "To"
 msgstr "Till"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8649,7 +7934,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8674,16 +7958,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8726,7 +8001,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8734,7 +8009,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8755,7 +8029,6 @@ msgstr "Transaktion"
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8771,14 +8044,12 @@ msgstr "Transaktionsdatum saknas"
 msgid "Transaction Dates"
 msgstr "Överföringsdatum"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8817,7 +8088,6 @@ msgstr "Översättningar"
 msgid "Translations saved!"
 msgstr "Översättning sparad"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Saldo-beräkning"
@@ -8826,7 +8096,6 @@ msgstr "Saldo-beräkning"
 msgid "Trillion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8883,10 +8152,6 @@ msgstr ""
 msgid "Two"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8921,39 +8186,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8972,43 +8231,37 @@ msgstr "Enhet"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9016,23 +8269,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9049,7 +8297,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9077,21 +8324,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9100,7 +8342,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9118,24 +8359,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9145,7 +8381,6 @@ msgstr "Användare"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9166,7 +8401,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9192,8 +8426,6 @@ msgstr "Giltig till"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9203,11 +8435,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9223,7 +8451,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Leverantör"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9237,7 +8464,6 @@ msgstr "Leverantörshistorik"
 msgid "Vendor Invoice"
 msgstr "Kredit inköp"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr "Leverantörsfaktura / Utgiftsverifikat nr"
@@ -9247,9 +8473,6 @@ msgstr "Leverantörsfaktura / Utgiftsverifikat nr"
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9279,9 +8502,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "Leverantör saknas"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9289,8 +8510,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Leverantör finns ej"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9305,7 +8524,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9318,7 +8536,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9341,7 +8558,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Lager"
@@ -9350,11 +8566,26 @@ msgstr "Lager"
 msgid "Warning!"
 msgstr "Varning!"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9364,7 +8595,6 @@ msgstr ""
 msgid "Week"
 msgstr "Vecka"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9381,13 +8611,11 @@ msgstr ""
 msgid "Weeks"
 msgstr "Veckor"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Vikt"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Viktenhet"
@@ -9404,7 +8632,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9422,11 +8649,11 @@ msgstr "Arbetsorder"
 msgid "Work order"
 msgstr "Arbetsorder"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9469,15 +8696,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Ja"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9504,7 +8726,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9568,17 +8790,12 @@ msgstr "dagar"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9595,7 +8812,7 @@ msgstr ""
 msgid "done"
 msgstr "Färdigt"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9623,8 +8840,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9633,22 +8848,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9673,7 +8884,6 @@ msgstr ""
 msgid "sent"
 msgstr "Skickad"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9698,8 +8908,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr "oförberett fel!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/tr.po
+++ b/locale/po/tr.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Turkish (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -15,27 +15,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -48,12 +43,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -99,7 +90,6 @@ msgstr "Borçlar"
 msgid "AP Aging"
 msgstr "Gecikmiş Borçlar"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -108,7 +98,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -123,7 +112,6 @@ msgstr ""
 msgid "AP Transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Borç İşlemleri"
@@ -136,9 +124,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -157,7 +143,6 @@ msgstr "Alacaklar"
 msgid "AR Aging"
 msgstr "Gecikmiş Alacaklar"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -166,7 +151,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -181,7 +165,6 @@ msgstr ""
 msgid "AR Transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Alacak İşlemleri"
@@ -194,9 +177,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -205,8 +186,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Alacak İşlemleri"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -216,16 +195,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -251,38 +225,20 @@ msgstr ""
 msgid "Account"
 msgstr "Hesap"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -303,23 +259,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Hesap Numarası"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -359,17 +310,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -381,7 +330,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -409,12 +358,10 @@ msgstr ""
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -437,11 +384,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr "Grup Ekle"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -566,7 +513,6 @@ msgstr "Satış Siparişi Ekle"
 msgid "Add Service"
 msgstr "Hizmet Ekle"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -632,7 +578,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -657,7 +602,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -667,12 +611,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -692,8 +635,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -746,7 +688,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -755,11 +696,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -793,14 +729,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Miktar"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -809,27 +741,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -847,14 +773,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -873,17 +799,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -892,13 +815,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -907,7 +823,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -916,14 +831,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -935,19 +848,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Nis"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "Nisan"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -963,7 +873,6 @@ msgstr ""
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -982,19 +891,17 @@ msgstr ""
 msgid "Asset"
 msgstr "Aktif"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1007,29 +914,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1045,7 +949,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1143,8 +1046,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Ağu"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Ağustos"
 
@@ -1156,7 +1058,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1170,7 +1071,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1183,7 +1083,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1217,8 +1116,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1233,7 +1130,6 @@ msgstr ""
 msgid "Balance Sheet"
 msgstr "Bilanço"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1254,7 +1150,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1265,7 +1160,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1275,18 +1169,15 @@ msgstr "Para Birimi"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1299,12 +1190,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1321,13 +1210,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1368,8 +1255,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1415,17 +1300,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1438,12 +1320,10 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "ŞirketNo"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1453,12 +1333,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1480,7 +1358,6 @@ msgstr ""
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1512,18 +1389,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1649,12 +1524,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "Hesap Planı"
 
@@ -1674,7 +1548,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1703,7 +1576,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1715,9 +1588,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr ""
 
@@ -1745,15 +1618,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1767,8 +1638,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1783,22 +1652,18 @@ msgstr ""
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1810,39 +1675,31 @@ msgstr ""
 msgid "Company"
 msgstr "Şirket"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1863,7 +1720,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Onayla!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1881,7 +1738,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Kontak"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1897,7 +1753,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1915,9 +1770,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1947,7 +1799,6 @@ msgstr ""
 msgid "Contra"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1955,10 +1806,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1989,20 +1836,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2018,26 +1861,20 @@ msgstr ""
 msgid "Could not transfer Inventory!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2049,7 +1886,6 @@ msgstr ""
 msgid "Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2062,7 +1898,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2070,11 +1906,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2102,8 +1938,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2111,17 +1945,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Alacak"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2146,29 +1977,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2191,18 +2012,14 @@ msgstr ""
 msgid "Currency"
 msgstr "Para Birimi"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2212,11 +2029,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2231,7 +2044,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Alıcı"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2250,9 +2062,6 @@ msgstr "Alıcı"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2272,9 +2081,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2286,7 +2093,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2310,12 +2117,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2348,28 +2154,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2416,19 +2210,14 @@ msgstr ""
 msgid "Date"
 msgstr "Tarih"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2450,7 +2239,6 @@ msgstr ""
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2514,8 +2302,6 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2531,10 +2317,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2544,17 +2328,14 @@ msgstr ""
 msgid "Dec"
 msgstr "Ara"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Aralık"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2564,7 +2345,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2577,47 +2357,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2630,21 +2401,14 @@ msgstr ""
 msgid "Defaults"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2662,7 +2426,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Sil"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2675,7 +2438,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2689,37 +2451,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2741,20 +2499,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2765,46 +2520,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2915,12 +2631,10 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2933,7 +2647,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2942,7 +2655,6 @@ msgstr ""
 msgid "Discount"
 msgstr "İndirim"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2951,28 +2663,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2980,7 +2692,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2989,7 +2700,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -2997,12 +2708,10 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3015,12 +2724,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3029,19 +2736,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3057,10 +2761,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3079,7 +2779,7 @@ msgstr "Vade Tarihi yok!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3105,7 +2805,7 @@ msgstr ""
 msgid "E-mailed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3135,7 +2835,7 @@ msgstr ""
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3279,8 +2979,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3294,7 +2992,6 @@ msgstr ""
 msgid "Employee"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3304,12 +3001,11 @@ msgstr ""
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 msgid "Employee wage screen"
 msgstr ""
@@ -3318,37 +3014,26 @@ msgstr ""
 msgid "Employees"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3372,7 +3057,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3397,12 +3081,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3412,7 +3094,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3420,7 +3102,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3445,7 +3126,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3457,14 +3138,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Sermaye"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3478,16 +3156,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3495,7 +3172,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3508,8 +3185,6 @@ msgstr ""
 msgid "Exch"
 msgstr "D.Kuru"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3524,7 +3199,6 @@ msgstr "Döviz Kuru"
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3533,7 +3207,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3551,13 +3224,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Gider/Varlıklar"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3635,8 +3305,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Şub"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Şubat"
 
@@ -3652,14 +3321,10 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3670,11 +3335,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3685,7 +3350,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3743,12 +3407,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Kur Kazancı"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Kur Kaybı"
@@ -3757,12 +3419,10 @@ msgstr "Kur Kaybı"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3779,7 +3439,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3798,18 +3457,10 @@ msgstr ""
 msgid "From"
 msgstr "Başlangıç"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3830,7 +3481,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3841,15 +3491,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3863,10 +3508,8 @@ msgstr ""
 msgid "GIFI"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3887,7 +3530,6 @@ msgstr ""
 msgid "GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3896,7 +3538,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3904,11 +3546,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3917,7 +3558,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3925,9 +3566,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr ""
 
@@ -3943,7 +3583,7 @@ msgstr ""
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3951,7 +3591,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3967,12 +3607,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3981,7 +3619,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4055,21 +3692,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4100,7 +3722,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4110,13 +3731,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4159,7 +3778,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4193,14 +3811,10 @@ msgstr "Seçmeli Menüye dahil et"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4208,12 +3822,10 @@ msgstr ""
 msgid "Income"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4224,7 +3836,6 @@ msgstr "Gelir Tablosu"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4234,7 +3845,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Gelir Tablosu"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4254,11 +3864,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4268,30 +3877,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4301,17 +3906,14 @@ msgstr "Stok"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4337,11 +3939,7 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4383,8 +3981,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4400,11 +3996,6 @@ msgstr "Fatura Tarihi yok!"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4423,7 +4014,6 @@ msgstr "Fatura No"
 msgid "Invoice Number missing!"
 msgstr "Fatura Numarası yok!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4453,12 +4043,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4516,8 +4104,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Oca"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "Ocak"
 
@@ -4546,8 +4133,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Tem"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Temmuz"
 
@@ -4555,8 +4141,8 @@ msgstr "Temmuz"
 msgid "Jun"
 msgstr "Haz"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Haziran"
 
@@ -4569,10 +4155,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4594,15 +4176,12 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Dil"
@@ -4623,7 +4202,6 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4634,7 +4212,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4656,40 +4233,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4701,9 +4277,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4725,9 +4299,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4741,8 +4313,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4759,7 +4329,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4796,7 +4365,6 @@ msgstr ""
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4822,7 +4390,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4840,7 +4407,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4861,7 +4427,7 @@ msgstr ""
 msgid "Login"
 msgstr "Giriş"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4889,45 +4455,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Marka"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4949,40 +4508,34 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Mart"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "May"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr ""
@@ -4999,7 +4552,6 @@ msgstr ""
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr ""
@@ -5008,7 +4560,6 @@ msgstr ""
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5027,14 +4578,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5048,7 +4596,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5061,14 +4608,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Model"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5086,7 +4631,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5110,14 +4655,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5126,15 +4669,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5153,7 +4687,6 @@ msgstr "İsim"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5204,8 +4737,6 @@ msgstr ""
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5227,12 +4758,10 @@ msgstr ""
 msgid "Ninety"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Hayır"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5241,7 +4770,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5249,11 +4778,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5261,7 +4790,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5270,11 +4798,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5282,21 +4810,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5315,12 +4840,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5329,12 +4852,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5372,11 +4893,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5422,23 +4938,18 @@ msgstr ""
 msgid "Nov"
 msgstr "Kas"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "Kasım"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5469,7 +4980,7 @@ msgstr ""
 msgid "Number"
 msgstr "Numara"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Rakam Formatı"
 
@@ -5490,13 +5001,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Eski"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5505,8 +5014,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Eki"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Ekim"
 
@@ -5518,9 +5026,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5570,7 +5075,6 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5592,9 +5096,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5640,7 +5141,6 @@ msgstr "Sipariş Tarihi yok!"
 msgid "Order Entry"
 msgstr "Sipariş Girişi"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5662,7 +5162,6 @@ msgstr ""
 msgid "Order generation failed!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5684,7 +5183,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5729,7 +5228,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5748,10 +5246,6 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5795,11 +5289,6 @@ msgstr ""
 msgid "Packing list"
 msgstr "Paketleme Listesi"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5817,12 +5306,10 @@ msgstr "Ödendi"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "Parça"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5832,14 +5319,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5869,14 +5348,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5892,15 +5367,12 @@ msgstr ""
 msgid "Parts"
 msgstr "Parça"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5910,7 +5382,6 @@ msgstr ""
 msgid "Password"
 msgstr "Şifre"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5923,7 +5394,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5937,7 +5407,6 @@ msgstr ""
 msgid "Payables"
 msgstr "Borçlar"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5946,7 +5415,6 @@ msgstr "Borçlar"
 msgid "Payment"
 msgstr "Ödeme"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5959,7 +5427,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5976,7 +5443,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6012,15 +5478,15 @@ msgstr "Ödemeler"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6039,7 +5505,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6069,108 +5534,88 @@ msgstr ""
 msgid "Pick list"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6186,7 +5631,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6195,24 +5639,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6221,13 +5663,11 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6268,7 +5708,6 @@ msgstr ""
 msgid "Postscript"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6306,20 +5745,16 @@ msgstr ""
 msgid "Price"
 msgstr "Fiyat"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6355,8 +5790,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6366,7 +5799,6 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6383,7 +5815,7 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr ""
 
@@ -6427,17 +5859,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6466,7 +5896,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6485,7 +5914,6 @@ msgstr ""
 msgid "Project Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6494,9 +5922,6 @@ msgstr ""
 msgid "Projects"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6506,7 +5931,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6524,22 +5948,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Satınalma Siparişi"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Satınalma Siparişleri"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6554,14 +5972,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Satınalma Siparişi"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6592,7 +6006,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Adet"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6606,8 +6019,6 @@ msgstr ""
 msgid "Quarter"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6644,9 +6055,7 @@ msgstr ""
 msgid "Quotation deleted!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6667,25 +6076,20 @@ msgstr ""
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6697,7 +6101,6 @@ msgstr "Oran"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6720,13 +6123,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6744,7 +6143,6 @@ msgstr ""
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6758,8 +6156,7 @@ msgstr ""
 msgid "Receivables"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr ""
 
@@ -6767,7 +6164,6 @@ msgstr ""
 msgid "Receive Merchandise"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6788,7 +6184,6 @@ msgstr ""
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6809,13 +6204,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6854,12 +6242,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6897,7 +6283,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6909,7 +6295,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6922,7 +6308,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6971,7 +6356,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -6991,13 +6376,10 @@ msgstr ""
 msgid "Required by"
 msgstr "Talep tarihi:"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7027,7 +6409,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7036,7 +6417,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7053,7 +6433,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7103,11 +6482,11 @@ msgstr ""
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7133,7 +6512,6 @@ msgstr "Satışlar"
 msgid "Sales Invoice"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7149,20 +6527,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr "Satış Siparişi"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Satış Siparişleri"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr ""
@@ -7184,9 +6559,6 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7210,13 +6582,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7236,7 +6605,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7246,7 +6615,6 @@ msgstr "Kaydet"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7305,11 +6673,10 @@ msgstr ""
 msgid "Save as new"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7332,10 +6699,8 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr ""
 
@@ -7355,7 +6720,6 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7364,7 +6728,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7417,11 +6780,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7433,11 +6796,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7449,7 +6812,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7457,7 +6820,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7513,7 +6875,6 @@ msgstr ""
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7522,9 +6883,6 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7578,13 +6936,11 @@ msgstr ""
 msgid "Sep"
 msgstr "Eyl"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "Eylül"
 
@@ -7605,9 +6961,6 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7637,7 +6990,6 @@ msgstr ""
 msgid "Services"
 msgstr "servis"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 msgid "Session Timeout (e.g. \"90 minutes\")"
 msgstr ""
@@ -7650,7 +7002,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7670,10 +7022,10 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr ""
 
@@ -7700,10 +7052,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7764,10 +7112,6 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7808,7 +7152,6 @@ msgstr ""
 msgid "Short"
 msgstr "Kısa"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7849,7 +7192,6 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7862,12 +7204,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7894,7 +7230,6 @@ msgstr "Kaynak"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7916,21 +7251,10 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7961,8 +7285,6 @@ msgstr ""
 msgid "Startdate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -7999,13 +7321,11 @@ msgstr ""
 msgid "Statement"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8035,7 +7355,7 @@ msgstr "Grubu Stokla"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Düzen Sayfası"
 
@@ -8060,7 +7380,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8103,7 +7422,6 @@ msgstr ""
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8136,12 +7454,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8153,9 +7465,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8174,8 +7483,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8186,17 +7493,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8339,7 +7643,6 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8348,7 +7651,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8401,7 +7703,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8413,7 +7715,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8464,24 +7766,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8504,14 +7803,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8555,7 +7850,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8585,19 +7879,10 @@ msgstr ""
 msgid "To"
 msgstr "Bitiş"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8634,7 +7919,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8659,16 +7943,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8711,7 +7986,7 @@ msgstr ""
 msgid "Total"
 msgstr "Toplam"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8719,7 +7994,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8740,7 +8014,6 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8756,14 +8029,12 @@ msgstr "İşlem Tarihi yok!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8802,7 +8073,6 @@ msgstr ""
 msgid "Translations saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Proforma Bilanço"
@@ -8811,7 +8081,6 @@ msgstr "Proforma Bilanço"
 msgid "Trillion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8868,10 +8137,6 @@ msgstr ""
 msgid "Two"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8906,39 +8171,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8957,43 +8216,37 @@ msgstr "Birim"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9001,23 +8254,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9034,7 +8282,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9062,21 +8309,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9085,7 +8327,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9103,24 +8344,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9130,7 +8366,6 @@ msgstr "Kullanıcı"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9151,7 +8386,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9177,8 +8411,6 @@ msgstr ""
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9188,11 +8420,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9208,7 +8436,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Satıcı"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9222,7 +8449,6 @@ msgstr ""
 msgid "Vendor Invoice"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9232,9 +8458,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9264,9 +8487,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9274,8 +8495,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9290,7 +8509,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9303,7 +8521,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9326,7 +8543,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr ""
@@ -9335,11 +8551,26 @@ msgstr ""
 msgid "Warning!"
 msgstr ""
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9349,7 +8580,6 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9366,13 +8596,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Ağırlık"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "Ağırlık Birimi"
@@ -9389,7 +8617,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9406,11 +8633,11 @@ msgstr ""
 msgid "Work order"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9453,15 +8680,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Evet"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9488,7 +8710,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9552,17 +8774,12 @@ msgstr "gün. "
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9579,7 +8796,7 @@ msgstr ""
 msgid "done"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9607,8 +8824,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9617,22 +8832,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9657,7 +8868,6 @@ msgstr ""
 msgid "sent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9682,8 +8892,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/uk.po
+++ b/locale/po/uk.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Ukrainian (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -18,27 +18,22 @@ msgstr ""
 "> 14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || (n % "
 "100 >=11 && n % 100 <=14 )) ? 2: 3);\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -51,12 +46,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -102,7 +93,6 @@ msgstr "Витрати"
 msgid "AP Aging"
 msgstr "Старіння рахунків витрат"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -111,7 +101,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -126,7 +115,6 @@ msgstr "Несплачені рахунки витрат"
 msgid "AP Transaction"
 msgstr "Проводка витрат"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "Проводки витрат"
@@ -139,9 +127,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -160,7 +146,6 @@ msgstr "Доходи"
 msgid "AR Aging"
 msgstr "Старіння рахунків доходів"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -169,7 +154,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -184,7 +168,6 @@ msgstr "Несплачені рахунки доходів"
 msgid "AR Transaction"
 msgstr "Проводка доходів"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "Проводки доходів"
@@ -197,9 +180,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -208,8 +189,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Проводка доходів"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -219,16 +198,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -254,38 +228,20 @@ msgstr ""
 msgid "Account"
 msgstr "Рахунок"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -306,23 +262,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "Номер рахунку"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -362,17 +313,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -384,7 +333,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -412,12 +361,10 @@ msgstr "Активний"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -440,11 +387,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr "Додати комплект"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -569,7 +516,6 @@ msgstr "Нове замовлення на продаж"
 msgid "Add Service"
 msgstr "Нова послуга"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -636,7 +582,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "Оновити"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -661,7 +606,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -671,12 +615,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -696,8 +639,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -750,7 +692,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -759,11 +700,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -797,14 +733,10 @@ msgstr ""
 msgid "Amount"
 msgstr "Сума"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -813,27 +745,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "Заплатити суму"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -851,14 +777,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -877,17 +803,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -896,13 +819,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -911,7 +827,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -920,14 +835,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -939,19 +852,16 @@ msgstr ""
 msgid "Apr"
 msgstr "квітня"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "Квітень"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -967,7 +877,6 @@ msgstr "Ви певні, що хочете видалити номер коти�
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -986,19 +895,17 @@ msgstr "Комплекти інвентаризовані!"
 msgid "Asset"
 msgstr "Актив"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1011,29 +918,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1049,7 +953,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1147,8 +1050,7 @@ msgstr ""
 msgid "Aug"
 msgstr "серпня"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "Серпень"
 
@@ -1160,7 +1062,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1174,7 +1075,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1187,7 +1087,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1221,8 +1120,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1237,7 +1134,6 @@ msgstr "Баланс"
 msgid "Balance Sheet"
 msgstr "Баланс-зведення"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1258,7 +1154,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1269,7 +1164,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1279,18 +1173,15 @@ msgstr "Валюта"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1303,12 +1194,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1325,13 +1214,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1372,8 +1259,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1420,17 +1305,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1443,12 +1325,10 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "Бізнес-номер"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1458,12 +1338,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1485,7 +1363,6 @@ msgstr "Бізнес збережено"
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1517,18 +1394,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1654,12 +1529,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "План Рахунків"
 
@@ -1679,7 +1553,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1708,7 +1581,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1720,9 +1593,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "Проведено"
 
@@ -1750,15 +1623,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "Закрито"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1772,8 +1643,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1788,22 +1657,18 @@ msgstr "Відсутній код"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1815,39 +1680,31 @@ msgstr ""
 msgid "Company"
 msgstr "Підприємство"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "Назва підприємства"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1868,7 +1725,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Підтвердіть!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1886,7 +1743,6 @@ msgstr ""
 msgid "Contact"
 msgstr "Контактна особа"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1902,7 +1758,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1920,9 +1775,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1952,7 +1804,6 @@ msgstr ""
 msgid "Contra"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1960,10 +1811,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1994,20 +1841,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "Затрати"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2023,26 +1866,20 @@ msgstr "Не вдалось зберегти!"
 msgid "Could not transfer Inventory!"
 msgstr "Не вдалось перевести інвентар!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2054,7 +1891,6 @@ msgstr ""
 msgid "Country"
 msgstr "Країна"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2067,7 +1903,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2075,11 +1911,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2107,8 +1943,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2116,17 +1950,14 @@ msgstr ""
 msgid "Credit"
 msgstr "Кредит"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2151,29 +1982,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "Валюта"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2196,18 +2017,14 @@ msgstr "Валюта"
 msgid "Currency"
 msgstr "Валюта"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "Поточний"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2217,11 +2034,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2236,7 +2049,6 @@ msgstr ""
 msgid "Customer"
 msgstr "Клієнт"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2255,9 +2067,6 @@ msgstr "Клієнта нема в списку!"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2277,9 +2086,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "Не вказаний клієнт!"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2291,7 +2098,7 @@ msgstr "Клієнта нема в списку!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2315,12 +2122,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2353,28 +2159,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2421,19 +2215,14 @@ msgstr ""
 msgid "Date"
 msgstr "Дата"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2455,7 +2244,6 @@ msgstr ""
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2519,8 +2307,6 @@ msgstr ""
 msgid "Days"
 msgstr "Дні(в)"
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2536,10 +2322,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2549,17 +2333,14 @@ msgstr ""
 msgid "Dec"
 msgstr "грудня"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "Грудень"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2569,7 +2350,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2582,47 +2362,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2635,21 +2406,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "Типові значення"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2667,7 +2431,6 @@ msgstr ""
 msgid "Delete"
 msgstr "Видалити"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2680,7 +2443,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr "Видалити розклад"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2694,37 +2456,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Дата доставки"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2746,20 +2504,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2770,46 +2525,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2920,12 +2636,10 @@ msgstr "Подробиці"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2938,7 +2652,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2947,7 +2660,6 @@ msgstr ""
 msgid "Discount"
 msgstr "Знижка"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2956,28 +2668,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2985,7 +2697,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2994,7 +2705,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -3002,12 +2713,10 @@ msgstr ""
 msgid "Done"
 msgstr "Зроблено"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3020,12 +2729,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3034,19 +2741,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "Малюнок"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3062,10 +2766,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3084,7 +2784,7 @@ msgstr "Не вказаний термін оплати!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3110,7 +2810,7 @@ msgstr "Повідомлення ел. пошти"
 msgid "E-mailed"
 msgstr "Ел. пошту відіслано"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3140,7 +2840,7 @@ msgstr "Редагувати проводку доходів"
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3284,8 +2984,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3299,7 +2997,6 @@ msgstr ""
 msgid "Employee"
 msgstr "Працівник"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3309,12 +3006,11 @@ msgstr "Номер працівника"
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3324,37 +3020,26 @@ msgstr "Номер працівника"
 msgid "Employees"
 msgstr "Працівники"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3378,7 +3063,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3403,12 +3087,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3418,7 +3100,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3426,7 +3108,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3452,7 +3133,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Назва підприємства"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3464,14 +3145,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "Капітал"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3485,16 +3163,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3502,7 +3179,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3515,8 +3192,6 @@ msgstr "Кожні"
 msgid "Exch"
 msgstr "Курс"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3531,7 +3206,6 @@ msgstr "Курс валюти"
 msgid "Exchange rate for payment missing!"
 msgstr "Не вказаний курс валюти для платежу!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3540,7 +3214,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "Не вказаний курс валюти!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3558,13 +3231,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "Видаток/Актив"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3642,8 +3312,7 @@ msgstr ""
 msgid "Feb"
 msgstr "лютого"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "Лютий"
 
@@ -3659,14 +3328,10 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3677,11 +3342,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3692,7 +3357,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3750,12 +3414,10 @@ msgstr ""
 msgid "For"
 msgstr "Для"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "Прибуток з Обміну Валюти"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "Втрата на Обміні Валюти"
@@ -3764,12 +3426,10 @@ msgstr "Втрата на Обміні Валюти"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3786,7 +3446,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3805,18 +3464,10 @@ msgstr ""
 msgid "From"
 msgstr "Від/З"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3837,7 +3488,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3848,15 +3498,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3870,10 +3515,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "GIFI"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3894,7 +3537,6 @@ msgstr "GIFI збережено!"
 msgid "GL"
 msgstr "ГК"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3903,7 +3545,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3911,11 +3553,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3924,7 +3565,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3932,9 +3573,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr "Створити"
 
@@ -3950,7 +3590,7 @@ msgstr "Створити замовлення"
 msgid "Generate Purchase Orders"
 msgstr "Створити купівельні замовлення"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3958,7 +3598,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3974,12 +3614,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3988,7 +3626,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4062,21 +3699,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4107,7 +3729,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4117,13 +3738,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "Зображення"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4166,7 +3785,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4200,14 +3818,10 @@ msgstr "Додати до листових меню"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4215,12 +3829,10 @@ msgstr ""
 msgid "Income"
 msgstr "Прибуток"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4231,7 +3843,6 @@ msgstr "Звіт про доходи і видатки"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4241,7 +3852,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "Звіт про доходи і видатки"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4261,11 +3871,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4275,30 +3884,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "Внутрішні примітки"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4308,17 +3913,14 @@ msgstr "Інвентар"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4346,11 +3948,7 @@ msgstr "Інвентар збережено!"
 msgid "Inventory transferred!"
 msgstr "Інвентар перенесено!"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4392,8 +3990,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4409,11 +4005,6 @@ msgstr "Не вказана дата виставлення рахунка-фа�
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4432,7 +4023,6 @@ msgstr "Номер рахунка-фактури"
 msgid "Invoice Number missing!"
 msgstr "Не вказаний номер рахунка-фактури"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4462,12 +4052,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4525,8 +4113,7 @@ msgstr ""
 msgid "Jan"
 msgstr "січня"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "січень"
 
@@ -4555,8 +4142,7 @@ msgstr ""
 msgid "Jul"
 msgstr "липня"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "Липень"
 
@@ -4564,8 +4150,8 @@ msgstr "Липень"
 msgid "Jun"
 msgstr "червня"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Червень"
 
@@ -4578,10 +4164,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4603,15 +4185,12 @@ msgstr "Робота/додаткові витрати"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "Мова"
@@ -4632,7 +4211,6 @@ msgstr "Мови не визначено!"
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4643,7 +4221,6 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4665,40 +4242,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4710,9 +4286,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4734,9 +4308,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4750,8 +4322,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4768,7 +4338,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4805,7 +4374,6 @@ msgstr "Список мов"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4831,7 +4399,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4849,7 +4416,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4870,7 +4436,7 @@ msgstr ""
 msgid "Login"
 msgstr "Вхід"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4898,45 +4464,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "Виробництво"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4958,40 +4517,34 @@ msgstr ""
 msgid "Mar"
 msgstr "березня"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "Березень"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "Націнка"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "травня"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "Нотатка"
@@ -5008,7 +4561,6 @@ msgstr "Повідомлення"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "Метод"
@@ -5017,7 +4569,6 @@ msgstr "Метод"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5036,14 +4587,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5057,7 +4605,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5070,14 +4617,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "Модель"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5095,7 +4640,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5119,14 +4664,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5135,15 +4678,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5162,7 +4696,6 @@ msgstr "Назва"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5213,8 +4746,6 @@ msgstr "Наступна дата"
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5236,12 +4767,10 @@ msgstr ""
 msgid "Ninety"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "Ні"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5250,7 +4779,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5258,11 +4787,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5270,7 +4799,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5279,11 +4807,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5291,21 +4819,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5324,12 +4849,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5338,12 +4861,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5381,11 +4902,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5431,23 +4947,18 @@ msgstr "Нема що перенести"
 msgid "Nov"
 msgstr "листопада"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "Листопад"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5478,7 +4989,7 @@ msgstr ""
 msgid "Number"
 msgstr "Номер"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "Формат Числа"
 
@@ -5499,13 +5010,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "Застаріле"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5514,8 +5023,7 @@ msgstr ""
 msgid "Oct"
 msgstr "жовтня"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "Жовтень"
 
@@ -5527,9 +5035,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5579,7 +5084,6 @@ msgstr ""
 msgid "Open"
 msgstr "Відкрито"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5601,9 +5105,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5649,7 +5150,6 @@ msgstr "Не вказано дату замовлення!"
 msgid "Order Entry"
 msgstr "Виставлення замовлення"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5671,7 +5171,6 @@ msgstr "Замовлення видалено!"
 msgid "Order generation failed!"
 msgstr "Створення замовлення зазнало невдачі!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5693,7 +5192,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5739,7 +5238,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5758,10 +5256,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5805,11 +5299,6 @@ msgstr "Не вказано номер пакувального списку"
 msgid "Packing list"
 msgstr "Пакувальний список"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5827,12 +5316,10 @@ msgstr "Заплачено"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5842,14 +5329,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5879,14 +5358,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5902,15 +5377,12 @@ msgstr "Номер частини"
 msgid "Parts"
 msgstr "Новий Товар"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5920,7 +5392,6 @@ msgstr ""
 msgid "Password"
 msgstr "Пароль"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5933,7 +5404,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5947,7 +5417,6 @@ msgstr ""
 msgid "Payables"
 msgstr "Зобовязання (платіжні)"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5956,7 +5425,6 @@ msgstr "Зобовязання (платіжні)"
 msgid "Payment"
 msgstr "Платіж"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5969,7 +5437,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5986,7 +5453,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6022,15 +5488,15 @@ msgstr "Платежі"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6049,7 +5515,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6080,108 +5545,88 @@ msgstr "Список комплектування"
 msgid "Pick list"
 msgstr "Список комплектування"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6197,7 +5642,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6206,24 +5650,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6232,13 +5674,11 @@ msgstr ""
 msgid "Post"
 msgstr "Виставити"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6279,7 +5719,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Postscript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6317,20 +5756,16 @@ msgstr ""
 msgid "Price"
 msgstr "Ціна"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6366,8 +5801,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6377,7 +5810,6 @@ msgstr ""
 msgid "Print"
 msgstr "Надрукувати"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6394,7 +5826,7 @@ msgstr ""
 msgid "Printed"
 msgstr "Надруковано"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "Принтер"
 
@@ -6438,17 +5870,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6477,7 +5907,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6496,7 +5925,6 @@ msgstr ""
 msgid "Project Number"
 msgstr "Номер проекту"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6505,9 +5933,6 @@ msgstr ""
 msgid "Projects"
 msgstr "Проекти"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6517,7 +5942,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6535,22 +5959,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "Купівельне замовлення"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "Номер купівельного замовлення"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "Купівельні замовлення"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6565,14 +5983,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "Купівельне замовлення"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6603,7 +6017,6 @@ msgstr ""
 msgid "Qty"
 msgstr "Кількість"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6617,8 +6030,6 @@ msgstr ""
 msgid "Quarter"
 msgstr "Квартал"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6655,9 +6066,7 @@ msgstr "Відсутній номер котирування!"
 msgid "Quotation deleted!"
 msgstr "Котирування видалено!"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6678,25 +6087,20 @@ msgstr "RFQ"
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "RFQ номер"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "RFQs"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "ROP"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6708,7 +6112,6 @@ msgstr ""
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 msgid "Rate Type"
 msgstr ""
@@ -6729,13 +6132,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6753,7 +6152,6 @@ msgstr "Квитанція"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6767,8 +6165,7 @@ msgstr "Квитанції"
 msgid "Receivables"
 msgstr "Належності (дебити)"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "Отримати"
 
@@ -6776,7 +6173,6 @@ msgstr "Отримати"
 msgid "Receive Merchandise"
 msgstr "Отримати товари"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6797,7 +6193,6 @@ msgstr ""
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6818,13 +6213,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Періодичні проводки"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6863,12 +6251,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6906,7 +6292,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6918,7 +6304,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6931,7 +6317,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6981,7 +6366,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -7001,13 +6386,10 @@ msgstr ""
 msgid "Required by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7037,7 +6419,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7046,7 +6427,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7063,7 +6443,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7113,11 +6492,11 @@ msgstr "SKU"
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7143,7 +6522,6 @@ msgstr "Продаж"
 msgid "Sales Invoice"
 msgstr "Рахунок-фактура"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7159,20 +6537,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr "Накладна продажу"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "Номер накладної продажу"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "Накладні продажу"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr ""
@@ -7195,9 +6570,6 @@ msgstr "Не вдається видалити котирування!"
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7221,13 +6593,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7247,7 +6616,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7257,7 +6626,6 @@ msgstr "Зберегти"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7316,11 +6684,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "Зберегти як нове"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7343,10 +6710,8 @@ msgstr "Розклад"
 msgid "Scheduled"
 msgstr "В розкладі"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Екран"
 
@@ -7366,7 +6731,6 @@ msgstr "Екран"
 msgid "Search"
 msgstr "Пошук"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7375,7 +6739,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7428,11 +6791,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7444,11 +6807,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7460,7 +6823,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7468,7 +6831,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7524,7 +6886,6 @@ msgstr "Виберіть txt, postscript або PDF!"
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7533,9 +6894,6 @@ msgstr ""
 msgid "Sell"
 msgstr "Продати"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7589,13 +6947,11 @@ msgstr ""
 msgid "Sep"
 msgstr "вересня"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "Вересень"
 
@@ -7616,9 +6972,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "Серійний No."
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7648,7 +7001,6 @@ msgstr ""
 msgid "Services"
 msgstr "Послуга"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 #, fuzzy
 msgid "Session Timeout (e.g. \"90 minutes\")"
@@ -7662,7 +7014,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7682,10 +7034,10 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "Відіслати"
 
@@ -7712,10 +7064,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7776,10 +7124,6 @@ msgstr "Відсутня дата відсилання!"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7821,7 +7165,6 @@ msgstr "Дата відсилання"
 msgid "Short"
 msgstr "Скорочено"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7862,7 +7205,6 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7875,12 +7217,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7907,7 +7243,6 @@ msgstr "Джерело"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7929,21 +7264,10 @@ msgstr ""
 msgid "Standard"
 msgstr "Стандартні"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "Стандартні індустріальні коди"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7974,8 +7298,6 @@ msgstr ""
 msgid "Startdate"
 msgstr "Дата початку"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8012,13 +7334,11 @@ msgstr ""
 msgid "Statement"
 msgstr "Звіт"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "Балансовий Звіт"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8049,7 +7369,7 @@ msgstr "Інвентар комплекту"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "Оформленння"
 
@@ -8074,7 +7394,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8117,7 +7436,6 @@ msgstr "Зведення"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8150,12 +7468,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8167,9 +7479,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8188,8 +7497,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8200,17 +7507,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8354,7 +7658,6 @@ msgstr ""
 msgid "Template"
 msgstr "HTML Шаблони "
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8363,7 +7666,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8416,7 +7718,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8428,7 +7730,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8479,24 +7781,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8519,14 +7818,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8570,7 +7865,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8600,19 +7894,10 @@ msgstr ""
 msgid "To"
 msgstr "До"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8649,7 +7934,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8674,16 +7958,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8726,7 +8001,7 @@ msgstr ""
 msgid "Total"
 msgstr "Загальна Сума"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8734,7 +8009,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8755,7 +8029,6 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8771,14 +8044,12 @@ msgstr "Не вказана дата проводки"
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8817,7 +8088,6 @@ msgstr "Переклади"
 msgid "Translations saved!"
 msgstr "Переклади збережено!"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "Пробний баланс"
@@ -8826,7 +8096,6 @@ msgstr "Пробний баланс"
 msgid "Trillion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8883,10 +8152,6 @@ msgstr ""
 msgid "Two"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8921,39 +8186,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8972,43 +8231,37 @@ msgstr "Одиниця"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9016,23 +8269,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9049,7 +8297,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9077,21 +8324,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9100,7 +8342,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9118,24 +8359,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9145,7 +8381,6 @@ msgstr "Користувач"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9166,7 +8401,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9192,8 +8426,6 @@ msgstr ""
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9203,11 +8435,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9223,7 +8451,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "Постачальник"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9237,7 +8464,6 @@ msgstr "Історія постачальника"
 msgid "Vendor Invoice"
 msgstr "Рахунок-фактура"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9247,9 +8473,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9279,9 +8502,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "Постачальник не існує"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9289,8 +8510,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Потачальника нема у списку "
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9305,7 +8524,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9318,7 +8536,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9341,7 +8558,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "Склади"
@@ -9350,11 +8566,26 @@ msgstr "Склади"
 msgid "Warning!"
 msgstr "Попередження!"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9364,7 +8595,6 @@ msgstr ""
 msgid "Week"
 msgstr "Тиждень"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9381,13 +8611,11 @@ msgstr ""
 msgid "Weeks"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "Вага"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr ""
@@ -9404,7 +8632,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9422,11 +8649,11 @@ msgstr "Наряд"
 msgid "Work order"
 msgstr "Наряд"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9469,15 +8696,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Tak"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9504,7 +8726,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9568,17 +8790,12 @@ msgstr "днів"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9595,7 +8812,7 @@ msgstr ""
 msgid "done"
 msgstr "завершено"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9623,8 +8840,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9633,22 +8848,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9673,7 +8884,6 @@ msgstr ""
 msgid "sent"
 msgstr "нідіслано"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9698,8 +8908,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/zh_CN.po
+++ b/locale/po/zh_CN.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Chinese (China) (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,27 +15,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -48,12 +43,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -99,7 +90,6 @@ msgstr "应付帐款"
 msgid "AP Aging"
 msgstr "应付帐龄分析"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -108,7 +98,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -123,7 +112,6 @@ msgstr "应付未付"
 msgid "AP Transaction"
 msgstr "应付交易"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "应付交易"
@@ -136,9 +124,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -157,7 +143,6 @@ msgstr "应收帐款"
 msgid "AR Aging"
 msgstr "应收帐龄分析"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -166,7 +151,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -181,7 +165,6 @@ msgstr "应收未收"
 msgid "AR Transaction"
 msgstr "应收交易"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "应收交易"
@@ -194,9 +177,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -205,8 +186,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "应收交易"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -216,16 +195,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -251,38 +225,20 @@ msgstr ""
 msgid "Account"
 msgstr "帐户"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -303,23 +259,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "帐户编号"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -359,17 +310,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -381,7 +330,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -409,12 +358,10 @@ msgstr "活跃"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -437,11 +384,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr "新增商品"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -566,7 +513,6 @@ msgstr "新增销货单"
 msgid "Add Service"
 msgstr "新增服务"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -633,7 +579,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "更新"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -658,7 +603,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -668,12 +612,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -693,8 +636,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -747,7 +689,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -756,11 +697,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -794,14 +730,10 @@ msgstr ""
 msgid "Amount"
 msgstr "总计"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -810,27 +742,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "应得的总计"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -848,14 +774,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -874,17 +800,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -893,13 +816,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -908,7 +824,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -917,14 +832,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -936,19 +849,16 @@ msgstr ""
 msgid "Apr"
 msgstr "四月"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "四月"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -964,7 +874,6 @@ msgstr "您是否确定要删除报价单编号"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -983,19 +892,17 @@ msgstr "巳重新进货的商品"
 msgid "Asset"
 msgstr "资产"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1008,29 +915,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1046,7 +950,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1144,8 +1047,7 @@ msgstr ""
 msgid "Aug"
 msgstr "八月"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "八月"
 
@@ -1157,7 +1059,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1171,7 +1072,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1184,7 +1084,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr "平均成本"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1218,8 +1117,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1234,7 +1131,6 @@ msgstr "余额"
 msgid "Balance Sheet"
 msgstr "资产负债表"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1255,7 +1151,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1266,7 +1161,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1276,18 +1170,15 @@ msgstr "币别"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1300,12 +1191,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1322,13 +1211,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1369,8 +1256,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1417,17 +1302,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1440,12 +1322,10 @@ msgstr ""
 msgid "Business"
 msgstr "业务"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "业务编号"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1455,12 +1335,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1482,7 +1360,6 @@ msgstr "巳储存业务"
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1514,18 +1391,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1651,12 +1526,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "会计科目表"
 
@@ -1676,7 +1550,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "检查存货清单"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1705,7 +1578,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1717,9 +1590,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "已清除"
 
@@ -1747,15 +1620,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "已关闭"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1769,8 +1640,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1785,22 +1654,18 @@ msgstr "未指明编码"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1812,39 +1677,31 @@ msgstr ""
 msgid "Company"
 msgstr "公司"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "公司名称"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1865,7 +1722,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "入帐成功!"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1883,7 +1740,6 @@ msgstr ""
 msgid "Contact"
 msgstr "连络人"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1899,7 +1755,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1917,9 +1772,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1949,7 +1801,6 @@ msgstr ""
 msgid "Contra"
 msgstr "相反"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1957,10 +1808,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1991,20 +1838,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "成本"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2020,26 +1863,20 @@ msgstr "不能储存"
 msgid "Could not transfer Inventory!"
 msgstr "存货清单不能转移"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2051,7 +1888,6 @@ msgstr ""
 msgid "Country"
 msgstr "国家"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2064,7 +1900,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2072,11 +1908,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2104,8 +1940,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2113,17 +1947,14 @@ msgstr ""
 msgid "Credit"
 msgstr "贷方"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2148,29 +1979,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "目前"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2193,18 +2014,14 @@ msgstr "目前"
 msgid "Currency"
 msgstr "币别"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "现有"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2214,11 +2031,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2233,7 +2046,6 @@ msgstr ""
 msgid "Customer"
 msgstr "客户"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2252,9 +2064,6 @@ msgstr "客户未存档"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2274,9 +2083,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "未指明客户"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2288,7 +2095,7 @@ msgstr "客户未存档"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2312,12 +2119,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2350,28 +2156,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2418,19 +2212,14 @@ msgstr ""
 msgid "Date"
 msgstr "日期"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2452,7 +2241,6 @@ msgstr "收款日期"
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2516,8 +2304,6 @@ msgstr "日"
 msgid "Days"
 msgstr "日"
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2533,10 +2319,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2546,17 +2330,14 @@ msgstr ""
 msgid "Dec"
 msgstr "十二月"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "十二月"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2566,7 +2347,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2579,47 +2359,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2632,21 +2403,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "预设"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2664,7 +2428,6 @@ msgstr ""
 msgid "Delete"
 msgstr "删除"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2677,7 +2440,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr "删除预定"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2691,37 +2453,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "到期日"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2743,20 +2501,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2767,46 +2522,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2917,12 +2633,10 @@ msgstr "详情"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2935,7 +2649,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2944,7 +2657,6 @@ msgstr ""
 msgid "Discount"
 msgstr "折扣"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2953,28 +2665,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2982,7 +2694,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2991,7 +2702,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -2999,12 +2710,10 @@ msgstr ""
 msgid "Done"
 msgstr "巳完成"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3017,12 +2726,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3031,19 +2738,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "图画"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3059,10 +2763,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3081,7 +2781,7 @@ msgstr "未指明到期日!"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3107,7 +2807,7 @@ msgstr "发送电邮"
 msgid "E-mailed"
 msgstr "巳电邮"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3137,7 +2837,7 @@ msgstr "编辑应收记录"
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3281,8 +2981,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3296,7 +2994,6 @@ msgstr ""
 msgid "Employee"
 msgstr "职员"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3306,12 +3003,11 @@ msgstr "工号"
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3321,37 +3017,26 @@ msgstr "工号"
 msgid "Employees"
 msgstr "职员"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3375,7 +3060,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3400,12 +3084,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3415,7 +3097,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3423,7 +3105,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3449,7 +3130,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "公司名称"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3461,14 +3142,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "股权"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3482,16 +3160,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3499,7 +3176,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3512,8 +3189,6 @@ msgstr ""
 msgid "Exch"
 msgstr "汇率"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3528,7 +3203,6 @@ msgstr "汇率"
 msgid "Exchange rate for payment missing!"
 msgstr "未指明付款的汇率"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3537,7 +3211,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "未指明汇率"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3555,13 +3228,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "费用/资产"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3639,8 +3309,7 @@ msgstr ""
 msgid "Feb"
 msgstr "二月"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "二月"
 
@@ -3656,14 +3325,10 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3674,11 +3339,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3689,7 +3354,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3747,12 +3411,10 @@ msgstr ""
 msgid "For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "外汇收益"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "外汇损失"
@@ -3761,12 +3423,10 @@ msgstr "外汇损失"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3783,7 +3443,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3802,18 +3461,10 @@ msgstr ""
 msgid "From"
 msgstr "从"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3834,7 +3485,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr "从仓库"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3845,15 +3495,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3867,10 +3512,8 @@ msgstr ""
 msgid "GIFI"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3891,7 +3534,6 @@ msgstr "巳储存"
 msgid "GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr ""
@@ -3900,7 +3542,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3908,11 +3550,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3921,7 +3562,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3929,9 +3570,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr "产生"
 
@@ -3947,7 +3587,7 @@ msgstr "产生订单"
 msgid "Generate Purchase Orders"
 msgstr "产生采购单"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3955,7 +3595,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3971,12 +3611,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3985,7 +3623,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4059,21 +3696,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4104,7 +3726,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4114,13 +3735,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "形像"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4163,7 +3782,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4197,14 +3815,10 @@ msgstr "包含在下拉式选单中"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4212,12 +3826,10 @@ msgstr ""
 msgid "Income"
 msgstr "收入"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4228,7 +3840,6 @@ msgstr "损益表"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4238,7 +3849,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "损益表"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4258,11 +3868,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4272,30 +3881,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "内部备忘录"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4305,17 +3910,14 @@ msgstr "库存"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4341,11 +3943,7 @@ msgstr "巳储存存货"
 msgid "Inventory transferred!"
 msgstr "转移的存货"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4387,8 +3985,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4404,11 +4000,6 @@ msgstr "未指明发票日期!"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4427,7 +4018,6 @@ msgstr "发票编号"
 msgid "Invoice Number missing!"
 msgstr "未指明发票编号!"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4457,12 +4047,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4520,8 +4108,7 @@ msgstr ""
 msgid "Jan"
 msgstr "一月"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "一月"
 
@@ -4550,8 +4137,7 @@ msgstr ""
 msgid "Jul"
 msgstr "七月"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "七月"
 
@@ -4559,8 +4145,8 @@ msgstr "七月"
 msgid "Jun"
 msgstr "六月"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "六月"
 
@@ -4573,10 +4159,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "LaTex 模版"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4598,15 +4180,12 @@ msgstr "劳工/经常费用"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "语言"
@@ -4627,7 +4206,6 @@ msgstr "不能辨认语言"
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4638,7 +4216,6 @@ msgstr "最后成本"
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4660,40 +4237,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr "总需时"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4705,9 +4281,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4729,9 +4303,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4745,8 +4317,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4763,7 +4333,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4800,7 +4369,6 @@ msgstr "列出语言"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4826,7 +4394,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4844,7 +4411,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4865,7 +4431,7 @@ msgstr ""
 msgid "Login"
 msgstr "登入"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4893,45 +4459,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "制造"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4953,40 +4512,34 @@ msgstr ""
 msgid "Mar"
 msgstr "三月"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "三月"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "涨价"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "五月"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "备忘录"
@@ -5003,7 +4556,6 @@ msgstr "讯息"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "方法"
@@ -5012,7 +4564,6 @@ msgstr "方法"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5031,14 +4582,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5052,7 +4600,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5065,14 +4612,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "型号"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5090,7 +4635,7 @@ msgstr "月"
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5114,14 +4659,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5130,15 +4673,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5157,7 +4691,6 @@ msgstr "名称"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5208,8 +4741,6 @@ msgstr ""
 msgid "Next Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5231,12 +4762,10 @@ msgstr ""
 msgid "Ninety"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "否"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5245,7 +4774,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5253,11 +4782,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5265,7 +4794,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5274,11 +4802,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5286,21 +4814,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5319,12 +4844,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5333,12 +4856,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5376,11 +4897,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5426,23 +4942,18 @@ msgstr "没有可转移的项目"
 msgid "Nov"
 msgstr "十一月"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "十一月"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5473,7 +4984,7 @@ msgstr ""
 msgid "Number"
 msgstr "编号"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "数字格式"
 
@@ -5494,13 +5005,11 @@ msgstr ""
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "停用"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5509,8 +5018,7 @@ msgstr ""
 msgid "Oct"
 msgstr "十月"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "十月"
 
@@ -5522,9 +5030,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5574,7 +5079,6 @@ msgstr ""
 msgid "Open"
 msgstr "开启"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5596,9 +5100,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5644,7 +5145,6 @@ msgstr "未指明下单日期!"
 msgid "Order Entry"
 msgstr "下单项目"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5666,7 +5166,6 @@ msgstr "巳删除订单"
 msgid "Order generation failed!"
 msgstr "订单产生失败!"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5688,7 +5187,7 @@ msgstr ""
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5734,7 +5233,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5753,10 +5251,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5800,11 +5294,6 @@ msgstr "未指明包装清单编号!"
 msgid "Packing list"
 msgstr "出货单"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5822,12 +5311,10 @@ msgstr "已付"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "原料"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5837,14 +5324,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5874,14 +5353,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5897,15 +5372,12 @@ msgstr "料号"
 msgid "Parts"
 msgstr "原料"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5915,7 +5387,6 @@ msgstr ""
 msgid "Password"
 msgstr "密码"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5928,7 +5399,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5942,7 +5412,6 @@ msgstr ""
 msgid "Payables"
 msgstr "应付科目"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5951,7 +5420,6 @@ msgstr "应付科目"
 msgid "Payment"
 msgstr "付款"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5964,7 +5432,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5981,7 +5448,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6017,15 +5483,15 @@ msgstr "付款"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6044,7 +5510,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6075,108 +5540,88 @@ msgstr "选择单"
 msgid "Pick list"
 msgstr "选择单"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6192,7 +5637,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6201,24 +5645,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6227,13 +5669,11 @@ msgstr ""
 msgid "Post"
 msgstr "加入"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6274,7 +5714,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "附言"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6312,20 +5751,16 @@ msgstr ""
 msgid "Price"
 msgstr "价格"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6361,8 +5796,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6372,7 +5805,6 @@ msgstr ""
 msgid "Print"
 msgstr "列印"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6389,7 +5821,7 @@ msgstr "列印及另存新档"
 msgid "Printed"
 msgstr "巳列印"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "印表机"
 
@@ -6433,17 +5865,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6472,7 +5902,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6491,7 +5920,6 @@ msgstr "方案描述的翻译"
 msgid "Project Number"
 msgstr "方案号码"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6500,9 +5928,6 @@ msgstr ""
 msgid "Projects"
 msgstr "方案"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6512,7 +5937,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6530,22 +5954,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "采购单"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "采购单编号"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "采购单"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6560,14 +5978,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "采购单"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6598,7 +6012,6 @@ msgstr ""
 msgid "Qty"
 msgstr "数量"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6612,8 +6025,6 @@ msgstr "超过可库存的数量"
 msgid "Quarter"
 msgstr "季度"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6650,9 +6061,7 @@ msgstr "未指明报价单号码"
 msgid "Quotation deleted!"
 msgstr "巳删除报价单"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6673,25 +6082,20 @@ msgstr "报价请求(RFQ) "
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "RFD号码"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "报价请求"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "再订点"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6703,7 +6107,6 @@ msgstr "税率"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6726,13 +6129,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6750,7 +6149,6 @@ msgstr "收据"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6764,8 +6162,7 @@ msgstr "收据"
 msgid "Receivables"
 msgstr "应收帐户"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "收到"
 
@@ -6773,7 +6170,6 @@ msgstr "收到"
 msgid "Receive Merchandise"
 msgstr "收到货物"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6794,7 +6190,6 @@ msgstr "调和"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6815,13 +6210,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "多次记录"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6860,12 +6248,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6903,7 +6289,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6915,7 +6301,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6928,7 +6314,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6978,7 +6363,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -6998,13 +6383,10 @@ msgstr ""
 msgid "Required by"
 msgstr "需要者"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7034,7 +6416,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7043,7 +6424,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7060,7 +6440,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7110,11 +6489,11 @@ msgstr "被指定的数量"
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7140,7 +6519,6 @@ msgstr "销售"
 msgid "Sales Invoice"
 msgstr "销售发票"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
@@ -7156,20 +6534,17 @@ msgstr ""
 msgid "Sales Order"
 msgstr "销货单"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "销货单编号"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "销货单"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "报价单编号"
@@ -7192,9 +6567,6 @@ msgstr "报价单编号"
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7218,13 +6590,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7244,7 +6613,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7254,7 +6623,6 @@ msgstr "储存"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7313,11 +6681,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "当新的储存"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7340,10 +6707,8 @@ msgstr "预定"
 msgid "Scheduled"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "萤幕"
 
@@ -7363,7 +6728,6 @@ msgstr "萤幕"
 msgid "Search"
 msgstr "搜寻"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7372,7 +6736,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7425,11 +6788,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7441,11 +6804,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7457,7 +6820,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7465,7 +6828,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7521,7 +6883,6 @@ msgstr ""
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7530,9 +6891,6 @@ msgstr ""
 msgid "Sell"
 msgstr "卖价"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7586,13 +6944,11 @@ msgstr ""
 msgid "Sep"
 msgstr "九月"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "九月"
 
@@ -7613,9 +6969,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "序号"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7645,7 +6998,6 @@ msgstr ""
 msgid "Services"
 msgstr "服务"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 #, fuzzy
 msgid "Session Timeout (e.g. \"90 minutes\")"
@@ -7659,7 +7011,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7679,10 +7031,10 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "船"
 
@@ -7709,10 +7061,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7773,10 +7121,6 @@ msgstr "未指明海运日期"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7818,7 +7162,6 @@ msgstr "海运日期"
 msgid "Short"
 msgstr "短"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7859,7 +7202,6 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7872,12 +7214,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7904,7 +7240,6 @@ msgstr "来源"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7926,21 +7261,10 @@ msgstr ""
 msgid "Standard"
 msgstr "标准"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "标准工业编码"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7971,8 +7295,6 @@ msgstr ""
 msgid "Startdate"
 msgstr "开始日期"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8009,13 +7331,11 @@ msgstr ""
 msgid "Statement"
 msgstr "会计帐"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "会计帐余额"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8045,7 +7365,7 @@ msgstr "盘点"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "样式表"
 
@@ -8070,7 +7390,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8113,7 +7432,6 @@ msgstr "摘要"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8146,12 +7464,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8163,9 +7475,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8184,8 +7493,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8196,17 +7503,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8350,7 +7654,6 @@ msgstr ""
 msgid "Template"
 msgstr "HTML 表单"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8359,7 +7662,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8412,7 +7714,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8424,7 +7726,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8475,24 +7777,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8515,14 +7814,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8566,7 +7861,6 @@ msgstr ""
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr ""
@@ -8596,19 +7890,10 @@ msgstr ""
 msgid "To"
 msgstr "至"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8645,7 +7930,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8670,16 +7954,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8722,7 +7997,7 @@ msgstr ""
 msgid "Total"
 msgstr "总计"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8730,7 +8005,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8751,7 +8025,6 @@ msgstr "记录"
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8767,14 +8040,12 @@ msgstr "未指明交易日期!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8813,7 +8084,6 @@ msgstr "翻译"
 msgid "Translations saved!"
 msgstr "巳储存翻译"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "试算表"
@@ -8822,7 +8092,6 @@ msgstr "试算表"
 msgid "Trillion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8879,10 +8148,6 @@ msgstr ""
 msgid "Two"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8917,39 +8182,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8968,43 +8227,37 @@ msgstr "单位"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9012,23 +8265,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9045,7 +8293,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9073,21 +8320,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9096,7 +8338,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9114,24 +8355,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9141,7 +8377,6 @@ msgstr "使用者"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9162,7 +8397,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9188,8 +8422,6 @@ msgstr "有效至"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9199,11 +8431,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9219,7 +8447,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "供应商"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9233,7 +8460,6 @@ msgstr "供应商历史"
 msgid "Vendor Invoice"
 msgstr "供应商发票"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
@@ -9243,9 +8469,6 @@ msgstr ""
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9275,9 +8498,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "未指明供应商"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9285,8 +8506,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "档案没有此供应商"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9301,7 +8520,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9314,7 +8532,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9337,7 +8554,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "仓库"
@@ -9346,11 +8562,26 @@ msgstr "仓库"
 msgid "Warning!"
 msgstr "警告"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9360,7 +8591,6 @@ msgstr ""
 msgid "Week"
 msgstr "周"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9377,13 +8607,11 @@ msgstr ""
 msgid "Weeks"
 msgstr "周"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "重量"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "重量单位"
@@ -9400,7 +8628,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9418,11 +8645,11 @@ msgstr "工作单"
 msgid "Work order"
 msgstr "工作单"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9465,15 +8692,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "是"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9500,7 +8722,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9564,17 +8786,12 @@ msgstr "日"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9591,7 +8808,7 @@ msgstr ""
 msgid "done"
 msgstr "完成"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9619,8 +8836,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9629,22 +8844,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9669,7 +8880,6 @@ msgstr ""
 msgid "sent"
 msgstr "巳送出"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9694,8 +8904,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr "意外错误!"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/locale/po/zh_TW.po
+++ b/locale/po/zh_TW.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2020-12-20 13:40+0000\n"
+"POT-Creation-Date: 2020-12-20 15:04+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Chinese (Taiwan) (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,27 +15,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:174
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
 msgid "# Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:115
 msgid "% Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:99
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:107
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:111
 msgid "(=) NBV"
 msgstr ""
@@ -48,12 +43,8 @@ msgstr ""
 msgid "--TEMPLATE--"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:385
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:406
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:605
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:626 lib/LedgerSMB/Upgrade_Tests.pm:385
-#: lib/LedgerSMB/Upgrade_Tests.pm:406 lib/LedgerSMB/Upgrade_Tests.pm:605
-#: lib/LedgerSMB/Upgrade_Tests.pm:626
+#: lib/LedgerSMB/Upgrade_Tests.pm:385 lib/LedgerSMB/Upgrade_Tests.pm:406
+#: lib/LedgerSMB/Upgrade_Tests.pm:605 lib/LedgerSMB/Upgrade_Tests.pm:626
 msgid "."
 msgstr ""
 
@@ -99,7 +90,6 @@ msgstr "應付帳款"
 msgid "AP Aging"
 msgstr "應付帳齡分析"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:113
 msgid "AP Invoice"
 msgstr ""
@@ -108,7 +98,6 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
@@ -123,7 +112,6 @@ msgstr "應付未付"
 msgid "AP Transaction"
 msgstr "應付交易"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:131
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:131
 msgid "AP Transactions"
 msgstr "應付交易"
@@ -136,9 +124,7 @@ msgstr ""
 msgid "AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:404
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:624 lib/LedgerSMB/Upgrade_Tests.pm:404
-#: lib/LedgerSMB/Upgrade_Tests.pm:624
+#: lib/LedgerSMB/Upgrade_Tests.pm:404 lib/LedgerSMB/Upgrade_Tests.pm:624
 msgid "AP account available when vendors defined"
 msgstr ""
 
@@ -157,7 +143,6 @@ msgstr "應收帳款"
 msgid "AR Aging"
 msgstr "應收帳齡分析"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:109
 msgid "AR Invoice"
 msgstr ""
@@ -166,7 +151,6 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
@@ -181,7 +165,6 @@ msgstr "應收未收"
 msgid "AR Transaction"
 msgstr "應收交易"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:133
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:133
 msgid "AR Transactions"
 msgstr "應收交易"
@@ -194,9 +177,7 @@ msgstr ""
 msgid "AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:383
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:603 lib/LedgerSMB/Upgrade_Tests.pm:383
-#: lib/LedgerSMB/Upgrade_Tests.pm:603
+#: lib/LedgerSMB/Upgrade_Tests.pm:383 lib/LedgerSMB/Upgrade_Tests.pm:603
 msgid "AR account available when customers defined"
 msgstr ""
 
@@ -205,8 +186,6 @@ msgstr ""
 msgid "AR transaction"
 msgstr "應收交易"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:116
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
 msgid "AR/AP/GL Amount"
@@ -216,16 +195,11 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:442 UI/pod/src/LedgerSMB.pm:443
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:355 lib/LedgerSMB.pm:440
-#: lib/LedgerSMB.pm:441 lib/LedgerSMB/Scripts/configuration.pm:355
+#: lib/LedgerSMB.pm:442 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB/Scripts/configuration.pm:355
 msgid "Access Denied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:70
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
@@ -251,38 +225,20 @@ msgstr ""
 msgid "Account"
 msgstr "帳戶"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:161
 #: lib/LedgerSMB/Report/Trial_Balance.pm:161
 #: UI/payments/use_overpayment2.html:122
 msgid "Account Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:80
 #: lib/LedgerSMB/Report/Budget/Variance.pm:80
 msgid "Account Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:160 lib/LedgerSMB/Report/GL.pm:160
-#: UI/Reports/co/filter_bm.html:84 UI/Reports/co/filter_cd.html:68
-#: UI/Reports/filters/gl.html:286
+#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:129
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:76
-#: UI/pod/src/LedgerSMB/Report/COA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:151
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:62
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:147
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:107
-#: UI/pod/src/LedgerSMB/Report/GL.pm:155 UI/pod/src/LedgerSMB/Report/GL.pm:219
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:186
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:88
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:117
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:87
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:82
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:155
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:183
 #: lib/LedgerSMB/Report/Budget/Search.pm:129
 #: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
 #: lib/LedgerSMB/Report/Contact/History.pm:151
@@ -303,23 +259,18 @@ msgstr ""
 msgid "Account Number"
 msgstr "帳戶編號"
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:135
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:135
 msgid "Account Number End"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:133
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:133
 msgid "Account Number Start"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:188
 #: lib/LedgerSMB/Scripts/payment.pm:188
 msgid "Account Title"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:78
 #: lib/LedgerSMB/Report/Taxform/Details.pm:83
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:78 UI/accounts/edit.html:209
 msgid "Account Type"
@@ -359,17 +310,15 @@ msgstr ""
 msgid "Accounts To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:684 lib/LedgerSMB/Upgrade_Tests.pm:684
+#: lib/LedgerSMB/Upgrade_Tests.pm:684
 msgid "Accounts marked for recon -- once"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:700 lib/LedgerSMB/Upgrade_Tests.pm:700
+#: lib/LedgerSMB/Upgrade_Tests.pm:700
 msgid "Accounts marked for recon exist"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:785
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:785
-#: lib/LedgerSMB/Upgrade_Tests.pm:988
+#: lib/LedgerSMB/Upgrade_Tests.pm:785 lib/LedgerSMB/Upgrade_Tests.pm:988
 msgid "Accounts without heading"
 msgstr ""
 
@@ -381,7 +330,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:816 lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -409,12 +358,10 @@ msgstr "生效的"
 msgid "Active On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:72 lib/LedgerSMB/Scripts/admin.pm:72
+#: lib/LedgerSMB/Scripts/admin.pm:72
 msgid "Active Sessions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:96
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:84
 #: lib/LedgerSMB/Report/File/Incoming.pm:96
 #: lib/LedgerSMB/Report/File/Internal.pm:84 old/bin/ic.pl:2086
 #: UI/Configuration/currency.html:35 UI/Configuration/ratetype.html:28
@@ -437,11 +384,11 @@ msgstr ""
 msgid "Add Assembly"
 msgstr "新增製成品"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:156 lib/LedgerSMB/Scripts/asset.pm:156
+#: lib/LedgerSMB/Scripts/asset.pm:156
 msgid "Add Asset"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:55 lib/LedgerSMB/Scripts/asset.pm:55
+#: lib/LedgerSMB/Scripts/asset.pm:55
 msgid "Add Asset Class"
 msgstr ""
 
@@ -566,7 +513,6 @@ msgstr "新增銷貨單"
 msgid "Add Service"
 msgstr "新增服務"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:80
 #: lib/LedgerSMB/Report/Taxform/List.pm:80 sql/Pg-database.sql:2656
 msgid "Add Tax Form"
 msgstr ""
@@ -633,7 +579,6 @@ msgstr ""
 msgid "Add/Update"
 msgstr "更新"
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:178
 #: lib/LedgerSMB/Scripts/business_unit.pm:178
 msgid "Added id [_1]"
 msgstr ""
@@ -658,7 +603,6 @@ msgstr ""
 msgid "Address: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:192
 #: lib/LedgerSMB/Scripts/contact.pm:192 UI/Contact/divs/address.html:2
 #: t/data/04-complex_template.html:30
 msgid "Addresses"
@@ -668,12 +612,11 @@ msgstr ""
 msgid "Adj"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:142
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:142
 msgid "Adjusted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:822 lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:822
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -693,8 +636,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:182 lib/LedgerSMB/Report/Aging.pm:182
-#: UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:182 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -747,7 +689,6 @@ msgstr ""
 msgid "All prices in [_1]."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:127
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:127 UI/timecards/timecard.html:132
 msgid "Allocated"
 msgstr ""
@@ -756,11 +697,6 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:229
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:281
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:225
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:129
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
@@ -794,14 +730,10 @@ msgstr ""
 msgid "Amount"
 msgstr "金額"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:85
 #: lib/LedgerSMB/Report/Budget/Variance.pm:85
 msgid "Amount Budgetted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:249
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:940
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:945
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
 #: lib/LedgerSMB/Scripts/payment.pm:940 lib/LedgerSMB/Scripts/payment.pm:945
 #: UI/Reports/filters/invoice_outstanding.html:240
@@ -810,27 +742,21 @@ msgstr ""
 msgid "Amount Due"
 msgstr "到期金額"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:108
 #: UI/Reports/filters/reconciliation_search.html:31
 msgid "Amount From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:153
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
 msgid "Amount Greater Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:155
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
 msgid "Amount Less Than"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:109
 #: UI/Reports/filters/reconciliation_search.html:39
 msgid "Amount To"
@@ -848,14 +774,14 @@ msgstr ""
 msgid "Amount/Rate"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:970 lib/LedgerSMB/Upgrade_Tests.pm:970
+#: lib/LedgerSMB/Upgrade_Tests.pm:970
 msgid ""
 "An account can either be a summary account (which have a# link of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having any# number of \"AR_*"
 "\", \"AP_*\" and/or \"IC_*\" links concatenated by colons (:)."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:767 lib/LedgerSMB/Upgrade_Tests.pm:767
+#: lib/LedgerSMB/Upgrade_Tests.pm:767
 msgid ""
 "An account can either be a summary account (which have alink of \"AR\", \"AP"
 "\" or \"IC\" value) or be linked to dropdowns (having anynumber of \"AR_*\", "
@@ -874,17 +800,14 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1356
 #: lib/LedgerSMB/Scripts/payment.pm:1356
 msgid "Applied discount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2013
 #: lib/LedgerSMB/Scripts/payment.pm:2013
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:938
 #: lib/LedgerSMB/Scripts/payment.pm:938
 msgid "Apply Disc"
 msgstr ""
@@ -893,13 +816,6 @@ msgstr ""
 msgid "Approval Status"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:529
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:643
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:744
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:849
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:113
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
 #: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
@@ -908,7 +824,6 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:148
 #: UI/Reports/filters/batches.html:28 UI/Reports/filters/gl.html:176
 #: UI/Reports/filters/invoice_search.html:228
@@ -917,14 +832,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:96
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:160
 #: lib/LedgerSMB/Report/Budget/Search.pm:96
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:487 lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:487
 msgid "Approved at"
 msgstr ""
 
@@ -936,19 +849,16 @@ msgstr ""
 msgid "Apr"
 msgstr "四月"
 
-#: UI/pod/src/LedgerSMB.pm:524 lib/LedgerSMB.pm:522 old/bin/aa.pl:71
-#: old/bin/gl.pl:66 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:524 old/bin/aa.pl:71 old/bin/gl.pl:66 old/bin/io.pl:66
 msgid "April"
 msgstr "四月"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:578
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:687
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:810 lib/LedgerSMB/Scripts/asset.pm:578
-#: lib/LedgerSMB/Scripts/asset.pm:687 lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:716 lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:716
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -964,7 +874,6 @@ msgstr "您是否確定要刪除報價單編號"
 msgid "As per"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:137
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:137
 msgid "Assembled"
 msgstr ""
@@ -983,19 +892,17 @@ msgstr "製成品已重新進貨"
 msgid "Asset"
 msgstr "資產"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:81
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:81 UI/asset/edit_asset.html:154
 #: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
 #: UI/asset/search_class.html:44
 msgid "Asset Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:476 lib/LedgerSMB/Scripts/asset.pm:476
-#: UI/asset/begin_approval.html:14 UI/asset/begin_report.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:114
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:114
 msgid "Asset Class List"
 msgstr ""
@@ -1008,29 +915,26 @@ msgstr ""
 msgid "Asset Classes"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:362 lib/LedgerSMB/Scripts/asset.pm:362
+#: lib/LedgerSMB/Scripts/asset.pm:362
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:364 lib/LedgerSMB/Scripts/asset.pm:364
+#: lib/LedgerSMB/Scripts/asset.pm:364
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:144
 #: lib/LedgerSMB/Report/Listings/Asset.pm:144
 msgid "Asset Listing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:381 lib/LedgerSMB/Scripts/asset.pm:381
+#: lib/LedgerSMB/Scripts/asset.pm:381
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:326 lib/LedgerSMB/Scripts/asset.pm:326
+#: lib/LedgerSMB/Scripts/asset.pm:326
 msgid "Asset Tag"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:207
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:199
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:199
 #: sql/Pg-database.sql:2669
 msgid "Assets"
@@ -1046,7 +950,6 @@ msgstr ""
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:102
 #: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1097
 #: old/bin/ic.pl:921 old/bin/ir.pl:1011 old/bin/is.pl:1121 old/bin/oe.pl:933
 #: UI/journal/journal_entry.html:408
@@ -1144,8 +1047,7 @@ msgstr ""
 msgid "Aug"
 msgstr "八月"
 
-#: UI/pod/src/LedgerSMB.pm:528 lib/LedgerSMB.pm:526 old/bin/aa.pl:75
-#: old/bin/gl.pl:70 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:528 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:70
 msgid "August"
 msgstr "八月"
 
@@ -1157,7 +1059,6 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:149
 #: UI/payments/use_overpayment2.html:123
 msgid "Available"
@@ -1171,7 +1072,6 @@ msgstr ""
 msgid "Available Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:217
 #: lib/LedgerSMB/Scripts/currency.pm:217
 msgid "Available exchange rates"
 msgstr ""
@@ -1184,7 +1084,6 @@ msgstr ""
 msgid "Average Cost"
 msgstr "平均成本"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:241
 #: lib/LedgerSMB/Report/Inventory/Search.pm:241
 msgid "Avg. Cost"
 msgstr ""
@@ -1218,8 +1117,6 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:170
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:147
 #: templates/demo/invoice.tex:175 templates/xedemo/invoice.html:147
@@ -1234,7 +1131,6 @@ msgstr "餘額"
 msgid "Balance Sheet"
 msgstr "資產負債表"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:299
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:299 UI/templates/widget.html:33
 msgid "Balance sheet"
 msgstr ""
@@ -1255,7 +1151,6 @@ msgstr ""
 msgid "Bank Account:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:194
 #: lib/LedgerSMB/Scripts/contact.pm:194 UI/Contact/divs/bank_act.html:2
 #: UI/Contact/divs/bank_act.html:6 t/data/04-complex_template.html:32
 #: t/data/04-complex_template.html:554
@@ -1266,7 +1161,6 @@ msgstr ""
 msgid "Bar Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:57
 #: lib/LedgerSMB/Scripts/configuration.pm:57
 #, fuzzy
 msgid "Base Currency"
@@ -1276,18 +1170,15 @@ msgstr "幣別"
 msgid "Base system"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:95
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:655
 #: old/bin/is.pl:758
 msgid "Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 msgid "Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
 msgid "Batch Class"
 msgstr ""
@@ -1300,12 +1191,10 @@ msgstr ""
 msgid "Batch Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:145
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:145
 msgid "Batch Description"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:158
 msgid "Batch ID"
 msgstr ""
@@ -1322,13 +1211,11 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
 msgid "Batch Search"
 msgstr ""
@@ -1369,8 +1256,6 @@ msgstr ""
 msgid "Billion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:137
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:217
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:217 old/bin/ic.pl:2079
 #: old/bin/ic.pl:485 old/bin/io.pl:240 old/bin/oe.pl:1839
@@ -1417,17 +1302,14 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:119
 #: lib/LedgerSMB/Report/Budget/Variance.pm:119
 msgid "Budget Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:113
 #: lib/LedgerSMB/Report/Budget/Search.pm:113
 msgid "Budget Search Results"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:107
 msgid "Budget Variance Report"
 msgstr ""
@@ -1440,12 +1322,10 @@ msgstr ""
 msgid "Business"
 msgstr "業務"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:43
 #: lib/LedgerSMB/Scripts/configuration.pm:43
 msgid "Business Number"
 msgstr "業務編號"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
@@ -1455,12 +1335,10 @@ msgstr ""
 msgid "Business Type:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:83
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:83
 msgid "Business Unit List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:123
 #: lib/LedgerSMB/Scripts/configuration.pm:123
 msgid "Business Unit Number"
 msgstr ""
@@ -1482,7 +1360,6 @@ msgstr "已儲存業務！"
 msgid "CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:132
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:132 old/bin/ic.pl:522 old/bin/ic.pl:691
 #: UI/accounts/edit.html:435
 msgid "COGS"
@@ -1514,18 +1391,16 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:186
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:232 lib/LedgerSMB/Scripts/setup.pm:186
-#: lib/LedgerSMB/Scripts/setup.pm:232 old/bin/io.pl:1808
-#: UI/templates/widget.html:146 UI/templates/widget.html:162
+#: lib/LedgerSMB/Scripts/setup.pm:186 lib/LedgerSMB/Scripts/setup.pm:232
+#: old/bin/io.pl:1808 UI/templates/widget.html:146 UI/templates/widget.html:162
 msgid "Cancel"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:218 lib/LedgerSMB/Upgrade_Tests.pm:218
+#: lib/LedgerSMB/Upgrade_Tests.pm:218
 msgid "Cancel the <b>whole migration</b>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:284 lib/LedgerSMB/Scripts/setup.pm:284
+#: lib/LedgerSMB/Scripts/setup.pm:284
 msgid "Cancel?"
 msgstr ""
 
@@ -1651,12 +1526,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:150 lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:150
 msgid "Chart ID"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:139 lib/LedgerSMB/Report/COA.pm:139
-#: sql/Pg-database.sql:2574
+#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2574
 msgid "Chart of Accounts"
 msgstr "會計科目表"
 
@@ -1676,7 +1550,6 @@ msgstr ""
 msgid "Check Inventory"
 msgstr "檢查存貨清單"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:135
 #: lib/LedgerSMB/Scripts/configuration.pm:135
 msgid "Check Prefix"
 msgstr ""
@@ -1705,7 +1578,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:476 lib/LedgerSMB/Scripts/recon.pm:476
+#: lib/LedgerSMB/Scripts/recon.pm:476
 msgid "Clear date"
 msgstr ""
 
@@ -1717,9 +1590,9 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:140 lib/LedgerSMB/Report/GL.pm:140
-#: UI/Reports/filters/gl.html:259 UI/reconciliation/report.html:115
-#: UI/reconciliation/report.html:235 UI/reconciliation/report.html:295
+#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: UI/reconciliation/report.html:115 UI/reconciliation/report.html:235
+#: UI/reconciliation/report.html:295
 msgid "Cleared"
 msgstr "已清除"
 
@@ -1747,15 +1620,13 @@ msgstr ""
 msgid "Close books"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:234 lib/LedgerSMB/Report/Orders.pm:234
-#: old/bin/oe.pl:321 UI/Reports/filters/invoice_search.html:214
-#: UI/Reports/filters/orders.html:100
+#: lib/LedgerSMB/Report/Orders.pm:234 old/bin/oe.pl:321
+#: UI/Reports/filters/invoice_search.html:214 UI/Reports/filters/orders.html:100
 #: UI/Reports/filters/purchase_history.html:209
 #: UI/Reports/filters/timecards.html:35
 msgid "Closed"
 msgstr "已關閉"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:276
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:276
 #, fuzzy
 msgid "Closing Balance"
@@ -1769,8 +1640,6 @@ msgstr ""
 msgid "Closing data"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:49
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:47
 #: lib/LedgerSMB/Report/Listings/Language.pm:49
 #: lib/LedgerSMB/Report/Listings/SIC.pm:47 UI/am-language-form.html:11
 #: UI/am-sic-form.html:11
@@ -1785,22 +1654,18 @@ msgstr "未指明編碼！"
 msgid "Cold Lead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:116 lib/LedgerSMB/Scripts/order.pm:116
-#: sql/Pg-database.sql:2647
+#: lib/LedgerSMB/Scripts/order.pm:116 sql/Pg-database.sql:2647
 msgid "Combine"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:76 lib/LedgerSMB/Scripts/order.pm:76
+#: lib/LedgerSMB/Scripts/order.pm:76
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:68 lib/LedgerSMB/Scripts/order.pm:68
+#: lib/LedgerSMB/Scripts/order.pm:68
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:79
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:74
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:186
 #: lib/LedgerSMB/Report/Taxform/Details.pm:79
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
@@ -1812,39 +1677,31 @@ msgstr ""
 msgid "Company"
 msgstr "公司"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:40
 #: lib/LedgerSMB/Scripts/configuration.pm:40
 msgid "Company Address"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:42
 #: lib/LedgerSMB/Scripts/configuration.pm:42
 msgid "Company Fax"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:35
 #: lib/LedgerSMB/Scripts/configuration.pm:35
 msgid "Company Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:55
 #: lib/LedgerSMB/Scripts/configuration.pm:55
 msgid "Company License Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:142
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:37
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:37
 msgid "Company Name"
 msgstr "公司名稱"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:41
 #: lib/LedgerSMB/Scripts/configuration.pm:41
 msgid "Company Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:53
 #: lib/LedgerSMB/Scripts/configuration.pm:53
 msgid "Company Sales Tax ID"
 msgstr ""
@@ -1865,7 +1722,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "入帳成功！"
 
-#: UI/pod/src/LedgerSMB.pm:448 lib/LedgerSMB.pm:446
+#: lib/LedgerSMB.pm:448
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1883,7 +1740,6 @@ msgstr ""
 msgid "Contact"
 msgstr "連絡人"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:193
 #: lib/LedgerSMB/Scripts/contact.pm:193 UI/Contact/divs/contact_info.html:2
 #: UI/Contact/divs/contact_info.html:31 UI/Contact/divs/contact_info.html:111
 #: UI/Reports/filters/purchase_history.html:28
@@ -1899,7 +1755,6 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:94
 #: lib/LedgerSMB/Report/Contact/Search.pm:94
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
@@ -1917,9 +1772,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1559
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:770
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:832
 #: lib/LedgerSMB/Scripts/payment.pm:1559 lib/LedgerSMB/Scripts/payment.pm:770
 #: lib/LedgerSMB/Scripts/payment.pm:832 old/bin/arap.pl:263 old/bin/ic.pl:1753
 #: old/bin/ic.pl:2034 old/bin/ic.pl:2183 old/bin/ic.pl:948 old/bin/io.pl:1094
@@ -1949,7 +1801,6 @@ msgstr ""
 msgid "Contra"
 msgstr "相反"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1128
 #: lib/LedgerSMB/Upgrade_Tests.pm:1128
 msgid ""
 "Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
@@ -1957,10 +1808,6 @@ msgid ""
 "are presented by pairs, with a suffix added to the invoice number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:67
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:59
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:90
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:86
 #: lib/LedgerSMB/Report/Contact/Search.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
@@ -1991,20 +1838,16 @@ msgstr ""
 msgid "Copy to New Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:127
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1015
 #: old/bin/ic.pl:1259 old/bin/oe.pl:2390
 msgid "Cost"
 msgstr "成本"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:103
 #: lib/LedgerSMB/Scripts/configuration.pm:103
 msgid "Cost of Goods Sold"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Template/DB.pm:127
-#: UI/pod/src/LedgerSMB/Template/DB.pm:77 lib/LedgerSMB/Template/DB.pm:127
-#: lib/LedgerSMB/Template/DB.pm:77
+#: lib/LedgerSMB/Template/DB.pm:127 lib/LedgerSMB/Template/DB.pm:77
 msgid "Could Not Load Template from DB"
 msgstr ""
 
@@ -2020,26 +1863,20 @@ msgstr "不能儲存！"
 msgid "Could not transfer Inventory!"
 msgstr "存貨清單不能轉移！"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:101
 #: UI/inventory/adjustment_entry.html:26
 msgid "Counted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:137
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:102
 msgid "Counterparty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:105
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Counterparty Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1636
 #: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:192
@@ -2051,7 +1888,6 @@ msgstr ""
 msgid "Country"
 msgstr "國家"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:55
 #: lib/LedgerSMB/Report/Taxform/List.pm:55
 msgid "Country Name"
 msgstr ""
@@ -2064,7 +1900,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:196 lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:196
 msgid "Create Account"
 msgstr ""
 
@@ -2072,11 +1908,11 @@ msgstr ""
 msgid "Create Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:265 lib/LedgerSMB/Scripts/setup.pm:265
+#: lib/LedgerSMB/Scripts/setup.pm:265
 msgid "Create Database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:203 lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:203
 msgid "Create Heading"
 msgstr ""
 
@@ -2104,8 +1940,6 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:92
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
@@ -2113,17 +1947,14 @@ msgstr ""
 msgid "Credit"
 msgstr "貸方"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:298
 #: lib/LedgerSMB/Scripts/contact.pm:298
 msgid "Credit Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:72
 #: lib/LedgerSMB/Report/Contact/Search.pm:72
 msgid "Credit Account Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:191
 #: lib/LedgerSMB/Scripts/contact.pm:191 UI/Contact/divs/credit.html:2
 msgid "Credit Accounts"
 msgstr ""
@@ -2148,29 +1979,19 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:112 UI/pod/src/LedgerSMB/Report/GL.pm:124
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:185
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:210 lib/LedgerSMB/Report/COA.pm:112
-#: lib/LedgerSMB/Report/GL.pm:124 lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
 #: lib/LedgerSMB/Scripts/payment.pm:210 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:156 UI/reconciliation/report.html:158
 msgid "Credits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:254
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:278
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1004
 #: old/bin/ic.pl:1098 old/bin/oe.pl:2395
 msgid "Curr"
 msgstr "目前"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:74
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:80
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:84
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:293
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:230
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:240
 #: lib/LedgerSMB/Report/Contact/History.pm:74
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:80
 #: lib/LedgerSMB/Report/Contact/Search.pm:84
@@ -2193,18 +2014,14 @@ msgstr "目前"
 msgid "Currency"
 msgstr "幣別"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:131 lib/LedgerSMB/Report/Aging.pm:131
-#: old/bin/pe.pl:816 UI/Reports/co/filter_bm.html:52
-#: UI/Reports/filters/aging.html:98 UI/lib/report_base.html:159
-#: UI/lib/report_base.html:252 templates/demo/statement.html:55
-#: templates/demo/statement.tex:34 templates/xedemo/statement.html:55
-#: templates/xedemo/statement.tex:32
+#: lib/LedgerSMB/Report/Aging.pm:131 old/bin/pe.pl:816
+#: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
+#: UI/lib/report_base.html:159 UI/lib/report_base.html:252
+#: templates/demo/statement.html:55 templates/demo/statement.tex:34
+#: templates/xedemo/statement.html:55 templates/xedemo/statement.tex:32
 msgid "Current"
 msgstr "現有"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:234
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:215
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:94
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:234 lib/LedgerSMB/Report/PNL.pm:215
 #: lib/LedgerSMB/Scripts/configuration.pm:94
 msgid "Current earnings"
@@ -2214,11 +2031,7 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:189
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:251
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:179
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:185 lib/LedgerSMB/Report/Aging.pm:85
+#: lib/LedgerSMB/Report/Aging.pm:85
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
@@ -2233,7 +2046,6 @@ msgstr ""
 msgid "Customer"
 msgstr "客戶"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:250
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
 msgid "Customer Account"
 msgstr ""
@@ -2252,9 +2064,6 @@ msgstr "沒有此客戶的記錄！"
 msgid "Customer Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:117
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:180
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:125
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
 #: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/io.pl:1574
@@ -2274,9 +2083,7 @@ msgstr ""
 msgid "Customer missing!"
 msgstr "未指明客戶！"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:881
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:927 lib/LedgerSMB/Upgrade_Tests.pm:881
-#: lib/LedgerSMB/Upgrade_Tests.pm:927
+#: lib/LedgerSMB/Upgrade_Tests.pm:881 lib/LedgerSMB/Upgrade_Tests.pm:927
 msgid "Customer not in a business"
 msgstr ""
 
@@ -2288,7 +2095,7 @@ msgstr "沒有此客戶的記錄！"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:805 lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:805
 msgid "D M"
 msgstr ""
 
@@ -2312,12 +2119,11 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:416
 #: lib/LedgerSMB/Scripts/payment.pm:416 old/bin/aa.pl:1293
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:151 lib/LedgerSMB/Scripts/recon.pm:151
+#: lib/LedgerSMB/Scripts/recon.pm:151
 msgid "Data not saved.  Please update again."
 msgstr ""
 
@@ -2350,28 +2156,16 @@ msgstr ""
 msgid "Database component"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:264 lib/LedgerSMB/Scripts/setup.pm:264
+#: lib/LedgerSMB/Scripts/setup.pm:264
 msgid "Database does not exist."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:977 lib/LedgerSMB/Scripts/setup.pm:977
+#: lib/LedgerSMB/Scripts/setup.pm:977
 msgid "Database exists."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:119 UI/pod/src/LedgerSMB/Report/GL.pm:92
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:145
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:199
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:259
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:141
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:204
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:113
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:465
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:193
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:934 lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/GL.pm:92 lib/LedgerSMB/Report/Inventory/History.pm:145
+#: lib/LedgerSMB/Report/Aging.pm:119 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
@@ -2418,19 +2212,14 @@ msgstr ""
 msgid "Date"
 msgstr "日期"
 
-#: UI/users/preferences.html:67
+#: UI/users/preferences.html:80
 msgid "Date Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:106
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:106 old/bin/ic.pl:940
 msgid "Date From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:104
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:258
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:129
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:104
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
@@ -2452,7 +2241,6 @@ msgstr "收款日期"
 msgid "Date Reversed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:107
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:107 old/bin/ic.pl:943
 msgid "Date To"
 msgstr ""
@@ -2516,8 +2304,6 @@ msgstr "日"
 msgid "Days"
 msgstr "日"
 
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:86
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
@@ -2533,10 +2319,8 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:105 UI/pod/src/LedgerSMB/Report/GL.pm:118
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:179
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:204 lib/LedgerSMB/Report/COA.pm:105
-#: lib/LedgerSMB/Report/GL.pm:118 lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
 #: lib/LedgerSMB/Scripts/payment.pm:204 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:155 UI/reconciliation/report.html:157
 msgid "Debits"
@@ -2546,17 +2330,14 @@ msgstr ""
 msgid "Dec"
 msgstr "十二月"
 
-#: UI/pod/src/LedgerSMB.pm:532 lib/LedgerSMB.pm:530 old/bin/aa.pl:79
-#: old/bin/gl.pl:74 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:532 old/bin/aa.pl:79 old/bin/gl.pl:74 old/bin/io.pl:74
 msgid "December"
 msgstr "十二月"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:140
 #: lib/LedgerSMB/Scripts/configuration.pm:140
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
 #: UI/payroll/deduction.html:28
 msgid "Deduction Class"
@@ -2566,7 +2347,6 @@ msgstr ""
 msgid "Deduction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:53
 msgid "Deduction Types"
 msgstr ""
@@ -2579,47 +2359,38 @@ msgstr ""
 msgid "Default AR"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:90
 #: lib/LedgerSMB/Scripts/configuration.pm:90
 msgid "Default Accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:61
 #: lib/LedgerSMB/Scripts/configuration.pm:61 UI/setup/upgrade_info.html:43
 msgid "Default Country"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:49
 #: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Email BCC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:47
 #: lib/LedgerSMB/Scripts/configuration.pm:47
 msgid "Default Email CC"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:51
 #: lib/LedgerSMB/Scripts/configuration.pm:51
 msgid "Default Email From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:45
 #: lib/LedgerSMB/Scripts/configuration.pm:45
 msgid "Default Email To"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:68
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Default Format"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:64
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Default Language"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:59
 #: lib/LedgerSMB/Report/Taxform/List.pm:59
 msgid "Default Reportable"
 msgstr ""
@@ -2632,21 +2403,14 @@ msgstr ""
 msgid "Defaults"
 msgstr "預設"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:79
 #: lib/LedgerSMB/Scripts/currency.pm:79
 msgid "Defined currencies"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:164
 #: lib/LedgerSMB/Scripts/currency.pm:164
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:124 UI/pod/src/LedgerSMB/Report/COA.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:131
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:235
 #: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
@@ -2664,7 +2428,6 @@ msgstr ""
 msgid "Delete"
 msgstr "刪除"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:201
 msgid "Delete Batch"
 msgstr ""
@@ -2677,7 +2440,6 @@ msgstr ""
 msgid "Delete Schedule"
 msgstr "刪除時間表"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:208
 msgid "Delete Vouchers"
 msgstr ""
@@ -2691,37 +2453,33 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:108
 #: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:259
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "到期日"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:595 lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:595
 msgid "Dep. Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:584
 msgid "Dep. Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:572
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:681
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:793 lib/LedgerSMB/Scripts/asset.pm:572
-#: lib/LedgerSMB/Scripts/asset.pm:681 lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
+#: lib/LedgerSMB/Scripts/asset.pm:793
 msgid "Dep. Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:103
 msgid "Dep. Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:619 lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:619
 msgid "Dep. YTD"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:613 lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:613
 msgid "Dep. this run"
 msgstr ""
 
@@ -2743,20 +2501,17 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:512 lib/LedgerSMB/Scripts/asset.pm:512
-#: UI/accounts/edit.html:504 sql/Pg-database.sql:2679
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:504
+#: sql/Pg-database.sql:2679
 msgid "Depreciation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:84
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:84 UI/asset/edit_asset.html:167
 #: UI/asset/edit_class.html:48 UI/asset/search_asset.html:154
 #: UI/asset/search_class.html:55
 msgid "Depreciation Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:78
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:101
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78 UI/asset/edit_class.html:24
 #: UI/asset/search_class.html:20
@@ -2767,46 +2522,7 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:114
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:88
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:121
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:72
-#: UI/pod/src/LedgerSMB/Report/COA.pm:94
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:85
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:76
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:53
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:51
-#: UI/pod/src/LedgerSMB/Report/GL.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:166
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:98
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:125
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:201
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:129
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:94
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:50
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:63
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:52
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:53
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:51
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:97
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:46
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:79
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:106
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:93
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:124
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:76
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:331
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:693
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:788
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:138
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:53
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:135 lib/LedgerSMB/Report/Aging.pm:114
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
 #: lib/LedgerSMB/Report/Budget/Search.pm:88
 #: lib/LedgerSMB/Report/Budget/Variance.pm:121
@@ -2917,12 +2633,10 @@ msgstr "詳情"
 msgid "Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:73
 #: lib/LedgerSMB/Scripts/configuration.pm:73
 msgid "Disable Back Button"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:104
 #: lib/LedgerSMB/Report/Contact/History.pm:104
 msgid "Disc"
 msgstr ""
@@ -2935,7 +2649,6 @@ msgstr ""
 msgid "Disc %"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:937
 #: lib/LedgerSMB/Scripts/payment.pm:937 old/bin/ic.pl:1109
 #: UI/Contact/divs/credit.html:166 UI/Contact/divs/credit.html:167
 #: UI/Reports/filters/purchase_history.html:303 UI/accounts/edit.html:364
@@ -2944,7 +2657,6 @@ msgstr ""
 msgid "Discount"
 msgstr "折扣"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:57
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:57
 msgid "Discount (%)"
 msgstr ""
@@ -2953,28 +2665,28 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:704 lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:513 lib/LedgerSMB/Scripts/asset.pm:513
-#: sql/Pg-database.sql:2677 sql/Pg-database.sql:2680
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2677
+#: sql/Pg-database.sql:2680
 msgid "Disposal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:799 lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:799
 msgid "Disposal Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:368 lib/LedgerSMB/Scripts/asset.pm:368
+#: lib/LedgerSMB/Scripts/asset.pm:368
 msgid "Disposal Method"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:861 lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:445 lib/LedgerSMB.pm:443
+#: lib/LedgerSMB.pm:445
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2982,7 +2694,6 @@ msgstr ""
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:81
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:81
 msgid "Document"
 msgstr ""
@@ -2991,7 +2702,7 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:475 lib/LedgerSMB/Scripts/setup.pm:475
+#: lib/LedgerSMB/Scripts/setup.pm:475
 msgid "Don't know what to do with backup"
 msgstr ""
 
@@ -2999,12 +2710,10 @@ msgstr ""
 msgid "Done"
 msgstr "已完成"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1008
 #: lib/LedgerSMB/Upgrade_Tests.pm:1008
 msgid "Double customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1043
 #: lib/LedgerSMB/Upgrade_Tests.pm:1043
 msgid "Double vendornumbers"
 msgstr ""
@@ -3017,12 +2726,10 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:133
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
 msgid "Draft Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:145
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
 msgid "Draft Type"
 msgstr ""
@@ -3031,19 +2738,16 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:265
 #: lib/LedgerSMB/Report/Inventory/Search.pm:265 old/bin/ic.pl:501
 #: UI/Reports/filters/search_goods.html:106
 #: UI/Reports/filters/search_goods.html:387
 msgid "Drawing"
 msgstr "圖畫"
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:119 lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:119
 msgid "Dropdowns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:100
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:100
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:55 templates/demo/ap_transaction.tex:56
@@ -3059,10 +2763,6 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:124
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:108
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:262
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:299
 #: lib/LedgerSMB/Report/Aging.pm:124
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:108
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
@@ -3081,7 +2781,7 @@ msgstr "未指明到期日！"
 msgid "Duplicate User Found: Importing User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:492 lib/LedgerSMB/Upgrade_Tests.pm:492
+#: lib/LedgerSMB/Upgrade_Tests.pm:492
 msgid "Duplicate employee numbers"
 msgstr ""
 
@@ -3107,7 +2807,7 @@ msgstr "電子郵件訊息"
 msgid "E-mailed"
 msgstr "已電郵"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:77 lib/LedgerSMB/Report/PNL/ECA.pm:77
+#: lib/LedgerSMB/Report/PNL/ECA.pm:77
 msgid "ECA Income Statement"
 msgstr ""
 
@@ -3137,7 +2837,7 @@ msgstr "編輯應收交易"
 msgid "Edit Assembly"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:53 lib/LedgerSMB/Scripts/asset.pm:53
+#: lib/LedgerSMB/Scripts/asset.pm:53
 msgid "Edit Asset Class"
 msgstr ""
 
@@ -3281,8 +2981,6 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:254
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:188
 #: lib/LedgerSMB/Report/Orders.pm:254 lib/LedgerSMB/Scripts/contact.pm:188
 #: old/bin/aa.pl:486 old/bin/oe.pl:541 old/bin/pe.pl:861
 #: UI/Contact/divs/employee.html:2 UI/Reports/filters/contact_search.html:64
@@ -3296,7 +2994,6 @@ msgstr ""
 msgid "Employee"
 msgstr "職員"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:124
 #: lib/LedgerSMB/Scripts/configuration.pm:124 UI/Contact/divs/employee.html:132
 #: UI/setup/new_user.html:134 t/data/04-complex_template.html:92
 msgid "Employee Number"
@@ -3306,12 +3003,11 @@ msgstr "職員編號"
 msgid "Employee Search"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:474 lib/LedgerSMB/Upgrade_Tests.pm:474
+#: lib/LedgerSMB/Upgrade_Tests.pm:474
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:156
 #: lib/LedgerSMB/Scripts/configuration.pm:156
 #, fuzzy
 msgid "Employee wage screen"
@@ -3321,37 +3017,26 @@ msgstr "職員編號"
 msgid "Employees"
 msgstr "職員"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:726 lib/LedgerSMB/Upgrade_Tests.pm:726
+#: lib/LedgerSMB/Upgrade_Tests.pm:726
 msgid "Empty AP account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:715 lib/LedgerSMB/Upgrade_Tests.pm:715
+#: lib/LedgerSMB/Upgrade_Tests.pm:715
 msgid "Empty AR account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:824 lib/LedgerSMB/Upgrade_Tests.pm:824
+#: lib/LedgerSMB/Upgrade_Tests.pm:824
 msgid "Empty businesses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:801 lib/LedgerSMB/Upgrade_Tests.pm:801
+#: lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Empty customernumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1024
 #: lib/LedgerSMB/Upgrade_Tests.pm:1024
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:127
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:78
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:125
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:156
-#: UI/pod/src/LedgerSMB/Report/GL.pm:217
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:85
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:160
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:127
 #: lib/LedgerSMB/Report/Budget/Search.pm:78
 #: lib/LedgerSMB/Report/Budget/Variance.pm:125
@@ -3375,7 +3060,6 @@ msgstr ""
 msgid "Ending"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:191
 #: lib/LedgerSMB/Report/Trial_Balance.pm:191
 msgid "Ending Balance"
 msgstr ""
@@ -3400,12 +3084,10 @@ msgstr ""
 msgid "Enter User"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:460 lib/LedgerSMB/Upgrade_Tests.pm:460
+#: lib/LedgerSMB/Upgrade_Tests.pm:460
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:92
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:157
 #: lib/LedgerSMB/Report/Budget/Search.pm:92
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
@@ -3415,7 +3097,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:481 lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:481
 msgid "Entered at"
 msgstr ""
 
@@ -3423,7 +3105,6 @@ msgstr ""
 msgid "Entered at: [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:296
 #: lib/LedgerSMB/Scripts/contact.pm:296 sql/Pg-database.sql:1057
 msgid "Entity"
 msgstr ""
@@ -3449,7 +3130,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "公司名稱"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:113 lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:113
 msgid "Entry ID"
 msgstr ""
 
@@ -3461,14 +3142,11 @@ msgstr ""
 msgid "Environment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:227
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:209
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:227 lib/LedgerSMB/Report/PNL.pm:209
 #: UI/Reports/filters/gl.html:151 UI/accounts/edit.html:215
 msgid "Equity"
 msgstr "股權"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:213
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:213
 msgid "Equity & Liabilities"
 msgstr ""
@@ -3482,16 +3160,15 @@ msgstr ""
 msgid "Equity to Liabilities"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:431 lib/LedgerSMB/Scripts/setup.pm:431
+#: lib/LedgerSMB/Scripts/setup.pm:431
 msgid "Error creating backup file"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/vouchers.pm:128
 #: lib/LedgerSMB/Scripts/vouchers.pm:128
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:449 lib/LedgerSMB.pm:447
+#: lib/LedgerSMB.pm:449
 msgid "Error from Function:"
 msgstr ""
 
@@ -3499,7 +3176,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:589 lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:589
 msgid "Est. Life"
 msgstr ""
 
@@ -3512,8 +3189,6 @@ msgstr "每"
 msgid "Exch"
 msgstr "匯率"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:118
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:944
 #: lib/LedgerSMB/Report/Contact/History.pm:118
 #: lib/LedgerSMB/Scripts/payment.pm:944 old/bin/aa.pl:436 old/bin/ir.pl:331
 #: old/bin/is.pl:329 old/bin/oe.pl:1522 old/bin/oe.pl:342 old/bin/oe.pl:350
@@ -3528,7 +3203,6 @@ msgstr "匯率"
 msgid "Exchange rate for payment missing!"
 msgstr "未指明付款的匯率！"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1258
 #: lib/LedgerSMB/Scripts/payment.pm:1258
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
@@ -3537,7 +3211,6 @@ msgstr ""
 msgid "Exchange rate missing!"
 msgstr "未指明匯率！"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:104
 msgid "Expected"
 msgstr ""
@@ -3555,13 +3228,10 @@ msgstr ""
 msgid "Expense/Asset"
 msgstr "費用/資產"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:196
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:188
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:196 lib/LedgerSMB/Report/PNL.pm:188
 msgid "Expenses"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:153
 #: lib/LedgerSMB/Scripts/configuration.pm:153
 msgid "Experimental features"
 msgstr ""
@@ -3639,8 +3309,7 @@ msgstr ""
 msgid "Feb"
 msgstr "二月"
 
-#: UI/pod/src/LedgerSMB.pm:522 lib/LedgerSMB.pm:520 old/bin/aa.pl:69
-#: old/bin/gl.pl:64 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:522 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:64
 msgid "February"
 msgstr "二月"
 
@@ -3656,14 +3325,10 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:1063
 #: lib/LedgerSMB/Scripts/asset.pm:1063
 msgid "File Imported"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:50
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:53
 #: lib/LedgerSMB/Report/File/Incoming.pm:50
 #: lib/LedgerSMB/Report/File/Internal.pm:48
 #: lib/LedgerSMB/Report/Listings/Templates.pm:53
@@ -3674,11 +3339,11 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:134 lib/LedgerSMB/Scripts/file.pm:134
-#: old/bin/aa.pl:1047 old/bin/aa.pl:1066 old/bin/ic.pl:871 old/bin/ic.pl:890
-#: old/bin/ir.pl:963 old/bin/ir.pl:982 old/bin/is.pl:1073 old/bin/is.pl:1092
-#: old/bin/oe.pl:885 old/bin/oe.pl:904 UI/Contact/divs/files.html:9
-#: UI/journal/journal_entry.html:363 UI/journal/journal_entry.html:381
+#: lib/LedgerSMB/Scripts/file.pm:134 old/bin/aa.pl:1047 old/bin/aa.pl:1066
+#: old/bin/ic.pl:871 old/bin/ic.pl:890 old/bin/ir.pl:963 old/bin/ir.pl:982
+#: old/bin/is.pl:1073 old/bin/is.pl:1092 old/bin/oe.pl:885 old/bin/oe.pl:904
+#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:363
+#: UI/journal/journal_entry.html:381
 msgid "File name"
 msgstr ""
 
@@ -3689,7 +3354,6 @@ msgstr ""
 msgid "File type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:196
 #: lib/LedgerSMB/Scripts/contact.pm:196 UI/Contact/divs/files.html:2
 msgid "Files"
 msgstr ""
@@ -3747,12 +3411,10 @@ msgstr ""
 msgid "For"
 msgstr "重覆"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:106
 #: lib/LedgerSMB/Scripts/configuration.pm:106
 msgid "Foreign Exchange Gain"
 msgstr "外匯收益"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:109
 #: lib/LedgerSMB/Scripts/configuration.pm:109
 msgid "Foreign Exchange Loss"
 msgstr "外匯損失"
@@ -3761,12 +3423,10 @@ msgstr "外匯損失"
 msgid "Form"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:51
 #: lib/LedgerSMB/Report/Taxform/List.pm:51
 msgid "Form Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:57
 #: lib/LedgerSMB/Report/Listings/Templates.pm:57 UI/templates/widget.html:87
 msgid "Format"
 msgstr ""
@@ -3783,7 +3443,6 @@ msgstr ""
 msgid "Fourteen"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:130
 #: lib/LedgerSMB/Report/Timecards.pm:130
 msgid "Fri"
 msgstr ""
@@ -3802,18 +3461,10 @@ msgstr ""
 msgid "From"
 msgstr "從"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:186
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:186
 msgid "From Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:167
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:188
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:182
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:114
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:110
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:147
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:149
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:167
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
@@ -3834,7 +3485,6 @@ msgstr ""
 msgid "From Warehouse"
 msgstr "從貨倉"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:205
 #: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
@@ -3845,15 +3495,10 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1103
 #: lib/LedgerSMB/Scripts/setup.pm:1103
 msgid "Full Permissions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/COA.pm:100 UI/pod/src/LedgerSMB/Report/GL.pm:165
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:48
-#: UI/pod/src/LedgerSMB/Report/Listings/GIFI.pm:65
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:167
 #: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
@@ -3867,10 +3512,8 @@ msgstr ""
 msgid "GIFI"
 msgstr "財務訊息通用索引(GIFI)"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:585
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:647
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:666 lib/LedgerSMB/Upgrade_Tests.pm:585
-#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:666
+#: lib/LedgerSMB/Upgrade_Tests.pm:585 lib/LedgerSMB/Upgrade_Tests.pm:647
+#: lib/LedgerSMB/Upgrade_Tests.pm:666
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
@@ -3891,7 +3534,6 @@ msgstr "已儲存！"
 msgid "GL"
 msgstr "總帳"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:113
 #: lib/LedgerSMB/Scripts/configuration.pm:113
 msgid "GL Reference Number"
 msgstr "總帳索引編號"
@@ -3900,7 +3542,7 @@ msgstr "總帳索引編號"
 msgid "Gain"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:834 lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:834
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3908,11 +3550,10 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:723 lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:723
 msgid "Gain/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:87
 #: lib/LedgerSMB/Scripts/configuration.pm:87
 msgid "Gapless AR"
 msgstr ""
@@ -3921,7 +3562,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:203 lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:203
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3929,9 +3570,8 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:124 lib/LedgerSMB/Scripts/order.pm:124
-#: UI/Reports/aging_report.html:84 sql/Pg-database.sql:2563
-#: sql/Pg-database.sql:2601
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: sql/Pg-database.sql:2563 sql/Pg-database.sql:2601
 msgid "Generate"
 msgstr "生成"
 
@@ -3947,7 +3587,7 @@ msgstr "生成訂單"
 msgid "Generate Purchase Orders"
 msgstr "生成採購單"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:66 lib/LedgerSMB/Scripts/order.pm:66
+#: lib/LedgerSMB/Scripts/order.pm:66
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
@@ -3955,7 +3595,7 @@ msgstr ""
 msgid "Generate Sales Orders"
 msgstr "生成銷貨單"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:79 lib/LedgerSMB/Scripts/order.pm:79
+#: lib/LedgerSMB/Scripts/order.pm:79
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
@@ -3971,12 +3611,10 @@ msgstr ""
 msgid "Goods & Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:319
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 sql/Pg-database.sql:2705
 msgid "Goods and Services"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:180
 #: lib/LedgerSMB/Report/Inventory/History.pm:180
 msgid "Goods and Services History"
 msgstr ""
@@ -3985,7 +3623,6 @@ msgstr ""
 msgid "Grand Total"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1262
 #: old/bin/ic.pl:418 old/bin/io.pl:262 old/bin/oe.pl:2035 old/bin/oe.pl:2108
 #: old/bin/oe.pl:2143 old/bin/pe.pl:141 UI/io-email.html:86
@@ -4059,21 +3696,6 @@ msgstr ""
 msgid "Hundred"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:60
-#: UI/pod/src/LedgerSMB/Report/GL.pm:87
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:116
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:192
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:203
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:256
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:88
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:200
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:97
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:459
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
@@ -4104,7 +3726,6 @@ msgstr ""
 msgid "Identification"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:209
 #: lib/LedgerSMB/Report/Trial_Balance.pm:209
 #: UI/Reports/filters/trial_balance.html:68 UI/lib/report_base.html:86
 msgid "Ignore Year-ends"
@@ -4114,13 +3735,11 @@ msgstr ""
 msgid "Ignore year-closing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:261
 #: lib/LedgerSMB/Report/Inventory/Search.pm:261 old/bin/ic.pl:495
 #: UI/Reports/filters/search_goods.html:380
 msgid "Image"
 msgstr "影像"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:142
 #: lib/LedgerSMB/Scripts/configuration.pm:142
 msgid "Images in Templates"
 msgstr ""
@@ -4163,7 +3782,6 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:83
 msgid "In Svc"
 msgstr ""
@@ -4197,14 +3815,10 @@ msgstr "包含在下拉式選單中"
 msgid "Includes Part"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:87
 msgid "Including partnumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:201
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:194
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:100
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:201 lib/LedgerSMB/Report/PNL.pm:194
 #: lib/LedgerSMB/Scripts/configuration.pm:100 old/bin/ic.pl:518
 #: old/bin/ic.pl:651 UI/Reports/filters/gl.html:159 UI/accounts/edit.html:217
@@ -4212,12 +3826,10 @@ msgstr ""
 msgid "Income"
 msgstr "收入"
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:38
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38 UI/payroll/income.html:29
 msgid "Income Class"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:55
 #: UI/Reports/filters/income_statement.html:15 templates/demo/PNL.tex:28
 #: templates/xedemo/PNL.tex:28 sql/Pg-database.sql:2646
@@ -4228,7 +3840,6 @@ msgstr "損益表"
 msgid "Income Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:53
 #: lib/LedgerSMB/Report/Payroll/Income_Types.pm:53
 msgid "Income Types"
 msgstr ""
@@ -4238,7 +3849,6 @@ msgstr ""
 msgid "Income statement"
 msgstr "損益表"
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:72
 #: lib/LedgerSMB/Report/File/Incoming.pm:72
 msgid "Incoming Files"
 msgstr ""
@@ -4258,11 +3868,10 @@ msgid ""
 "charge."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:441 lib/LedgerSMB.pm:439
+#: lib/LedgerSMB.pm:441
 msgid "Internal Database Error"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:70
 #: lib/LedgerSMB/Report/File/Internal.pm:70
 msgid "Internal Files"
 msgstr ""
@@ -4272,30 +3881,26 @@ msgstr ""
 msgid "Internal Notes"
 msgstr "內部備忘錄"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:83
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:83
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:427 lib/LedgerSMB/Scripts/setup.pm:427
+#: lib/LedgerSMB/Scripts/setup.pm:427
 msgid "Invalid backup request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:444 lib/LedgerSMB.pm:442
+#: lib/LedgerSMB.pm:444
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1011
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1018
 #: lib/LedgerSMB/Scripts/setup.pm:1011 lib/LedgerSMB/Scripts/setup.pm:1018
 msgid "Invalid request"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:331 lib/LedgerSMB/Scripts/recon.pm:331
+#: lib/LedgerSMB/Scripts/recon.pm:331
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:97
 #: lib/LedgerSMB/Scripts/configuration.pm:97 old/bin/ic.pl:514
 #: UI/accounts/edit.html:290 sql/Pg-database.sql:2727
 msgid "Inventory"
@@ -4305,17 +3910,14 @@ msgstr "庫存"
 msgid "Inventory Activity"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:181
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:181
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:72
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:73
 msgid "Inventory Adjustments"
 msgstr ""
@@ -4341,11 +3943,7 @@ msgstr "已儲存存貨！"
 msgid "Inventory transferred!"
 msgstr "轉移的存貨！"
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:108
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:281
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:181
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:933 lib/LedgerSMB/Report/Aging.pm:108
+#: lib/LedgerSMB/Report/Aging.pm:108
 #: lib/LedgerSMB/Report/Inventory/Search.pm:281
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
@@ -4387,8 +3985,6 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:126
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:96
 #: lib/LedgerSMB/Report/Contact/History.pm:126
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:645 old/bin/ir.pl:483
 #: old/bin/is.pl:530 UI/Reports/filters/invoice_outstanding.html:158
@@ -4404,11 +4000,6 @@ msgstr "未指明發票日期！"
 msgid "Invoice No."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:70
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:68
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:90
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:83
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:91
 #: lib/LedgerSMB/Report/Contact/History.pm:70
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:68
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
@@ -4427,7 +4018,6 @@ msgstr "發票編號"
 msgid "Invoice Number missing!"
 msgstr "未指明發票編號！"
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:72
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:72
 msgid "Invoice Profit/Loss"
 msgstr ""
@@ -4457,12 +4047,10 @@ msgstr ""
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:99
 #: lib/LedgerSMB/Report/Taxform/Details.pm:99
 msgid "Invoice sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:94
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:94
 #: UI/Reports/filters/purchase_history.html:171
 msgid "Invoices"
@@ -4520,8 +4108,7 @@ msgstr ""
 msgid "Jan"
 msgstr "一月"
 
-#: UI/pod/src/LedgerSMB.pm:521 lib/LedgerSMB.pm:519 old/bin/aa.pl:68
-#: old/bin/gl.pl:63 old/bin/io.pl:63
+#: lib/LedgerSMB.pm:521 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:63
 msgid "January"
 msgstr "一月"
 
@@ -4550,8 +4137,7 @@ msgstr ""
 msgid "Jul"
 msgstr "七月"
 
-#: UI/pod/src/LedgerSMB.pm:527 lib/LedgerSMB.pm:525 old/bin/aa.pl:74
-#: old/bin/gl.pl:69 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:527 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:69
 msgid "July"
 msgstr "七月"
 
@@ -4559,8 +4145,8 @@ msgstr "七月"
 msgid "Jun"
 msgstr "六月"
 
-#: UI/pod/src/LedgerSMB.pm:526 lib/LedgerSMB.pm:524 old/bin/aa.pl:73
-#: old/bin/gl.pl:68 old/bin/io.pl:68 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB.pm:526 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:68
+#: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "六月"
 
@@ -4573,10 +4159,6 @@ msgstr ""
 msgid "LaTeX Templates"
 msgstr "LaTex 模版"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:74
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset_Class.pm:99
-#: UI/pod/src/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
-#: UI/pod/src/LedgerSMB/Report/Payroll/Income_Types.pm:41
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:99
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:41
@@ -4598,15 +4180,12 @@ msgstr "直接人工/經常費用"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:101
-#: UI/pod/src/LedgerSMB/Report/Listings/Language.pm:65
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:72
 #: lib/LedgerSMB/Report/Aging.pm:101
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:386
 #: old/bin/pe.pl:559 UI/Contact/divs/credit.html:275
 #: UI/Contact/divs/credit.html:276 UI/Reports/filters/balance_sheet.html:237
-#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:87
+#: UI/Reports/filters/income_statement.html:289 UI/users/preferences.html:100
 #: sql/Pg-database.sql:2660
 msgid "Language"
 msgstr "語言"
@@ -4627,7 +4206,6 @@ msgstr "不能辨認語言！"
 msgid "Last"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:236
 #: lib/LedgerSMB/Report/Inventory/Search.pm:236 old/bin/ic.pl:452
 #: old/bin/ic.pl:630 UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:31
 #: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:324
@@ -4638,7 +4216,6 @@ msgstr "上次的成本"
 msgid "Last Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:154
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:154
 msgid "Last Updated"
 msgstr ""
@@ -4660,40 +4237,39 @@ msgstr ""
 msgid "Leadtime"
 msgstr "總需時"
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:95
 #: lib/LedgerSMB/Report/Taxform/Details.pm:95
 msgid "Ledger sum"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:190 lib/LedgerSMB/Scripts/setup.pm:190
+#: lib/LedgerSMB/Scripts/setup.pm:190
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:195 lib/LedgerSMB/Scripts/setup.pm:195
+#: lib/LedgerSMB/Scripts/setup.pm:195
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:200 lib/LedgerSMB/Scripts/setup.pm:200
+#: lib/LedgerSMB/Scripts/setup.pm:200
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:206 lib/LedgerSMB/Scripts/setup.pm:206
+#: lib/LedgerSMB/Scripts/setup.pm:206
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:211 lib/LedgerSMB/Scripts/setup.pm:211
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:216 lib/LedgerSMB/Scripts/setup.pm:216
+#: lib/LedgerSMB/Scripts/setup.pm:216
 msgid "LedgerSMB 1.7 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:221 lib/LedgerSMB/Scripts/setup.pm:221
+#: lib/LedgerSMB/Scripts/setup.pm:221
 msgid "LedgerSMB 1.8 db found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:226 lib/LedgerSMB/Scripts/setup.pm:226
+#: lib/LedgerSMB/Scripts/setup.pm:226
 msgid "LedgerSMB 1.9 db found."
 msgstr ""
 
@@ -4705,9 +4281,7 @@ msgstr ""
 msgid "LedgerSMB [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:886
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:932 lib/LedgerSMB/Upgrade_Tests.pm:886
-#: lib/LedgerSMB/Upgrade_Tests.pm:932
+#: lib/LedgerSMB/Upgrade_Tests.pm:886 lib/LedgerSMB/Upgrade_Tests.pm:932
 msgid ""
 "LedgerSMB customers must be assigned to a valid business.<br>Please review "
 "the selection or select the proper business from the list"
@@ -4729,9 +4303,7 @@ msgstr ""
 msgid "LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:863
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:909 lib/LedgerSMB/Upgrade_Tests.pm:863
-#: lib/LedgerSMB/Upgrade_Tests.pm:909
+#: lib/LedgerSMB/Upgrade_Tests.pm:863 lib/LedgerSMB/Upgrade_Tests.pm:909
 msgid ""
 "LedgerSMB vendors must be assigned to a valid business.<br>Please review the "
 "selection or select the proper business from the list"
@@ -4745,8 +4317,6 @@ msgstr ""
 msgid "Letterhead"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:220
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:204
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:220 lib/LedgerSMB/Report/PNL.pm:204
 msgid "Liabilities"
 msgstr ""
@@ -4763,7 +4333,6 @@ msgstr ""
 msgid "Lifetime Measured In"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:176
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:176
 msgid "Line Item COGS Report"
 msgstr ""
@@ -4800,7 +4369,6 @@ msgstr "列出語言"
 msgid "List Overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:226
 #: lib/LedgerSMB/Report/Inventory/Search.pm:226 old/bin/ic.pl:435
 #: UI/Reports/filters/search_goods.html:308
 msgid "List Price"
@@ -4826,7 +4394,6 @@ msgstr ""
 msgid "List Warehouse"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Type.pm:67
 #: lib/LedgerSMB/Report/Listings/Business_Type.pm:67
 msgid "List of Business Types"
 msgstr ""
@@ -4844,7 +4411,6 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:84
 #: lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Lock Item Description"
 msgstr ""
@@ -4865,7 +4431,7 @@ msgstr ""
 msgid "Login"
 msgstr "登入"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:979 lib/LedgerSMB/Scripts/setup.pm:979
+#: lib/LedgerSMB/Scripts/setup.pm:979
 msgid "Login?"
 msgstr ""
 
@@ -4893,45 +4459,38 @@ msgstr ""
 msgid "Mailing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:253
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:973
 #: UI/Reports/filters/search_goods.html:86
 #: UI/Reports/filters/search_goods.html:401
 msgid "Make"
 msgstr "生產商"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:494 lib/LedgerSMB/Upgrade_Tests.pm:494
+#: lib/LedgerSMB/Upgrade_Tests.pm:494
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:530
+#: lib/LedgerSMB/Upgrade_Tests.pm:530
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1146
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:514 lib/LedgerSMB/Upgrade_Tests.pm:1146
-#: lib/LedgerSMB/Upgrade_Tests.pm:514
+#: lib/LedgerSMB/Upgrade_Tests.pm:1146 lib/LedgerSMB/Upgrade_Tests.pm:514
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:572 lib/LedgerSMB/Upgrade_Tests.pm:572
+#: lib/LedgerSMB/Upgrade_Tests.pm:572
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:476 lib/LedgerSMB/Upgrade_Tests.pm:476
+#: lib/LedgerSMB/Upgrade_Tests.pm:476
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1102
 #: lib/LedgerSMB/Scripts/setup.pm:1102
 msgid "Manage Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:278
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:311
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:258
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:105
@@ -4953,40 +4512,34 @@ msgstr ""
 msgid "Mar"
 msgstr "三月"
 
-#: UI/pod/src/LedgerSMB.pm:523 lib/LedgerSMB.pm:521 old/bin/aa.pl:70
-#: old/bin/gl.pl:65 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:523 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:65
 msgid "March"
 msgstr "三月"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:245
 #: lib/LedgerSMB/Report/Inventory/Search.pm:245 old/bin/ic.pl:458
 #: old/bin/ic.pl:636 UI/Reports/filters/search_goods.html:345
 msgid "Markup"
 msgstr "漲價"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:138
 #: lib/LedgerSMB/Scripts/configuration.pm:138
 msgid "Max Invoices per Check Stub"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:136
 #: lib/LedgerSMB/Scripts/configuration.pm:136
 msgid "Max per dropdown"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:525 lib/LedgerSMB.pm:523 old/bin/aa.pl:72
-#: old/bin/aa.pl:86 old/bin/gl.pl:67 old/bin/gl.pl:81 old/bin/io.pl:67
-#: old/bin/io.pl:81
+#: lib/LedgerSMB.pm:525 old/bin/aa.pl:72 old/bin/aa.pl:86 old/bin/gl.pl:67
+#: old/bin/gl.pl:81 old/bin/io.pl:67 old/bin/io.pl:81
 msgid "May"
 msgstr "五月"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:135
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:939 lib/LedgerSMB/Report/GL.pm:135
-#: lib/LedgerSMB/Scripts/payment.pm:939 old/bin/aa.pl:838 old/bin/ir.pl:657
-#: old/bin/ir.pl:837 old/bin/is.pl:760 old/bin/is.pl:941
-#: UI/Reports/filters/gl.html:73 UI/Reports/filters/gl.html:253
-#: UI/journal/journal_entry.html:143 UI/orders/order.html:247
-#: UI/payments/payment2.html:317 templates/demo/ap_transaction.html:148
+#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:939
+#: old/bin/aa.pl:838 old/bin/ir.pl:657 old/bin/ir.pl:837 old/bin/is.pl:760
+#: old/bin/is.pl:941 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:143
+#: UI/orders/order.html:247 UI/payments/payment2.html:317
+#: templates/demo/ap_transaction.html:148
 #: templates/xedemo/ap_transaction.html:148
 msgid "Memo"
 msgstr "備忘錄"
@@ -5003,7 +4556,6 @@ msgstr "訊息"
 msgid "Message: "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:87
 msgid "Method"
 msgstr "方法"
@@ -5012,7 +4564,6 @@ msgstr "方法"
 msgid "Method Default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:269
 #: lib/LedgerSMB/Report/Inventory/Search.pm:269 old/bin/ic.pl:497
 #: UI/Reports/filters/search_goods.html:116
 #: UI/Reports/filters/search_goods.html:394
@@ -5031,14 +4582,11 @@ msgstr ""
 msgid "Million"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:56
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:54
 #: lib/LedgerSMB/Report/File/Incoming.pm:56
 #: lib/LedgerSMB/Report/File/Internal.pm:54
 msgid "Mime Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:145
 #: lib/LedgerSMB/Scripts/configuration.pm:145
 msgid "Min Empty Lines"
 msgstr ""
@@ -5052,7 +4600,6 @@ msgstr ""
 msgid "Min Taxable"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:128
 #: lib/LedgerSMB/Scripts/configuration.pm:128
 msgid "Misc Settings"
 msgstr ""
@@ -5065,14 +4612,12 @@ msgstr ""
 msgid "Miss."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:257
 #: lib/LedgerSMB/Report/Inventory/Search.pm:257 old/bin/ic.pl:974
 #: UI/Reports/filters/search_goods.html:96
 #: UI/Reports/filters/search_goods.html:408
 msgid "Model"
 msgstr "型號"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:114
 #: lib/LedgerSMB/Report/Timecards.pm:114
 msgid "Mon"
 msgstr ""
@@ -5090,7 +4635,7 @@ msgstr "月"
 msgid "Months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:457 lib/LedgerSMB.pm:455
+#: lib/LedgerSMB.pm:457
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -5114,14 +4659,12 @@ msgstr ""
 msgid "Multiple dates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1291
 #: lib/LedgerSMB/Upgrade_Tests.pm:1291
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:219
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:219
 msgid "Must have cash account in batch"
 msgstr ""
@@ -5130,15 +4673,6 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:148
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:58
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:145
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:63
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:105
-#: UI/pod/src/LedgerSMB/Report/Contact/Search.pm:62
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:221
-#: UI/pod/src/LedgerSMB/Report/PNL/ECA.pm:86
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Contact/History.pm:148
 #: lib/LedgerSMB/Report/Contact/History.pm:58
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:145
@@ -5157,7 +4691,6 @@ msgstr "名稱"
 msgid "Name:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:127
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2676
 msgid "Net Book Value"
 msgstr ""
@@ -5208,8 +4741,6 @@ msgstr "下一日"
 msgid "Next Number"
 msgstr "下一個號碼"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:111
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:331
 #: lib/LedgerSMB/Scripts/configuration.pm:111
 #: lib/LedgerSMB/Scripts/configuration.pm:331
 msgid "Next in Sequence"
@@ -5231,12 +4762,10 @@ msgstr ""
 msgid "Ninety"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:101
 #: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/Configuration/settings.html:45
 msgid "No"
 msgstr "否"
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:604
 #: lib/LedgerSMB/Scripts/contact.pm:604
 msgid "No AR or AP Account Selected"
 msgstr ""
@@ -5245,7 +4774,7 @@ msgstr ""
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:51 lib/LedgerSMB/Report/File.pm:51
+#: lib/LedgerSMB/Report/File.pm:51
 msgid "No File Class Specified"
 msgstr ""
 
@@ -5253,11 +4782,11 @@ msgstr ""
 msgid "No ID Set"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:545 lib/LedgerSMB/Upgrade_Tests.pm:545
+#: lib/LedgerSMB/Upgrade_Tests.pm:545
 msgid "No NULL Amounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:458 lib/LedgerSMB/Upgrade_Tests.pm:458
+#: lib/LedgerSMB/Upgrade_Tests.pm:458
 msgid "No Null employeenumber"
 msgstr ""
 
@@ -5265,7 +4794,6 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1104
 #: lib/LedgerSMB/Scripts/setup.pm:1104
 msgid "No changes"
 msgstr ""
@@ -5274,11 +4802,11 @@ msgstr ""
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:567 lib/LedgerSMB/Upgrade_Tests.pm:567
+#: lib/LedgerSMB/Upgrade_Tests.pm:567
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/file.pm:188 lib/LedgerSMB/Scripts/file.pm:188
+#: lib/LedgerSMB/Scripts/file.pm:188
 msgid "No file uploaded"
 msgstr ""
 
@@ -5286,21 +4814,18 @@ msgstr ""
 msgid "No open Projects!"
 msgstr "沒有已開啟的項目"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1410
 #: lib/LedgerSMB/Scripts/payment.pm:1410
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File.pm:38 lib/LedgerSMB/Report/File.pm:38
+#: lib/LedgerSMB/Report/File.pm:38
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/reports.pm:99
 #: lib/LedgerSMB/Scripts/reports.pm:99
 msgid "No report specified"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/taxform.pm:126
 #: lib/LedgerSMB/Scripts/taxform.pm:126
 msgid "No tax form selected"
 msgstr ""
@@ -5319,12 +4844,10 @@ msgstr ""
 msgid "Non-cash"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1197
 #: lib/LedgerSMB/Upgrade_Tests.pm:1197
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1348
 #: lib/LedgerSMB/Upgrade_Tests.pm:1348
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
@@ -5333,12 +4856,10 @@ msgstr ""
 msgid "Non-tracking Items"
 msgstr "不用追蹤的項目"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1099
 #: lib/LedgerSMB/Upgrade_Tests.pm:1099
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1122
 #: lib/LedgerSMB/Upgrade_Tests.pm:1122
 msgid "Non-unique invoice numbers detected"
 msgstr ""
@@ -5376,11 +4897,6 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:273
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:266
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:195
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:112
 #: lib/LedgerSMB/Report/Inventory/Search.pm:273
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
@@ -5426,23 +4942,18 @@ msgstr "沒有可轉移的項目！"
 msgid "Nov"
 msgstr "十一月"
 
-#: UI/pod/src/LedgerSMB.pm:531 lib/LedgerSMB.pm:529 old/bin/aa.pl:78
-#: old/bin/gl.pl:73 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:531 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:73
 msgid "November"
 msgstr "十一月"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1059
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1078
 #: lib/LedgerSMB/Upgrade_Tests.pm:1059 lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid "Null employee numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1177
 #: lib/LedgerSMB/Upgrade_Tests.pm:1177
 msgid "Null make numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1160
 #: lib/LedgerSMB/Upgrade_Tests.pm:1160
 msgid "Null model numbers"
 msgstr ""
@@ -5473,7 +4984,7 @@ msgstr ""
 msgid "Number"
 msgstr "編號"
 
-#: UI/users/preferences.html:77
+#: UI/users/preferences.html:90
 msgid "Number Format"
 msgstr "數字格式"
 
@@ -5494,13 +5005,11 @@ msgstr "已有存量"
 msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:128
 #: lib/LedgerSMB/Scripts/budgets.pm:128 old/bin/ic.pl:702
 #: UI/Reports/filters/search_goods.html:32 UI/accounts/edit.html:142
 msgid "Obsolete"
 msgstr "停用"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:100
 #: lib/LedgerSMB/Report/Budget/Search.pm:100
 msgid "Obsolete By"
 msgstr ""
@@ -5509,8 +5018,7 @@ msgstr ""
 msgid "Oct"
 msgstr "十月"
 
-#: UI/pod/src/LedgerSMB.pm:530 lib/LedgerSMB.pm:528 old/bin/aa.pl:77
-#: old/bin/gl.pl:72 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:530 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:72
 msgid "October"
 msgstr "十月"
 
@@ -5522,9 +5030,6 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:129
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:205
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:205
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:112 old/bin/ic.pl:469 old/bin/ic.pl:677
@@ -5574,7 +5079,6 @@ msgstr ""
 msgid "Open"
 msgstr "開啟"
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:277
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:277
 #, fuzzy
 msgid "Opening Balance"
@@ -5596,9 +5100,6 @@ msgstr ""
 msgid "Or Add To Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:285
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:212
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:272
 #: lib/LedgerSMB/Report/Inventory/Search.pm:285
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/io.pl:1048
@@ -5644,7 +5145,6 @@ msgstr "未指明下單日期！"
 msgid "Order Entry"
 msgstr "下單項目"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:72
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:637
 #: old/bin/ir.pl:474 old/bin/is.pl:521 old/bin/oe.pl:1779 old/bin/oe.pl:389
 #: UI/Reports/filters/invoice_outstanding.html:144
@@ -5666,7 +5166,6 @@ msgstr "已刪除訂單！"
 msgid "Order generation failed!"
 msgstr "生成訂單失敗！"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:141
 #: lib/LedgerSMB/Report/Inventory/History.pm:141
 msgid "Order/Invoice"
 msgstr ""
@@ -5688,7 +5187,7 @@ msgstr "已生成訂單！"
 msgid "Other Actions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:488 lib/LedgerSMB/Scripts/recon.pm:488
+#: lib/LedgerSMB/Scripts/recon.pm:488
 msgid "Our Balance"
 msgstr ""
 
@@ -5734,7 +5233,6 @@ msgstr ""
 msgid "Overpayment Account"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:81
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:81
 msgid "Overpayments"
 msgstr ""
@@ -5753,10 +5251,6 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:76
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:216
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:238
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:76
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
@@ -5800,11 +5294,6 @@ msgstr "未指明出貨單編號！"
 msgid "Packing list"
 msgstr "出貨單"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:95
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:244
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:290
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:145
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:936
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:95
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
@@ -5822,12 +5311,10 @@ msgstr "已付"
 msgid "Parent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:107
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:616
 msgid "Part"
 msgstr "零件"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:164
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:164
 msgid "Part Description"
 msgstr ""
@@ -5837,14 +5324,6 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:81
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:121
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:197
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:101
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:162
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:77
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:122
 #: lib/LedgerSMB/Report/Contact/History.pm:81
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
@@ -5874,14 +5353,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:728 lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:728
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:165
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:93
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:102
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:165
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:93
 #: lib/LedgerSMB/Report/Timecards.pm:102 lib/LedgerSMB/Report/Timecards.pm:151
@@ -5897,15 +5372,12 @@ msgstr "零件編號"
 msgid "Parts"
 msgstr "零件"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:71
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:277
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Search.pm:277
 #: UI/Reports/filters/search_partsgroups.html:11 sql/Pg-database.sql:2614
 msgid "Partsgroup"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:82
 msgid "Partsgroups"
 msgstr ""
@@ -5915,7 +5387,6 @@ msgstr ""
 msgid "Password"
 msgstr "密碼"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:76
 #: lib/LedgerSMB/Scripts/configuration.pm:76
 msgid "Password Duration (days)"
 msgstr ""
@@ -5928,7 +5399,6 @@ msgstr ""
 msgid "Pay From"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:178
 #: lib/LedgerSMB/Scripts/payment.pm:178 UI/Contact/divs/credit.html:96
 #: UI/Contact/divs/credit.html:97 UI/payments/payments_filter.html:92
 msgid "Pay To"
@@ -5942,7 +5412,6 @@ msgstr ""
 msgid "Payables"
 msgstr "應付科目"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1174
 #: lib/LedgerSMB/Scripts/payment.pm:1174 UI/Contact/divs/credit.html:208
 #: UI/Contact/divs/credit.html:209 UI/accounts/edit.html:334
 #: UI/accounts/edit.html:386 UI/payments/payments_detail.html:227
@@ -5951,7 +5420,6 @@ msgstr "應付科目"
 msgid "Payment"
 msgstr "付款"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
 msgid "Payment Amount"
 msgstr ""
@@ -5964,7 +5432,6 @@ msgstr ""
 msgid "Payment Processing"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:202
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:202
 msgid "Payment Results"
 msgstr ""
@@ -5981,7 +5448,6 @@ msgstr ""
 msgid "Payment Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:292
 #: lib/LedgerSMB/Scripts/payment.pm:292
 #, fuzzy
 msgid "Payment batch"
@@ -6017,15 +5483,15 @@ msgstr "付款"
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:384 lib/LedgerSMB/Scripts/asset.pm:384
+#: lib/LedgerSMB/Scripts/asset.pm:384
 msgid "Percent"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:698
 msgid "Percent Disposed"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:710 lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:710
 msgid "Percent Remaining"
 msgstr ""
 
@@ -6044,7 +5510,6 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:187
 #: lib/LedgerSMB/Scripts/contact.pm:187 UI/Contact/divs/person.html:2
 msgid "Person"
 msgstr ""
@@ -6075,108 +5540,88 @@ msgstr "揀貨清單"
 msgid "Pick list"
 msgstr "揀貨清單"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1271
 #: lib/LedgerSMB/Upgrade_Tests.pm:1271
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1252
 #: lib/LedgerSMB/Upgrade_Tests.pm:1252
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:653
+#: lib/LedgerSMB/Upgrade_Tests.pm:653
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:729 lib/LedgerSMB/Upgrade_Tests.pm:729
+#: lib/LedgerSMB/Upgrade_Tests.pm:729
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:718 lib/LedgerSMB/Upgrade_Tests.pm:718
+#: lib/LedgerSMB/Upgrade_Tests.pm:718
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1217
 #: lib/LedgerSMB/Upgrade_Tests.pm:1217
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1201
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1235
 #: lib/LedgerSMB/Upgrade_Tests.pm:1201 lib/LedgerSMB/Upgrade_Tests.pm:1235
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1352
 #: lib/LedgerSMB/Upgrade_Tests.pm:1352
 msgid ""
 "Please fix the pricegroup data in your partsvendor table (no UI available)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:789
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:992 lib/LedgerSMB/Upgrade_Tests.pm:789
-#: lib/LedgerSMB/Upgrade_Tests.pm:992
+#: lib/LedgerSMB/Upgrade_Tests.pm:789 lib/LedgerSMB/Upgrade_Tests.pm:992
 msgid ""
 "Please go into the SQL-Ledger UI and create/rename aheading which sorts "
 "alphanumerically before the first account by accno"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1105
 #: lib/LedgerSMB/Upgrade_Tests.pm:1105
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1012
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:427 lib/LedgerSMB/Upgrade_Tests.pm:1012
-#: lib/LedgerSMB/Upgrade_Tests.pm:427
+#: lib/LedgerSMB/Upgrade_Tests.pm:1012 lib/LedgerSMB/Upgrade_Tests.pm:427
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1083
 #: lib/LedgerSMB/Upgrade_Tests.pm:1083
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1047
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:446 lib/LedgerSMB/Upgrade_Tests.pm:1047
-#: lib/LedgerSMB/Upgrade_Tests.pm:446
+#: lib/LedgerSMB/Upgrade_Tests.pm:1047 lib/LedgerSMB/Upgrade_Tests.pm:446
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:748
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:952 lib/LedgerSMB/Upgrade_Tests.pm:748
-#: lib/LedgerSMB/Upgrade_Tests.pm:952
+#: lib/LedgerSMB/Upgrade_Tests.pm:748 lib/LedgerSMB/Upgrade_Tests.pm:952
 msgid ""
 "Please make sure all accounts have a category of(A)sset, (L)iability, "
 "e(Q)uity, (I)ncome or (E)xpense."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1063
 #: lib/LedgerSMB/Upgrade_Tests.pm:1063
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1182
 #: lib/LedgerSMB/Upgrade_Tests.pm:1182
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1164
 #: lib/LedgerSMB/Upgrade_Tests.pm:1164
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:805 lib/LedgerSMB/Upgrade_Tests.pm:805
+#: lib/LedgerSMB/Upgrade_Tests.pm:805
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1028
 #: lib/LedgerSMB/Upgrade_Tests.pm:1028
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
@@ -6192,7 +5637,6 @@ msgstr ""
 msgid "Please select a customer with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/account.pm:111
 #: lib/LedgerSMB/Scripts/account.pm:111
 msgid "Please select a valid heading"
 msgstr ""
@@ -6201,24 +5645,22 @@ msgstr ""
 msgid "Please select a vendor with unused overpayments"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/timecard.pm:142
 #: lib/LedgerSMB/Scripts/timecard.pm:142
 msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:688 lib/LedgerSMB/Upgrade_Tests.pm:688
+#: lib/LedgerSMB/Upgrade_Tests.pm:688
 msgid "Please use pgAdmin3 or psql to remove the duplicates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:589 lib/LedgerSMB/Upgrade_Tests.pm:589
+#: lib/LedgerSMB/Upgrade_Tests.pm:589
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:670
+#: lib/LedgerSMB/Upgrade_Tests.pm:670
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:936
 #: old/bin/aa.pl:965 old/bin/aa.pl:966 old/bin/aa.pl:967 old/bin/gl.pl:251
 #: old/bin/gl.pl:253 old/bin/ir.pl:521 old/bin/ir.pl:555 old/bin/ir.pl:942
@@ -6227,13 +5669,11 @@ msgstr ""
 msgid "Post"
 msgstr "加入"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:194
 msgid "Post Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:484 lib/LedgerSMB/Scripts/recon.pm:484
-#: UI/create_batch.html:76
+#: lib/LedgerSMB/Scripts/recon.pm:484 UI/create_batch.html:76
 msgid "Post Date"
 msgstr ""
 
@@ -6274,7 +5714,6 @@ msgstr ""
 msgid "Postscript"
 msgstr "Postscript"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1321
 #: lib/LedgerSMB/Upgrade_Tests.pm:1321
 msgid ""
 "Pre-migration checks found reconciliations on income or expense accounts or "
@@ -6312,20 +5751,16 @@ msgstr ""
 msgid "Price"
 msgstr "價格"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:55
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:55
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:71
 #: UI/Reports/filters/search_pricegroups.html:11
 msgid "Price Group"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 #: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:82
 msgid "Price Groups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:249
 #: lib/LedgerSMB/Report/Inventory/Search.pm:249
 #: UI/Reports/filters/search_goods.html:294
 msgid "Price Updated"
@@ -6361,8 +5796,6 @@ msgstr ""
 msgid "Primary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:138
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:133
 #: lib/LedgerSMB/Report/Taxform/Details.pm:138
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:133 old/bin/aa.pl:935
 #: old/bin/aa.pl:962 old/bin/am.pl:774 old/bin/arap.pl:465 old/bin/ir.pl:519
@@ -6372,7 +5805,6 @@ msgstr ""
 msgid "Print"
 msgstr "列印"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:222
 msgid "Print Batch"
 msgstr ""
@@ -6389,7 +5821,7 @@ msgstr "列印並儲存作為新的"
 msgid "Printed"
 msgstr "已列印"
 
-#: UI/users/preferences.html:110
+#: UI/users/preferences.html:123
 msgid "Printer"
 msgstr "印表機"
 
@@ -6433,17 +5865,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:607 lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:607
 msgid "Prior Dep."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:601 lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:601
 msgid "Prior Through"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:374
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:828 lib/LedgerSMB/Scripts/asset.pm:374
-#: lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
 msgid "Proceeds"
 msgstr ""
 
@@ -6472,7 +5902,6 @@ msgstr ""
 msgid "Profit/Loss"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Product.pm:67
 #: lib/LedgerSMB/Report/PNL/Product.pm:67
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
@@ -6491,7 +5920,6 @@ msgstr "項目描述的翻譯"
 msgid "Project Number"
 msgstr "項目號碼"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:89
 #: lib/LedgerSMB/Report/Timecards.pm:89
 msgid "Project/Department Number"
 msgstr ""
@@ -6500,9 +5928,6 @@ msgstr ""
 msgid "Projects"
 msgstr "項目"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:130
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:97
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:336
 #: lib/LedgerSMB/Report/Listings/Asset.pm:130
 #: lib/LedgerSMB/Report/Listings/Asset.pm:97 lib/LedgerSMB/Scripts/asset.pm:336
 msgid "Purchase Date"
@@ -6512,7 +5937,6 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:137
 #: lib/LedgerSMB/Report/Contact/History.pm:137
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
@@ -6530,22 +5954,16 @@ msgstr ""
 msgid "Purchase Order"
 msgstr "採購單"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:120
 #: lib/LedgerSMB/Scripts/configuration.pm:120
 msgid "Purchase Order Number"
 msgstr "採購單編號"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:181
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:273 lib/LedgerSMB/Report/Orders.pm:181
-#: lib/LedgerSMB/Report/Orders.pm:273 old/bin/am.pl:782
-#: UI/Reports/filters/search_goods.html:163 sql/Pg-database.sql:2598
-#: sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
+#: lib/LedgerSMB/Report/Orders.pm:181 lib/LedgerSMB/Report/Orders.pm:273
+#: old/bin/am.pl:782 UI/Reports/filters/search_goods.html:163
+#: sql/Pg-database.sql:2598 sql/Pg-database.sql:2600 sql/Pg-database.sql:2603
 msgid "Purchase Orders"
 msgstr "採購單"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:100
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:132
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:341
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
 #: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
@@ -6560,14 +5978,10 @@ msgstr ""
 msgid "Purchase order"
 msgstr "採購單"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:117
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:117
 msgid "Purchased"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:89
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:158
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:297
 #: lib/LedgerSMB/Report/Contact/History.pm:89
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:297 old/bin/ic.pl:1245
@@ -6598,7 +6012,6 @@ msgstr ""
 msgid "Qty"
 msgstr "數量"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:117
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:117
 msgid "Quantity"
 msgstr ""
@@ -6612,8 +6025,6 @@ msgstr "數量超過可庫存的數量！"
 msgid "Quarter"
 msgstr "季"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:289
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:242
 #: lib/LedgerSMB/Report/Inventory/Search.pm:289
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1228 old/bin/io.pl:1235
 #: old/bin/oe.pl:1244 old/bin/oe.pl:231 old/bin/oe.pl:661 old/bin/oe.pl:870
@@ -6650,9 +6061,7 @@ msgstr "未指明報價單號碼！"
 msgid "Quotation deleted!"
 msgstr "已刪除報價單！"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:184
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:275 lib/LedgerSMB/Report/Orders.pm:184
-#: lib/LedgerSMB/Report/Orders.pm:275
+#: lib/LedgerSMB/Report/Orders.pm:184 lib/LedgerSMB/Report/Orders.pm:275
 #: UI/Reports/filters/purchase_history.html:189
 #: UI/Reports/filters/search_goods.html:149 sql/Pg-database.sql:2610
 #: sql/Pg-database.sql:2703
@@ -6673,25 +6082,20 @@ msgstr "報價請求(RFQ) "
 msgid "RFQ #"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:121
 #: lib/LedgerSMB/Scripts/configuration.pm:121 old/bin/oe.pl:474
 msgid "RFQ Number"
 msgstr "報價請求號碼"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:187
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:277 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:277 UI/Reports/filters/search_goods.html:170
-#: sql/Pg-database.sql:2611
+#: lib/LedgerSMB/Report/Orders.pm:187 lib/LedgerSMB/Report/Orders.pm:277
+#: UI/Reports/filters/search_goods.html:170 sql/Pg-database.sql:2611
 msgid "RFQs"
 msgstr "報價請求"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:213
 #: lib/LedgerSMB/Report/Inventory/Search.pm:213 old/bin/ic.pl:2084
 #: old/bin/ic.pl:478 UI/Reports/filters/search_goods.html:359
 msgid "ROP"
 msgstr "再訂點"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:256
 #: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:654 old/bin/is.pl:757
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:99
 #: templates/demo/timecard.tex:40 templates/xedemo/timecard.html:99
@@ -6703,7 +6107,6 @@ msgstr "稅率"
 msgid "Rate (%)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:244
 #: lib/LedgerSMB/Scripts/currency.pm:244
 #, fuzzy
 msgid "Rate Type"
@@ -6726,13 +6129,9 @@ msgstr ""
 msgid "Re-open Period"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:207
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:212
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:217
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:222
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:227 lib/LedgerSMB/Scripts/setup.pm:207
-#: lib/LedgerSMB/Scripts/setup.pm:212 lib/LedgerSMB/Scripts/setup.pm:217
-#: lib/LedgerSMB/Scripts/setup.pm:222 lib/LedgerSMB/Scripts/setup.pm:227
+#: lib/LedgerSMB/Scripts/setup.pm:207 lib/LedgerSMB/Scripts/setup.pm:212
+#: lib/LedgerSMB/Scripts/setup.pm:217 lib/LedgerSMB/Scripts/setup.pm:222
+#: lib/LedgerSMB/Scripts/setup.pm:227
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
@@ -6750,7 +6149,6 @@ msgstr "收據"
 msgid "Receipt Date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:203
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:203
 msgid "Receipt Results"
 msgstr ""
@@ -6764,8 +6162,7 @@ msgstr "收據"
 msgid "Receivables"
 msgstr "應收帳戶"
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:81 lib/LedgerSMB/Scripts/order.pm:81
-#: sql/Pg-database.sql:2605
+#: lib/LedgerSMB/Scripts/order.pm:81 sql/Pg-database.sql:2605
 msgid "Receive"
 msgstr "收到"
 
@@ -6773,7 +6170,6 @@ msgstr "收到"
 msgid "Receive Merchandise"
 msgstr "收到貨物"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1001
 #: lib/LedgerSMB/Scripts/payment.pm:1001
 msgid "Received"
 msgstr ""
@@ -6794,7 +6190,6 @@ msgstr "調節"
 msgid "Reconciliation Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:200
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:200
 msgid "Reconciliation Reports"
 msgstr ""
@@ -6815,13 +6210,6 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "重覆出現的交易"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:131
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:83
-#: UI/pod/src/LedgerSMB/Report/GL.pm:221 UI/pod/src/LedgerSMB/Report/GL.pm:97
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:118
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:147
 #: lib/LedgerSMB/Report/Budget/Search.pm:131
 #: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
 #: lib/LedgerSMB/Report/GL.pm:97
@@ -6860,12 +6248,10 @@ msgstr ""
 msgid "Regular"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:119
 #: lib/LedgerSMB/Scripts/budgets.pm:119 UI/reconciliation/report.html:402
 msgid "Reject"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:91
 msgid "Rem. Life"
 msgstr ""
@@ -6903,7 +6289,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:441 lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:441
 msgid "Report Results"
 msgstr ""
 
@@ -6915,7 +6301,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:632 lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:632
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6928,7 +6314,6 @@ msgstr ""
 msgid "Report type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:64
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:64
 msgid "Reporting Basis"
 msgstr ""
@@ -6978,7 +6363,7 @@ msgstr ""
 msgid "Required By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:213 lib/LedgerSMB/Report/Orders.pm:213
+#: lib/LedgerSMB/Report/Orders.pm:213
 msgid "Required Date"
 msgstr ""
 
@@ -6998,13 +6383,10 @@ msgstr ""
 msgid "Required by"
 msgstr "要求交付日期"
 
-#: UI/pod/src/LedgerSMB.pm:446 UI/pod/src/LedgerSMB.pm:447 lib/LedgerSMB.pm:444
-#: lib/LedgerSMB.pm:445
+#: lib/LedgerSMB.pm:446 lib/LedgerSMB.pm:447
 msgid "Required input not provided"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Balance_Sheet.pm:87
-#: UI/pod/src/LedgerSMB/Report/PNL/Income_Statement.pm:85
 #: lib/LedgerSMB/Report/Balance_Sheet.pm:87
 #: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
 msgid "Required period type"
@@ -7034,7 +6416,6 @@ msgstr ""
 msgid "Returns"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:112
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:112
 msgid "Revenue"
 msgstr ""
@@ -7043,7 +6424,6 @@ msgstr ""
 msgid "Reversal Information"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Overpayments.pm:164
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:164
 msgid "Reverse"
 msgstr ""
@@ -7060,7 +6440,6 @@ msgstr ""
 msgid "Reverse Payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:230
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:230
 msgid "Reverse Payments"
 msgstr ""
@@ -7110,11 +6489,11 @@ msgstr "庫存單位"
 msgid "SO Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:177
+#: lib/LedgerSMB/Scripts/setup.pm:177
 msgid "SQL-Ledger 3.0 database detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:153 lib/LedgerSMB/Scripts/setup.pm:153
+#: lib/LedgerSMB/Scripts/setup.pm:153
 msgid "SQL-Ledger database detected."
 msgstr ""
 
@@ -7140,7 +6519,6 @@ msgstr "銷售"
 msgid "Sales Invoice"
 msgstr "銷售發票"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:115
 #: lib/LedgerSMB/Scripts/configuration.pm:115
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "銷售發票/應收帳交易編號"
@@ -7156,20 +6534,17 @@ msgstr "銷售發票/應收帳交易編號"
 msgid "Sales Order"
 msgstr "銷貨單"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:116
 #: lib/LedgerSMB/Scripts/configuration.pm:116
 msgid "Sales Order Number"
 msgstr "銷貨單編號"
 
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:178
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:271 lib/LedgerSMB/Report/Orders.pm:178
-#: lib/LedgerSMB/Report/Orders.pm:271 old/bin/am.pl:781
-#: UI/Reports/filters/search_goods.html:142 sql/Pg-database.sql:2597
-#: sql/Pg-database.sql:2599 sql/Pg-database.sql:2602 sql/Pg-database.sql:2616
+#: lib/LedgerSMB/Report/Orders.pm:178 lib/LedgerSMB/Report/Orders.pm:271
+#: old/bin/am.pl:781 UI/Reports/filters/search_goods.html:142
+#: sql/Pg-database.sql:2597 sql/Pg-database.sql:2599 sql/Pg-database.sql:2602
+#: sql/Pg-database.sql:2616
 msgid "Sales Orders"
 msgstr "銷貨單"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:117
 #: lib/LedgerSMB/Scripts/configuration.pm:117
 msgid "Sales Quotation Number"
 msgstr "銷售報價單編號"
@@ -7192,9 +6567,6 @@ msgstr "銷售報價單編號"
 msgid "Sales:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:274
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:308
 #: lib/LedgerSMB/Report/Contact/History.pm:122
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:485
@@ -7218,13 +6590,10 @@ msgstr ""
 msgid "Salvage Value:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:134
 #: lib/LedgerSMB/Report/Timecards.pm:134
 msgid "Sat"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:354
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:104
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/aa.pl:996 old/bin/am.pl:167 old/bin/am.pl:173 old/bin/am.pl:65
 #: old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:825 old/bin/ic.pl:834
@@ -7244,7 +6613,7 @@ msgstr ""
 #: UI/payroll/income.html:98 UI/reconciliation/report.html:380
 #: UI/taxform/add_taxform.html:84 UI/templates/widget.html:142
 #: UI/templates/widget.html:156 UI/timecards/timecard-week.html:126
-#: UI/timecards/timecard.html:169 UI/users/preferences.html:140
+#: UI/timecards/timecard.html:169 UI/users/preferences.html:153
 #: t/data/04-complex_template.html:131 t/data/04-complex_template.html:310
 #: t/data/04-complex_template.html:620 t/data/04-complex_template.html:644
 msgid "Save"
@@ -7254,7 +6623,6 @@ msgstr "儲存"
 msgid "Save As New"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:277
 #: lib/LedgerSMB/Scripts/payment.pm:277
 msgid "Save Batch"
 msgstr ""
@@ -7313,11 +6681,10 @@ msgstr ""
 msgid "Save as new"
 msgstr "當新的儲存"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:217 lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:217
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/business_unit.pm:192
 #: lib/LedgerSMB/Scripts/business_unit.pm:192
 msgid "Saved id [_1]"
 msgstr ""
@@ -7340,10 +6707,8 @@ msgstr "時間表"
 msgid "Scheduled"
 msgstr "編排了時間"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:690
-#: UI/pod/src/LedgerSMB/Template/UI.pm:157 lib/LedgerSMB/Scripts/payment.pm:690
-#: lib/LedgerSMB/Template/UI.pm:157 old/bin/printer.pl:130
-#: UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:690 lib/LedgerSMB/Template/UI.pm:157
+#: old/bin/printer.pl:130 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "螢幕"
 
@@ -7363,7 +6728,6 @@ msgstr "螢幕"
 msgid "Search"
 msgstr "搜尋"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:330
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:330
 msgid "Search AP"
 msgstr ""
@@ -7372,7 +6736,6 @@ msgstr ""
 msgid "Search AP Invoices"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:331
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:331
 msgid "Search AR"
 msgstr ""
@@ -7425,11 +6788,11 @@ msgstr ""
 msgid "Search Pricegroups"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:74 lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:74
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:85 lib/LedgerSMB/Scripts/order.pm:85
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Quotations"
 msgstr ""
 
@@ -7441,11 +6804,11 @@ msgstr ""
 msgid "Search Reconciliation Reports"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:89 lib/LedgerSMB/Scripts/order.pm:89
+#: lib/LedgerSMB/Scripts/order.pm:89
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:63 lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:63
 msgid "Search Sales Orders"
 msgstr ""
 
@@ -7457,7 +6820,7 @@ msgstr ""
 msgid "Search and GL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:419 lib/LedgerSMB/Scripts/asset.pm:419
+#: lib/LedgerSMB/Scripts/asset.pm:419
 msgid "Search reports"
 msgstr ""
 
@@ -7465,7 +6828,6 @@ msgstr ""
 msgid "Secondary Phone"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:70
 #: lib/LedgerSMB/Scripts/configuration.pm:70
 msgid "Security Settings"
 msgstr ""
@@ -7521,7 +6883,6 @@ msgstr "選擇文字、postscript或PDF！"
 msgid "Select using"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:123
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:123
 msgid "Selected"
 msgstr ""
@@ -7530,9 +6891,6 @@ msgstr ""
 msgid "Sell"
 msgstr "售賣"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:99
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:154
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:231
 #: lib/LedgerSMB/Report/Contact/History.pm:99
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1110
@@ -7586,13 +6944,11 @@ msgstr ""
 msgid "Sep"
 msgstr "九月"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:81
 #: lib/LedgerSMB/Scripts/configuration.pm:81
 msgid "Separate Duties"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB.pm:529 lib/LedgerSMB.pm:527 old/bin/aa.pl:76
-#: old/bin/gl.pl:71 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:529 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:71
 msgid "September"
 msgstr "九月"
 
@@ -7613,9 +6969,6 @@ msgstr ""
 msgid "Serial No."
 msgstr "序號"
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:112
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:167
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:306
 #: lib/LedgerSMB/Report/Contact/History.pm:112
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:306
@@ -7645,7 +6998,6 @@ msgstr "服務編號"
 msgid "Services"
 msgstr "服務"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:79
 #: lib/LedgerSMB/Scripts/configuration.pm:79
 #, fuzzy
 msgid "Session Timeout (e.g. \"90 minutes\")"
@@ -7659,7 +7011,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: UI/users/preferences.html:64
+#: UI/users/preferences.html:77
 msgid "Settings"
 msgstr ""
 
@@ -7679,10 +7031,10 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/order.pm:70 lib/LedgerSMB/Scripts/order.pm:70
-#: old/bin/io.pl:165 old/bin/oe.pl:1815 templates/demo/packing_list.html:89
-#: templates/demo/pick_list.html:87 templates/xedemo/packing_list.html:89
-#: templates/xedemo/pick_list.html:87 sql/Pg-database.sql:2604
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:165 old/bin/oe.pl:1815
+#: templates/demo/packing_list.html:89 templates/demo/pick_list.html:87
+#: templates/xedemo/packing_list.html:89 templates/xedemo/pick_list.html:87
+#: sql/Pg-database.sql:2604
 msgid "Ship"
 msgstr "付運"
 
@@ -7709,10 +7061,6 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:120
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:286
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:317
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:250
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:120
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
@@ -7773,10 +7121,6 @@ msgstr "未指明付運日期！"
 msgid "Shipping Label"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:116
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:282
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:246
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:116
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
@@ -7818,7 +7162,6 @@ msgstr "付運日期"
 msgid "Short"
 msgstr "短"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:131
 #: lib/LedgerSMB/Scripts/configuration.pm:131
 msgid "Show Credit Limit"
 msgstr ""
@@ -7859,7 +7202,6 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:102
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:102
 msgid "Sold"
 msgstr ""
@@ -7872,12 +7214,6 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:133
-#: UI/pod/src/LedgerSMB/Report/GL.pm:130 UI/pod/src/LedgerSMB/Report/GL.pm:223
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:81
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:136
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:199
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:480
 #: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
 #: lib/LedgerSMB/Report/GL.pm:223
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
@@ -7904,7 +7240,6 @@ msgstr "來源"
 msgid "Source documentation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:89
 msgid "Source starting with"
 msgstr ""
@@ -7926,21 +7261,10 @@ msgstr ""
 msgid "Standard"
 msgstr "標準"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/SIC.pm:63
 #: lib/LedgerSMB/Report/Listings/SIC.pm:63
 msgid "Standard Industrial Codes"
 msgstr "標準工業編碼"
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:125
-#: UI/pod/src/LedgerSMB/Report/Budget/Search.pm:73
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:123
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:153
-#: UI/pod/src/LedgerSMB/Report/GL.pm:215
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search_Adj.pm:83
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:158
-#: UI/pod/src/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
-#: UI/pod/src/LedgerSMB/Report/co/Caja_Diaria.pm:129
 #: lib/LedgerSMB/Report/Budget/Search.pm:125
 #: lib/LedgerSMB/Report/Budget/Search.pm:73
 #: lib/LedgerSMB/Report/Budget/Variance.pm:123
@@ -7971,8 +7295,6 @@ msgstr ""
 msgid "Startdate"
 msgstr "開始日期"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:173
-#: UI/pod/src/LedgerSMB/Report/co/Balance_y_Mayor.pm:80
 #: lib/LedgerSMB/Report/Trial_Balance.pm:173
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
@@ -8009,13 +7331,11 @@ msgstr ""
 msgid "Statement"
 msgstr "會計帳"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 #: UI/reconciliation/new_report.html:28
 msgid "Statement Balance"
 msgstr "會計帳餘額"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
 #: UI/reconciliation/new_report.html:38 UI/reconciliation/report.html:35
 msgid "Statement Date"
@@ -8046,7 +7366,7 @@ msgstr "把製成品入貨"
 msgid "Strength"
 msgstr ""
 
-#: UI/users/preferences.html:99
+#: UI/users/preferences.html:112
 msgid "Stylesheet"
 msgstr "樣式表"
 
@@ -8071,7 +7391,6 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:151
 #: UI/Reports/filters/reconciliation_search.html:78
 msgid "Submitted"
@@ -8114,7 +7433,6 @@ msgstr "摘要"
 msgid "Summary account for"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:110
 msgid "Sun"
 msgstr ""
@@ -8147,12 +7465,6 @@ msgstr ""
 msgid "TOTAL"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:128
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:90
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:567
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:676
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:783
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
 #: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
@@ -8164,9 +7476,6 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/Purchase.pm:90
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:234
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:284
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:90
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:534
@@ -8185,8 +7494,6 @@ msgstr ""
 msgid "Tax Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:116
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:112
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:112 UI/Contact/divs/credit.html:264
 #: UI/Contact/divs/credit.html:265
@@ -8197,17 +7504,14 @@ msgstr ""
 msgid "Tax Form Applied"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:127
 #: lib/LedgerSMB/Report/Taxform/Details.pm:127
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:71
 #: lib/LedgerSMB/Report/Taxform/List.pm:71
 msgid "Tax Form List"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:122
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:122
 msgid "Tax Form Report"
 msgstr ""
@@ -8351,7 +7655,6 @@ msgstr ""
 msgid "Template"
 msgstr "HTML 模版"
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Templates.pm:82
 #: lib/LedgerSMB/Report/Listings/Templates.pm:82
 msgid "Template Listing"
 msgstr ""
@@ -8360,7 +7663,6 @@ msgstr ""
 msgid "Template Saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:139
 msgid "Template Transactions"
 msgstr ""
@@ -8413,7 +7715,7 @@ msgstr ""
 msgid "The amount of"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/recon.pm:492 lib/LedgerSMB/Scripts/recon.pm:492
+#: lib/LedgerSMB/Scripts/recon.pm:492
 msgid "Their Balance"
 msgstr ""
 
@@ -8425,7 +7727,7 @@ msgstr ""
 msgid "Their Debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:550 lib/LedgerSMB/Upgrade_Tests.pm:550
+#: lib/LedgerSMB/Upgrade_Tests.pm:550
 msgid ""
 "There are NULL values in the amounts column of yoursource database. Please "
 "either find professional help to migrate yourdatabase, or delete the "
@@ -8476,24 +7778,21 @@ msgstr ""
 msgid "This document has been approved by"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1276
 #: lib/LedgerSMB/Scripts/payment.pm:1276
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2000
 #: lib/LedgerSMB/Scripts/payment.pm:2000
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1325
 #: lib/LedgerSMB/Upgrade_Tests.pm:1325
 msgid ""
 "This will <b>keep</b> the transactions but will <b>ignore</b> the non-"
 "necessary reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:846 lib/LedgerSMB/Upgrade_Tests.pm:846
+#: lib/LedgerSMB/Upgrade_Tests.pm:846
 msgid ""
 "This will <b>remove</b> the business references in <u>vendor</u> and "
 "<u>customer</u> tables"
@@ -8516,14 +7815,10 @@ msgstr ""
 msgid "Through date"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:126
 #: lib/LedgerSMB/Report/Timecards.pm:126
 msgid "Thu"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:145
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: lib/LedgerSMB/Report/GL.pm:145
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
@@ -8567,7 +7862,6 @@ msgstr "工時卡"
 msgid "Timecard Criteria"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:161
 #: lib/LedgerSMB/Report/Timecards.pm:161 sql/Pg-database.sql:2722
 msgid "Timecards"
 msgstr "工時卡"
@@ -8597,19 +7891,10 @@ msgstr ""
 msgid "To"
 msgstr "至"
 
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:188
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:188
 msgid "To Amount"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:168
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:190
-#: UI/pod/src/LedgerSMB/Report/Reconciliation/Summary.pm:184
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:115
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:111
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:149
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:207
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:151
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:168
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:190
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:184
@@ -8646,7 +7931,6 @@ msgstr ""
 msgid "To my browser"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:993
 #: lib/LedgerSMB/Scripts/payment.pm:993
 msgid "To pay"
 msgstr ""
@@ -8671,16 +7955,7 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:155
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:163
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:302
-#: UI/pod/src/LedgerSMB/Report/Invoices/COGS.pm:122
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:239
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:287
-#: UI/pod/src/LedgerSMB/Report/Taxform/Details.pm:103
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:99
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:493
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:935 lib/LedgerSMB/Report/Aging.pm:155
+#: lib/LedgerSMB/Report/Aging.pm:155
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:302
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
@@ -8723,7 +7998,7 @@ msgstr ""
 msgid "Total"
 msgstr "總計"
 
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:625 lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:625
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -8731,7 +8006,6 @@ msgstr ""
 msgid "Total Outstanding"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:133
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:133
 msgid "Total Paid"
 msgstr ""
@@ -8752,7 +8026,6 @@ msgstr "交易"
 msgid "Transaction Approval"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL/Invoice.pm:85
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:85
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342 UI/import_csv/import_csv.html:46
@@ -8768,14 +8041,12 @@ msgstr "未指明交易日期！"
 msgid "Transaction Dates"
 msgstr "交易日期"
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
 #: UI/Reports/filters/batches.html:14 UI/Reports/filters/unapproved.html:22
 #: UI/reconciliation/report.html:111 UI/reconciliation/report.html:234
 msgid "Transaction Type"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/Summary.pm:90
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:90
 #: UI/setup/confirm_operation.html:125
 msgid "Transactions"
@@ -8814,7 +8085,6 @@ msgstr "翻譯"
 msgid "Translations saved!"
 msgstr "已儲存翻譯！"
 
-#: UI/pod/src/LedgerSMB/Report/Trial_Balance.pm:142
 #: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2645
 msgid "Trial Balance"
 msgstr "試算表"
@@ -8823,7 +8093,6 @@ msgstr "試算表"
 msgid "Trillion"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:118
 #: lib/LedgerSMB/Report/Timecards.pm:118
 msgid "Tue"
 msgstr ""
@@ -8880,10 +8149,6 @@ msgstr ""
 msgid "Two"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:149
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: UI/pod/src/LedgerSMB/Scripts/asset.pm:471
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
@@ -8918,39 +8183,33 @@ msgstr ""
 msgid "Uncheck to remove entry from payment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:828 lib/LedgerSMB/Upgrade_Tests.pm:828
+#: lib/LedgerSMB/Upgrade_Tests.pm:828
 msgid ""
 "Undefined businesses.<br>Please make sure business used by vendors and "
 "constomers are defined.<br><i><b>Hover on buttons</b> to see their effects "
 "and impacts</i>"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/template.pm:118
 #: lib/LedgerSMB/Scripts/template.pm:118
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:528 lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:528
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:425 lib/LedgerSMB/Upgrade_Tests.pm:425
+#: lib/LedgerSMB/Upgrade_Tests.pm:425
 msgid "Unique Customernumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:444 lib/LedgerSMB/Upgrade_Tests.pm:444
+#: lib/LedgerSMB/Upgrade_Tests.pm:444
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1144
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:512 lib/LedgerSMB/Upgrade_Tests.pm:1144
-#: lib/LedgerSMB/Upgrade_Tests.pm:512
+#: lib/LedgerSMB/Upgrade_Tests.pm:1144 lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Contact/History.pm:93
-#: UI/pod/src/LedgerSMB/Report/Inventory/History.pm:133
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:209
 #: lib/LedgerSMB/Report/Contact/History.pm:93
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:209 old/bin/ic.pl:1247
@@ -8969,43 +8228,37 @@ msgstr "單位"
 msgid "Unit Price"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1248
 #: lib/LedgerSMB/Upgrade_Tests.pm:1248
 msgid "Unknown "
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1230
 #: lib/LedgerSMB/Upgrade_Tests.pm:1230
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1212
 #: lib/LedgerSMB/Upgrade_Tests.pm:1212
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:282 lib/LedgerSMB/Scripts/setup.pm:282
+#: lib/LedgerSMB/Scripts/setup.pm:282
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
 msgid "Unlock"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:215
 msgid "Unlock Batch"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:1314
 #: lib/LedgerSMB/Upgrade_Tests.pm:1314
 msgid "Unneeded Reconciliations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:231 lib/LedgerSMB/Scripts/setup.pm:231
+#: lib/LedgerSMB/Scripts/setup.pm:231
 msgid "Unsupported LedgerSMB version detected."
 msgstr ""
 
@@ -9013,23 +8266,18 @@ msgstr ""
 msgid "Unsupported Number"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:184 lib/LedgerSMB/Scripts/setup.pm:184
+#: lib/LedgerSMB/Scripts/setup.pm:184
 msgid "Unsupported SQL-Ledger version detected."
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:744
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:948 lib/LedgerSMB/Upgrade_Tests.pm:744
-#: lib/LedgerSMB/Upgrade_Tests.pm:948
+#: lib/LedgerSMB/Upgrade_Tests.pm:744 lib/LedgerSMB/Upgrade_Tests.pm:948
 msgid "Unsupported account categories"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:763
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:966 lib/LedgerSMB/Upgrade_Tests.pm:763
-#: lib/LedgerSMB/Upgrade_Tests.pm:966
+#: lib/LedgerSMB/Upgrade_Tests.pm:763 lib/LedgerSMB/Upgrade_Tests.pm:966
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:450
 #: lib/LedgerSMB/Scripts/contact.pm:450
 msgid "Unsupported account type"
 msgstr ""
@@ -9046,7 +8294,6 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/budgets.pm:98
 #: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:934 old/bin/aa.pl:959
 #: old/bin/gl.pl:248 old/bin/ic.pl:824 old/bin/ic.pl:833 old/bin/ir.pl:513
 #: old/bin/ir.pl:941 old/bin/is.pl:1048 old/bin/is.pl:575 old/bin/oe.pl:1932
@@ -9074,21 +8321,16 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:59
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:57
 #: lib/LedgerSMB/Report/File/Incoming.pm:59
 #: lib/LedgerSMB/Report/File/Internal.pm:57
 msgid "Uploaded At"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/File/Incoming.pm:62
-#: UI/pod/src/LedgerSMB/Report/File/Internal.pm:60
 #: lib/LedgerSMB/Report/File/Incoming.pm:62
 #: lib/LedgerSMB/Report/File/Internal.pm:60
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:386
 #: lib/LedgerSMB/Scripts/currency.pm:386
 msgid "Uploaded rates"
 msgstr ""
@@ -9097,7 +8339,6 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Asset.pm:103
 #: lib/LedgerSMB/Report/Listings/Asset.pm:103 UI/asset/edit_asset.html:91
 #: UI/asset/search_asset.html:86
 msgid "Usable Life"
@@ -9115,24 +8356,19 @@ msgstr ""
 msgid "Use Shipto"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1878
 #: lib/LedgerSMB/Scripts/payment.pm:1878
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:147
 #: lib/LedgerSMB/Scripts/configuration.pm:147
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:90
-#: UI/pod/src/LedgerSMB/Report/Inventory/Activity.pm:132
 #: lib/LedgerSMB/Report/Budget/Variance.pm:90
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:189
 #: lib/LedgerSMB/Scripts/contact.pm:189 UI/Contact/divs/user.html:3
 #: UI/main.html:27 t/data/04-complex_template.html:36
 msgid "User"
@@ -9142,7 +8378,6 @@ msgstr "使用者"
 msgid "User Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:1180
 #: lib/LedgerSMB/Scripts/setup.pm:1180
 msgid "User already exists. Import?"
 msgstr ""
@@ -9163,7 +8398,6 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:250
 #: lib/LedgerSMB/Scripts/currency.pm:250 UI/Contact/pricelist.csv:34
 #: UI/Contact/pricelist.html:46 UI/Contact/pricelist.tex:46
 msgid "Valid From"
@@ -9189,8 +8423,6 @@ msgstr "有效至"
 msgid "Valuation"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Budget/Variance.pm:95
-#: UI/pod/src/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 #: lib/LedgerSMB/Report/Budget/Variance.pm:95
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
@@ -9200,11 +8432,7 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Aging.pm:82
-#: UI/pod/src/LedgerSMB/Report/Invoices/Outstanding.pm:187
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:248
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:182
-#: UI/pod/src/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Aging.pm:82
+#: lib/LedgerSMB/Report/Aging.pm:82
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
@@ -9220,7 +8448,6 @@ msgstr ""
 msgid "Vendor"
 msgstr "供應商"
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Transactions.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
 msgid "Vendor Account"
 msgstr ""
@@ -9234,7 +8461,6 @@ msgstr "供應商歷史"
 msgid "Vendor Invoice"
 msgstr "供應商發票"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:119
 #: lib/LedgerSMB/Scripts/configuration.pm:119
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr "供應商發票/應付帳交易編號"
@@ -9244,9 +8470,6 @@ msgstr "供應商發票/應付帳交易編號"
 msgid "Vendor Name"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:115
-#: UI/pod/src/LedgerSMB/Report/Invoices/Payments.pm:178
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:126
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
 #: lib/LedgerSMB/Scripts/configuration.pm:126 old/bin/io.pl:1575
@@ -9276,9 +8499,7 @@ msgstr ""
 msgid "Vendor missing!"
 msgstr "未指明供應商！"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:858
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:904 lib/LedgerSMB/Upgrade_Tests.pm:858
-#: lib/LedgerSMB/Upgrade_Tests.pm:904
+#: lib/LedgerSMB/Upgrade_Tests.pm:858 lib/LedgerSMB/Upgrade_Tests.pm:904
 msgid "Vendor not in a business"
 msgstr ""
 
@@ -9286,8 +8507,6 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "沒有此供應商的記錄！"
 
-#: UI/pod/src/LedgerSMB/Report/GL.pm:103
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
@@ -9302,7 +8521,6 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 #: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
 msgid "Voucher List"
 msgstr ""
@@ -9315,7 +8533,6 @@ msgstr ""
 msgid "Wages and Deductions"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/contact.pm:190
 #: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "Wages/Deductions"
 msgstr ""
@@ -9338,7 +8555,6 @@ msgstr ""
 msgid "Warehouse saved!"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Listings/Warehouse.pm:58
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2663
 msgid "Warehouses"
 msgstr "倉庫"
@@ -9347,11 +8563,26 @@ msgstr "倉庫"
 msgid "Warning!"
 msgstr "警告！"
 
-#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40
-msgid "Warning:  Your password will expire in [_1]"
+#: UI/js/ui-header.html:46 UI/lib/ui-header.html:46 UI/users/preferences.html:58
+msgid "Warning: Your password will expire in [_1] days"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:122
+#: UI/js/ui-header.html:42 UI/lib/ui-header.html:42 UI/users/preferences.html:54
+msgid "Warning: Your password will expire in [_1] months"
+msgstr ""
+
+#: UI/js/ui-header.html:44 UI/lib/ui-header.html:44 UI/users/preferences.html:56
+msgid "Warning: Your password will expire in [_1] weeks"
+msgstr ""
+
+#: UI/js/ui-header.html:40 UI/lib/ui-header.html:40 UI/users/preferences.html:52
+msgid "Warning: Your password will expire in [_1] years"
+msgstr ""
+
+#: UI/js/ui-header.html:48 UI/lib/ui-header.html:48 UI/users/preferences.html:60
+msgid "Warning: Your password will expire today"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Timecards.pm:122
 msgid "Wed"
 msgstr ""
@@ -9361,7 +8592,6 @@ msgstr ""
 msgid "Week"
 msgstr "星期"
 
-#: UI/pod/src/LedgerSMB/Report/Timecards.pm:85
 #: lib/LedgerSMB/Report/Timecards.pm:85
 msgid "Week Starting"
 msgstr ""
@@ -9378,13 +8608,11 @@ msgstr ""
 msgid "Weeks"
 msgstr "星期"
 
-#: UI/pod/src/LedgerSMB/Report/Inventory/Search.pm:221
 #: lib/LedgerSMB/Report/Inventory/Search.pm:221 old/bin/ic.pl:542
 #: old/bin/ic.pl:569 old/bin/ic.pl:591 UI/Reports/filters/search_goods.html:366
 msgid "Weight"
 msgstr "重量"
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:59
 #: lib/LedgerSMB/Scripts/configuration.pm:59
 msgid "Weight Unit"
 msgstr "重量單位"
@@ -9401,7 +8629,6 @@ msgstr ""
 msgid "Whole Month Straight Line"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/configuration.pm:134
 #: lib/LedgerSMB/Scripts/configuration.pm:134
 msgid "Widgit Themes"
 msgstr ""
@@ -9419,11 +8646,11 @@ msgstr "工作單"
 msgid "Work order"
 msgstr "工作單"
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:155 lib/LedgerSMB/Scripts/setup.pm:155
+#: lib/LedgerSMB/Scripts/setup.pm:155
 msgid "Would you like to migrate the database?"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/setup.pm:158 lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:158
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
@@ -9466,15 +8693,10 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/Taxform/List.pm:100
 #: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1331
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "是"
-
-#: UI/users/preferences.html:52
-msgid "Your password will expire in [_1]"
-msgstr ""
 
 #: t/data/04-complex_template.html:388
 msgid "ZIP/Post Code"
@@ -9501,7 +8723,7 @@ msgstr ""
 msgid "Zip/Postal Code"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Report/PNL.pm:159 lib/LedgerSMB/Report/PNL.pm:159
+#: lib/LedgerSMB/Report/PNL.pm:159
 msgid ""
 "[_1]\n"
 "[_2]"
@@ -9565,17 +8787,12 @@ msgstr "日"
 msgid "debits"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:67
 #: lib/LedgerSMB/Scripts/currency.pm:67
 msgid "default"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/admin.pm:67
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:160
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:270
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:75 lib/LedgerSMB/Scripts/admin.pm:67
-#: lib/LedgerSMB/Scripts/currency.pm:160 lib/LedgerSMB/Scripts/currency.pm:270
-#: lib/LedgerSMB/Scripts/currency.pm:75
+#: lib/LedgerSMB/Scripts/admin.pm:67 lib/LedgerSMB/Scripts/currency.pm:160
+#: lib/LedgerSMB/Scripts/currency.pm:270 lib/LedgerSMB/Scripts/currency.pm:75
 msgid "delete"
 msgstr ""
 
@@ -9592,7 +8809,7 @@ msgstr ""
 msgid "done"
 msgstr "完成"
 
-#: UI/pod/src/LedgerSMB/Upgrade_Tests.pm:704 lib/LedgerSMB/Upgrade_Tests.pm:704
+#: lib/LedgerSMB/Upgrade_Tests.pm:704
 msgid "e"
 msgstr ""
 
@@ -9620,8 +8837,6 @@ msgstr ""
 msgid "in months"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:157
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:72
 #: lib/LedgerSMB/Scripts/currency.pm:157 lib/LedgerSMB/Scripts/currency.pm:72
 msgid "in use"
 msgstr ""
@@ -9630,22 +8845,18 @@ msgstr ""
 msgid "in years"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2028
 #: lib/LedgerSMB/Scripts/payment.pm:2028
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1729
 #: lib/LedgerSMB/Scripts/payment.pm:1729
 msgid "is lesser than 0"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1723
 #: lib/LedgerSMB/Scripts/payment.pm:1723
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:1985
 #: lib/LedgerSMB/Scripts/payment.pm:1985
 msgid "is null"
 msgstr ""
@@ -9670,7 +8881,6 @@ msgstr ""
 msgid "sent"
 msgstr "已送出"
 
-#: UI/pod/src/LedgerSMB/Scripts/currency.pm:152
 #: lib/LedgerSMB/Scripts/currency.pm:152
 msgid "system type"
 msgstr ""
@@ -9695,8 +8905,6 @@ msgstr ""
 msgid "unexpected error!"
 msgstr "沒有預期的錯誤！"
 
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2037
-#: UI/pod/src/LedgerSMB/Scripts/payment.pm:2056
 #: lib/LedgerSMB/Scripts/payment.pm:2037 lib/LedgerSMB/Scripts/payment.pm:2056
 msgid "use of an overpayment"
 msgstr ""

--- a/utils/devel/rebuild_pot.sh
+++ b/utils/devel/rebuild_pot.sh
@@ -29,12 +29,12 @@ EOF
 
 # EXTRACT STRINGS AND CREATE POT
 find . -name '*.pl' -o -name '*.pm' | \
-  grep -v blib | grep -v xt/lib/ | grep -v LaTeX | sort | \
+  grep -v '\(b\|xt/\)lib/\|UI/pod/' | grep -v LaTeX | sort | \
   utils/devel/extract-perl >> locale/LedgerSMB.pot
 
 find UI/ templates/ t/data/ \
      -name '*.html' -o -name '*.tex' -o -name '*.csv' | \
-   grep -v blib | grep -v dojo/ | sort | \
+   grep -v 'UI/\(js\|pod\)/)' | sort | \
    utils/devel/extract-template-translations >> locale/LedgerSMB.pot
 
 utils/devel/extract-sql < sql/Pg-database.sql >> locale/LedgerSMB.pot


### PR DESCRIPTION
When opening a DB connection, set the session to use ISO format
interval formatting (postgresql uses a human readable, locale
dependent format by default).

Fixes #1699.
