### PR TITLE
Move logo insertion inside the TT comment

### DIFF
--- a/templates/demo/letterhead.tex
+++ b/templates/demo/letterhead.tex
@@ -32,8 +32,12 @@ releases. No explicit versioning was applied before 2021-01-04.
 
   For information on the avaliable options for the 'includegraphics'
   command, see https://en.wikibooks.org/wiki/LaTeX/Importing_Graphics
+
+  Example:
+
+    \includegraphics[scale=0.3]{<?lsmb dbfile_path('logo.png') ?>}
+
     ?>
-    %\includegraphics[scale=0.3]{<?lsmb dbfile_path('logo.png') ?>}
     }\hfill
   \begin{tabular}[b]{rr@{}}
   <?lsmb text('Tel:') ?> & <?lsmb tel ?>\\


### PR DESCRIPTION
Even though the template evaluation is inside a TeX comment, TT still
tries to insert the path to the logo file. Hence when using this template,
a logo file is absolutely required (but it's not imported by default).
