### PR TITLE
Issue 975

### DIFF
--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -1183,6 +1183,7 @@ sub approve {
 
 sub update {
     my $display = shift;
+    my $form_id = delete $form->{id};
     $form->open_form() unless $form->check_form();
     $is_update = 1;
         $form->{invtotal} = 0;
@@ -1282,6 +1283,7 @@ sub update {
 
     &create_links;
     $form->generate_selects(\%myconfig);
+    $form->{id} = $form_id;
     &display_form;
 
 }

--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -960,7 +960,7 @@ sub form_footer {
             'print' =>
               { ndx => 3, key => 'P', value => $locale->text('Print'),
                 type => 'lsmb/PrintButton' },
-            'edit_and_save' => { ndx   => 4, key   => 'E', value => $locale->text('Save Draft') },
+            'edit_and_save' => { ndx   => 4, key   => 'E', value => $locale->text('Save') },
             'post' => { ndx => 5, key => 'O', value => $locale->text('Post') },
             'post_as_new' => { ndx => 6, key => 'O', value => $locale->text('Post') },
             'approve' => { ndx   => 7, key   => 'O', value => $locale->text('Post') },

--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -1023,6 +1023,7 @@ qq|<td align=center><input data-dojo-type="dijit/form/TextBox" name="memo_$i" id
 }
 
 sub update {
+    my $form_id = delete $form->{id}; # github issue #975
     $form->{ARAP} = 'AP';
     delete $form->{"partnumber_$form->{delete_line}"} if $form->{delete_line};
     $form->{exchangerate} =
@@ -1214,6 +1215,7 @@ sub update {
                     $form->{"id_$i"}   = 0;
                     $form->{"unit_$i"} = $locale->text('ea');
 
+                    $form->{id} = $form_id;
                     &new_item;
 
                 }
@@ -1229,6 +1231,7 @@ sub update {
     check_form();
 
     $form->{rowcount}--;
+    $form->{id} = $form_id;
     display_form();
 }
 

--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -557,7 +557,7 @@ sub form_header {
                    $button{edit_and_save} = {
                        ndx   => 4,
                        key   => 'E',
-                       value => $locale->text('Save Draft') };
+                       value => $locale->text('Save') };
               }
                # Delete these for batches too
                delete $button{$_}

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -1133,6 +1133,7 @@ qq|<td align="center"><input data-dojo-type="dijit/form/TextBox" name="memo_$i" 
 }
 
 sub update {
+    my $form_id = delete $form->{id}; # github issue #975
     $form->{ARAP} = 'AR';
     delete $form->{"partnumber_$form->{delete_line}"} if $form->{delete_line};
     $form->{exchangerate} =
@@ -1330,6 +1331,7 @@ sub update {
                     && ( $form->{"description_$i"} eq "" ) )
                 {
                     $form->{rowcount}--;
+                    $form->{id} = $form_id;
                     &display_form;
                 }
                 else {
@@ -1337,6 +1339,7 @@ sub update {
                     $form->{"id_$i"}   = 0;
                     $form->{"unit_$i"} = $locale->text('ea');
 
+                    $form->{id} = $form_id;
                     &new_item;
 
                 }
@@ -1352,6 +1355,7 @@ sub update {
     check_form();
 
     $form->{rowcount}--;
+    $form->{id} = $form_id;
     display_form();
 }
 

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -623,7 +623,7 @@ sub form_header {
                        $button{edit_and_save} = {
                            ndx   => 4,
                            key   => 'E',
-                           value => $locale->text('Save Draft') };
+                           value => $locale->text('Save') };
                    }
               }
                delete $button{$_}

--- a/sql/modules/Drafts.sql
+++ b/sql/modules/Drafts.sql
@@ -137,6 +137,7 @@ begin
                      WHERE pl.payment_id = p.id) <= 1;
 
         DELETE FROM acc_trans WHERE trans_id = in_id;
+        DELETE FROM invoice WHERE trans_id = in_id;
         SELECT lower(table_name) into t_table
           FROM transactions where id = in_id;
 


### PR DESCRIPTION
Fix #975! What I had thought to be impossible in the current code-base has a contrived but targetted solution. Note that this fix may be only 2-3 lines per workflow script, but that the scope of the impact is much broader, because the 'id' is unavailable throughout the entire scope of the "update" function and all code in encloses.