### PR TITLE
Move Github Actions to a weekly schedule [skip ci]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,11 +4,8 @@ name: CI
 
 # Controls when the action will run.
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
-  push:
-    branches: '*'
-  pull_request:
-    branches: '*'
+  schedule:
+    - cron: "0 0 * * 0"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Instead of on every push & pull request, run github actions on each Sunday at midnight