### PR TITLE
Remove all uses of Company_Config other than PGNumber

### DIFF
--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -283,7 +283,6 @@ use strict;
 use warnings;
 use Carp;
 
-use LedgerSMB::Company_Config;
 use LedgerSMB::File;
 use LedgerSMB::Locale;
 use LedgerSMB::Magic qw( FC_INTERNAL );
@@ -515,9 +514,6 @@ sub _render {
     my $vars = shift;
     my $cvars = shift // {};
     $vars->{USER} = $self->{user};
-    $vars->{SETTINGS} = {
-        %$LedgerSMB::Company_Config::settings,
-    } if $vars->{DBNAME} && $LedgerSMB::Company_Config::settings;
 
     my $format = "LedgerSMB::Template::$self->{format}";
     my $escape = $format->can('escape');

--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -50,7 +50,6 @@ use LedgerSMB::IR;
 use LedgerSMB::IS;
 use LedgerSMB::Setting;
 use LedgerSMB::Tax;
-use LedgerSMB::Company_Config;
 use LedgerSMB::DBObject::Draft;
 use LedgerSMB::DBObject::TransTemplate;
 
@@ -361,7 +360,7 @@ sub create_links {
 }
 
 sub form_header {
-     my $min_lines = $LedgerSMB::Company_Config::settings->{min_empty} // 0;
+     my $min_lines = $form->get_setting('min_empty') // 0;
 
      $form->generate_selects(\%myconfig) unless $form->{"select$form->{ARAP}"};
     $title = $form->{title};

--- a/old/bin/arapprn.pl
+++ b/old/bin/arapprn.pl
@@ -43,7 +43,6 @@ package lsmb_legacy;
 
 use LedgerSMB::Legacy_Util;
 use LedgerSMB::Template;
-use LedgerSMB::Company_Config;
 
 require 'old/bin/aa.pl'; # for arapprn::reprint() and arapprn::print[_transaction]()
 require 'old/bin/printer.pl';# centralizing print options display
@@ -54,7 +53,14 @@ if ( -f "old/bin/custom/arapprn.pl" ) {
 }
 
 # end of main
-
+my %copy_settings = (
+    email => 'company_email',
+    company => 'company_name',
+    businessnumber => 'businessnumber',
+    address => 'company_address',
+    tel => 'company_phone',
+    fax => 'company_fax',
+    );
 sub print {
 
     &create_links;
@@ -72,13 +78,9 @@ sub print {
 
     }
 
-    my $csettings = $LedgerSMB::Company_Config::settings;
-    $form->{company} = $csettings->{company_name};
-    $form->{businessnumber} = $csettings->{businessnumber};
-    $form->{email} = $csettings->{company_email};
-    $form->{address} = $csettings->{company_address};
-    $form->{tel} = $csettings->{company_phone};
-    $form->{fax} = $csettings->{company_fax};
+    while (my ($key, $setting) = each %copy_settings ) {
+        $form->{$key} = $form->get_setting($setting);
+    }
 
     if ( $form->{media} !~ /screen/ ) {
         $form->error( $locale->text('Select postscript or PDF!')  )

--- a/old/bin/gl.pl
+++ b/old/bin/gl.pl
@@ -50,7 +50,6 @@ use LedgerSMB::GL;
 use LedgerSMB::PE;
 use LedgerSMB::Template::UI;
 use LedgerSMB::Setting::Sequence;
-use LedgerSMB::Company_Config;
 use LedgerSMB::Legacy_Util;
 use LedgerSMB::DBObject::Draft;
 use LedgerSMB::DBObject::TransTemplate;
@@ -155,8 +154,7 @@ sub add {
 
 sub display_form
 {
-    $form->{separate_duties}
-        = $LedgerSMB::Company_Config::settings->{separate_duties};
+    $form->{separate_duties} = $form->get_setting('separate_duties');
     #Add General Ledger Transaction
 
     # filter out '' transdates
@@ -535,7 +533,7 @@ sub gl_subtotal {
 
 sub update {
     &create_links;
-     my $min_lines = $LedgerSMB::Company_Config::settings->{min_empty};
+     my $min_lines = $form->get_setting('min_empty');
      $form->open_form unless $form->check_form;
 
      $form->{transdate} = LedgerSMB::PGDate->from_input($form->{transdate})->to_output();

--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -1091,7 +1091,7 @@ sub update {
     my $current_empties = $form->{rowcount} - $non_empty_rows;
     my $new_empties =
         max(0,
-            max($LedgerSMB::Company_Config::settings->{min_empty}, 1)
+            max($form->get_setting('min_empty'),1)
             - $current_empties);
 
 

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -1211,7 +1211,7 @@ sub update {
     my $current_empties = $form->{rowcount} - $non_empty_rows;
     my $new_empties =
         max(0,
-            max($LedgerSMB::Company_Config::settings->{min_empty},1)
+            max($form->get_setting('min_empty'),1)
             - $current_empties);
 
 

--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -1037,7 +1037,7 @@ sub update {
     my $current_empties = $form->{rowcount} - $non_empty_rows;
     my $new_empties =
         max(0,
-            max($LedgerSMB::Company_Config::settings->{min_empty}, 1)
+            max($form->get_setting('min_empty'),1)
             - $current_empties);
 
 

--- a/old/bin/printer.pl
+++ b/old/bin/printer.pl
@@ -8,7 +8,6 @@ printer.pl - centralized printing logic used for printing in legacy sl code
 package lsmb_legacy;
 use LedgerSMB::Sysconfig;
 use LedgerSMB::Setting;
-use LedgerSMB::Company_Config;
 
 sub print_options {
 

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -1153,7 +1153,7 @@ sub generate_selects {
                 }
           }
 
-        my $min_lines = $LedgerSMB::Company_Config::settings->{min_empty} // 0;
+        my $min_lines = $form->get_setting('min_empty') // 0;
         my $rowcount = $form->{rowcount} + $min_lines;
         if ($rowcount) {
                 for my $i ( 1 .. $rowcount ) {

--- a/old/lib/LedgerSMB/IC.pm
+++ b/old/lib/LedgerSMB/IC.pm
@@ -966,7 +966,7 @@ sub create_links {
                      WHERE entity_class = 1|;
         my ($count) = $dbh->selectrow_array($query);
 
-        if ( $count < $LedgerSMB::Company_Config::settings->{vclimit} ) {
+        if ( $count < $form->get_setting('vclimit') ) {
             $query = qq|SELECT v.id, e.name
                 FROM entity_credit_account v
                 join entity e on e.id = v.entity_id
@@ -988,7 +988,7 @@ sub create_links {
                 where entity_class = 2|;
     ($count) = $dbh->selectrow_array($query);
 
-    if ( $count < $LedgerSMB::Company_Config::settings->{vclimit} ) {
+    if ( $count < $form->get_setting('vclimit') ) {
         $query = qq|SELECT c.id, e.name
             FROM entity_credit_account c
             join entity e on e.id = c.entity_id


### PR DESCRIPTION
As part of the quest to remove as much global state as possible, remove
as much use of Company_Config as possible: there's no need to have this
configuration in global state.

The remaining issue is with PGNumber, which depends on it for the
number of decimal places in number formatting. Replacing it entirely
seems rather straight forward, except for the uses in Report and
Report/Hierarchical which currently don't seem to have access to the
request object.