### PR TITLE
Install CPAN like project document generator

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -169,6 +169,7 @@ on 'develop' => sub {
     requires 'Perl::Critic::Policy::Modules::RequireExplicitInclusion';
     requires 'Pherkin::Extension::Weasel', '0.15';
     requires 'Plack::Middleware::Pod'; # YLA - Generate browseable documentation
+    requires 'Pod::ProjectDocs';
     requires 'Selenium::Remote::Driver';
     requires 'TAP::Parser::SourceHandler::pgTAP', '3.33';
     requires 'Test::BDD::Cucumber', '0.73';


### PR DESCRIPTION
Project documentation can be installed with `make pod` but lacked the generator.
This makes sure it is installed.