### PR TITLE
Ensure clean HTML tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,7 +110,7 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: Run Perl tests
-        run: prove --verbose --jobs 2 --time --recurse --pgtap-option dbname=lsmbinstalltest --pgtap-option username=postgres --feature-option tags=~@wip t/ xt/
+        run: prove --failures --jobs 2 --time --recurse --pgtap-option dbname=lsmbinstalltest --pgtap-option username=postgres --feature-option tags=~@wip t/ xt/
         env:
           PGHOST: localhost
           PGPORT: 5432

--- a/UI/Configuration/rate.html
+++ b/UI/Configuration/rate.html
@@ -48,7 +48,9 @@
       [% PROCESS input element_data={
              label=text('Rate')
              name='rate'
-             type='exchangerate'
+             type='text'
+             size = '5'
+             maxlength = '20'
              required=1
          } %]
 

--- a/UI/journal/journal_entry.html
+++ b/UI/journal/journal_entry.html
@@ -194,7 +194,7 @@
                           [% PROCESS input element_data = {
                                   value = displayrow.debit
                                   name = "debit_$INDEX"
-                                  type = "currency"
+                                  type = "text"
                                   size = 12
                                   accesskey = displayrow.index
                                   id = "deb_$INDEX"
@@ -206,7 +206,7 @@
                           [% PROCESS input element_data = {
                                   value = displayrow.credit
                                   name = "credit_$INDEX"
-                                  type = "currency"
+                                  type = "text"
                                   size = 12
                                   id = "cre_$INDEX"
                                       }  %]
@@ -292,7 +292,7 @@
          [% PROCESS input element_data = {
                         value = displayrow.debit_fx
                         name = "debit_fx_$INDEX"
-                        type = "currency"
+                        type = "text"
                                   size = 12
                                   accesskey = displayrow.index
                                   id = "deb_fx_$INDEX"
@@ -303,7 +303,7 @@
          [% PROCESS input element_data = {
                                   value = displayrow.credit_fx
                                   name = "credit_fx_$INDEX"
-                                  type = "currency"
+                                  type = "text"
                                   size = 12
                                   id = "cre_fx_$INDEX"
                                       }  %]

--- a/UI/lib/elements.html
+++ b/UI/lib/elements.html
@@ -15,10 +15,6 @@
   input_keys.radio        = default_input_keys.merge(['checked'])
   input_keys.password     = default_input_keys
   input_keys.date         = default_input_keys
-  input_keys.text         = default_input_keys
-  input_keys.currency     = default_input_keys
-  input_keys.monetary     = default_input_keys
-  input_keys.exchangerate = default_input_keys
   input_keys.text         = default_input_keys.merge(['maxlength', 'readonly'])
 
 
@@ -58,29 +54,6 @@
   element_defaults.text = {
     size = '60',
     maxlength = '255',
-    "data-dojo-type" = "dijit/form/ValidationTextBox"
-  }
-
-  # default currency
-  # this is a workaround for https://github.com/ledgersmb/LedgerSMB/issues/2270
-  element_defaults.currency = element_defaults.text
-#  currency_defaults = {
-#    "data-dojo-type" = 'dijit/form/CurrencyTextBox',
-#    "data-dojo-props" = "currency:'$SETTINGS.default_currency'"
-#  }
-
-  # default monetary (currency without currency indicator)
-  # this is a workaround for https://github.com/ledgersmb/LedgerSMB/issues/2270
-  element_defaults.monetary = element_defaults.text
-#  monetary_defaults = {
-#    "data-dojo-type" = 'dijit/form/NumberTextBox',
-#    "data-dojo-props" = "constraints:{pattern:'0.00'}"
-#  }
-
-  # default exchangerate
-  element_defaults.exchangerate = {
-    size = '5',
-    maxlength = '20',
     "data-dojo-type" = "dijit/form/ValidationTextBox"
   }
 


### PR DESCRIPTION
Remove exchangerate, currency & monetary tags and replace them by text tags to ensure valid HTML inputs