### PR TITLE
Migrate sl30 mc

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -27,6 +27,7 @@ Removed functionalities
 * Configuration setting 'Only Timeout Locks' removed
 
 Bugs fixed
+* Optimize listing of configured currencies (don't check in-use)
 * Fixed mailing of aging reports (regression since 1.3.42)
 * Optimize listing of configured currencies (don't check in-use)
 * Default CoA referential integrity and consistency

--- a/lib/LedgerSMB/Database/Upgrade.pm
+++ b/lib/LedgerSMB/Database/Upgrade.pm
@@ -42,6 +42,14 @@ my %migration_script = (
     'ledgersmb/1.3'  => '1.3-1.5',
     );
 
+my %migration_upto = (
+    'sql-ledger/2.8' => 'migration-target-sl',
+    'sql-ledger/3.0' => 'migration-target-sl',
+    'sql-ledger/3.2' => undef,
+    'ledgersmb/1.2'  => 'migration-target-lsmb',
+    'ledgersmb/1.3'  => 'migration-target-lsmb',
+    );
+
 
 =head1 ATTRIBUTES
 
@@ -220,6 +228,7 @@ sub run_upgrade_script {
     my ($self, $vars) = @_;
     my $src_schema = $migration_schema{$self->type};
     my $template   = $migration_script{$self->type};
+    my $upto       = $migration_upto{$self->type};
 
     my $dbh = $self->database->connect({ PrintError => 0, AutoCommit => 0 });
     my $temp = $self->database->loader_log_filename();
@@ -244,7 +253,7 @@ sub run_upgrade_script {
     $self->database->load_base_schema(
         log     => $temp . '_stdout',
         errlog  => $temp . '_stderr',
-        upto_tag=> 'migration-target'
+        upto_tag=> $upto
         );
 
     $dbh->do(q(

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -52,7 +52,7 @@
 1.5/fixed-assets-not-null-constraints.sql
 1.5/template_menu-v2.sql
 1.5/abstract_tables.sql
-#tag: migration-target
+#tag: migration-target-lsmb
 # Note: the schema as created up to here, is the one as required by
 #   the migration scripts in sql/upgrade/. Don't insert any change
 #   scripts before this point, because it breaks the migrations from
@@ -98,6 +98,7 @@ mc/new-constraints.sql
 mc/dropped-objects.sql
 mc/views.sql
 mc/delete-migration-validation-data.sql
+#tag: migration-target-sl
 # 1.7 changes
 1.7/drop-custom-catalog.sql
 1.7/alter-menu-attributes.sql
@@ -141,4 +142,3 @@ mc/delete-migration-validation-data.sql
 1.9/company-strict-sic.sql
 1.9/workflow-schema.sql
 1.9/workflow-email-table.sql
-


### PR DESCRIPTION
Allow SQL-Ledger to have a different migration start point than LedgerSMB to cope with the the fact that it does support multi-currencies since version 2.8, whereas LedgerSMB got them in 1.7. 
So LedgerSMB migration start point is before multi-currencies whereas SQL-Ledger needs to migrate with the MC fixes in place