### PR TITLE
Fix #5298: Spurious gutter in HTML template main table

### DIFF
--- a/templates/demo/ap_transaction.html
+++ b/templates/demo/ap_transaction.html
@@ -27,13 +27,11 @@ releases. No explicit versioning was applied before 2021-01-04.
   <table width="100%">
     <?lsmb INCLUDE letterhead ?>
     <tr>
-      <td width="10">&nbsp;</td>
       <th colspan="3">
         <h4 class="c1"><?lsmb text('AP Transaction') ?></h4>
       </th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" cellspacing="0" cellpadding="0">
           <tr valign="top">
@@ -88,7 +86,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table>
           <?lsmb FOREACH account ?><?lsmb loop_count = loop.count - 1 ?>
@@ -127,11 +124,9 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td><?lsmb text_amount ?>***** <?lsmb decimal ?>/100 <?lsmb currency ?></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <?lsmb  FOREACH P IN notes.split('\n\n') ?>
         <p><?lsmb P ?></p><?lsmb END ?>
@@ -176,7 +171,7 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr><?lsmb IF taxincluded ?>
     <tr>
-      <td>&nbsp;</td>
+      <td></td>
     </tr>
     <tr>
       <th colspan="3" align="left"><span class=

--- a/templates/demo/ar_transaction.html
+++ b/templates/demo/ar_transaction.html
@@ -27,13 +27,11 @@ releases. No explicit versioning was applied before 2021-01-04.
   <table width="100%">
     <?lsmb INCLUDE letterhead ?>
     <tr>
-      <td width="10">&nbsp;</td>
       <th colspan="3">
         <h4 class="c1"><?lsmb text('AR Transaction') ?></h4>
       </th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" cellspacing="0" cellpadding="0">
           <tr valign="top">
@@ -86,7 +84,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table>
           <?lsmb FOREACH account ?><?lsmb loop_count = loop.count - 1 ?>
@@ -125,18 +122,15 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td><?lsmb text_amount ?>***** <?lsmb decimal ?>/100 <?lsmb currency ?></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <?lsmb  FOREACH P IN notes.split('\n\n') ?>
         <p><?lsmb P ?></p><?lsmb END ?>
       </td>
     </tr><?lsmb IF paid_1 ?>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table>
           <tr>
@@ -172,13 +166,12 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr><?lsmb FOREACH tax ?><?lsmb loop_count = loop.count - 1 ?>
     <tr>
-      <td>&nbsp;</td>
       <th colspan="9" align="left"><span class=
       "c2"><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?>
       <?lsmb text('Registration') _ ' ' _  taxnumber.${loop_count} ?></span></th>
     </tr><?lsmb END ?><?lsmb IF taxincluded ?>
     <tr>
-      <td>&nbsp;</td>
+      <td></td>
     </tr>
     <tr>
       <th colspan="3" align="left"><span class=

--- a/templates/demo/bin_list.html
+++ b/templates/demo/bin_list.html
@@ -28,7 +28,6 @@ releases. No explicit versioning was applied before 2021-01-04.
   <table width="100%">
     <?lsmb INCLUDE letterhead ?>
     <tr>
-      <td width="10">&nbsp;</td>
       <th colspan="3">
         <h4 class="c1"><?lsmb text('Bin List') ?></h4>
       </th>
@@ -70,7 +69,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" border="1">
           <tr>
@@ -94,7 +92,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr class="c3">
@@ -123,7 +120,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <hr noshade>
       </td>

--- a/templates/demo/invoice.html
+++ b/templates/demo/invoice.html
@@ -27,14 +27,12 @@ releases. No explicit versioning was applied before 2021-01-04.
   <table width="100%">
     <?lsmb INCLUDE letterhead ?>
     <tr>
-      <td width="10">&nbsp;</td>
       <th colspan="3">
         <h4 class="c1">
         <?lsmb IF reverse; text('Credit Invoice'); ELSE; text('Invoice'); END; ?></h4>
       </th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" cellspacing="0" cellpadding="0">
           <tr class="c3">
@@ -74,7 +72,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" border="1">
           <tr>
@@ -99,7 +96,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr class="c3">
@@ -162,7 +158,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="top">
@@ -178,7 +173,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr><?lsmb IF paymentdate.0 ?>
     <tr>
-      <td>&nbsp;</td>
       <td colspan="9">
         <table width="60%">
           <tr>
@@ -208,11 +202,9 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <th><?lsmb text('Thank you for your valued business!') ?></th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="top">
@@ -227,13 +219,12 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr><?lsmb FOREACH tax ?><?lsmb loop_count = loop.count - 1 ?>
     <tr>
-      <td>&nbsp;</td>
       <th colspan="9" align="left"><span class=
       "c5"><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?>
       <?lsmb text('Registration [_1]', taxnumber.${loop_count}) ?></span></th>
     </tr><?lsmb END ?><?lsmb IF taxincluded ?>
     <tr>
-      <td>&nbsp;</td>
+      <td></td>
     </tr>
     <tr>
       <th colspan="8" align="left"><span class=

--- a/templates/demo/letterhead.html
+++ b/templates/demo/letterhead.html
@@ -10,7 +10,6 @@ releases. No explicit versioning was applied before 2021-01-04.
 
 -?>
   <tr>
-    <td width="10">&nbsp;</td>
     <td>
       <table width="100%">
         <tr>

--- a/templates/demo/packing_list.html
+++ b/templates/demo/packing_list.html
@@ -29,13 +29,11 @@ releases. No explicit versioning was applied before 2021-01-04.
   <table width="100%">
     <?lsmb INCLUDE letterhead ?>
     <tr>
-      <td width="10">&nbsp;</td>
       <th colspan="3">
         <h4 class="c1"><?lsmb text('Packing List') ?></h4>
       </th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" cellspacing="0" cellpadding="0">
           <tr class="c3">
@@ -61,7 +59,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" border="1">
           <tr>
@@ -87,7 +84,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr class="c3">
@@ -114,13 +110,11 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <hr noshade>
       </td>
     </tr><?lsmb IF notes ?>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="top">
@@ -134,7 +128,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr><?lsmb END ?>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="top">

--- a/templates/demo/pick_list.html
+++ b/templates/demo/pick_list.html
@@ -28,13 +28,11 @@ releases. No explicit versioning was applied before 2021-01-04.
   <table width="100%">
     <?lsmb INCLUDE letterhead ?>
     <tr>
-      <td width="10">&nbsp;</td>
       <th colspan="3">
         <h4 class="c1"><?lsmb text('Pick List') ?></h4>
       </th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" cellspacing="0" cellpadding="0">
           <tr class="c3">
@@ -61,7 +59,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" border="1">
           <tr>
@@ -87,7 +84,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr class="c3">
@@ -112,7 +108,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <hr noshade>
       </td>

--- a/templates/demo/product_receipt.html
+++ b/templates/demo/product_receipt.html
@@ -28,13 +28,11 @@ releases. No explicit versioning was applied before 2021-01-04.
   <table width="100%">
     <?lsmb INCLUDE letterhead ?>
     <tr>
-      <td width="10">&nbsp;</td>
       <th colspan="3">
         <h4 class="c1"><?lsmb text('Product Receipt') ?></h4>
       </th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" cellspacing="0" cellpadding="0">
           <tr class="c3">
@@ -70,7 +68,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" border="1">
           <tr>
@@ -91,7 +88,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr class="c3">
@@ -160,7 +156,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr><?lsmb IF notes ?>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="top">
@@ -174,7 +169,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr><?lsmb END ?>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="top">

--- a/templates/demo/request_quotation.html
+++ b/templates/demo/request_quotation.html
@@ -28,13 +28,11 @@ releases. No explicit versioning was applied before 2021-01-04.
   <table width="100%">
     <?lsmb INCLUDE letterhead ?>
     <tr>
-      <td width="10">&nbsp;</td>
       <th colspan="3">
         <h4 class="c1"><?lsmb text('Request for Quotation') ?></h4>
       </th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr class="c3">
@@ -70,7 +68,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" border="1">
           <tr>
@@ -96,14 +93,12 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td><?lsmb text('Please provide price and delivery time for the following items:') ?></td>
     </tr>
     <tr>
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr>
@@ -132,7 +127,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr><?lsmb IF notes ?>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="top">

--- a/templates/demo/sales_order.html
+++ b/templates/demo/sales_order.html
@@ -29,13 +29,11 @@ releases. No explicit versioning was applied before 2021-01-04.
   <table width="100%">
     <?lsmb INCLUDE letterhead ?>
     <tr>
-      <td width="10">&nbsp;</td>
       <th colspan="3">
         <h4 class="c1"><?lsmb text('Sales Order') ?></h4>
       </th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" cellspacing="0" cellpadding="0">
           <tr class="c3">
@@ -73,7 +71,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" border="1">
           <tr>
@@ -96,7 +93,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr class="c3">
@@ -156,7 +152,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="top">
@@ -172,7 +167,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="top">

--- a/templates/demo/sales_quotation.html
+++ b/templates/demo/sales_quotation.html
@@ -29,13 +29,11 @@ releases. No explicit versioning was applied before 2021-01-04.
   <table width="100%">
     <?lsmb INCLUDE letterhead ?>
     <tr>
-      <td width="10">&nbsp;</td>
       <th colspan="3" class="c1">
         <h4><?lsmb text('Quotation') ?></h4>
       </th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="top">
@@ -55,7 +53,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" border="1">
           <tr>
@@ -78,7 +75,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr class="c3">
@@ -138,7 +134,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="top">
@@ -154,7 +149,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="top">

--- a/templates/demo/statement.html
+++ b/templates/demo/statement.html
@@ -27,17 +27,14 @@ releases. No explicit versioning was applied before 2021-01-04.
   <table width="100%">
     <?lsmb INCLUDE letterhead ?>
     <tr>
-      <td width="10">&nbsp;</td>
       <th colspan="3">
         <h4 class="c1"><?lsmb text('Statement') ?></h4>
       </th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td colspan="3" align="right"><?lsmb statementdate ?></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="top">
@@ -55,7 +52,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr>
@@ -100,7 +96,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td align="right">
         <table width="50%">
           <tr>
@@ -111,7 +106,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <hr noshade>
       </td>

--- a/templates/demo/timecard.html
+++ b/templates/demo/timecard.html
@@ -26,13 +26,11 @@ releases. No explicit versioning was applied before 2021-01-04.
   <table width="100%">
     <?lsmb INCLUDE letterhead ?>
     <tr>
-      <td width="10">&nbsp;</td>
       <th colspan="3">
         <h4 class="c1"><?lsmb text('Time Card') ?></h4>
       </th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" cellspacing="0" cellpadding="0">
           <tr valign="top">
@@ -80,7 +78,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="bottom">
@@ -124,7 +121,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <?lsmb  FOREACH P IN notes.split('\n\n') ?>
         <p><?lsmb P ?></p><?lsmb END ?>

--- a/templates/demo/work_order.html
+++ b/templates/demo/work_order.html
@@ -28,13 +28,11 @@ releases. No explicit versioning was applied before 2021-01-04.
   <table width="100%">
     <?lsmb INCLUDE letterhead ?>
     <tr>
-      <td width="10">&nbsp;</td>
       <th colspan="3">
         <h4 class="c1"><?lsmb text('Work Order') ?></h4>
       </th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" cellspacing="0" cellpadding="0">
           <tr class="c3">
@@ -72,7 +70,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" border="1">
           <tr>
@@ -95,7 +92,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr class="c3">
@@ -124,8 +120,7 @@ releases. No explicit versioning was applied before 2021-01-04.
         </table>
       </td>
     </tr>
-    <tr>
-      <td>&nbsp;</td><?lsmb IF notes ?>
+    <tr><?lsmb IF notes ?>
       <td>
         <?lsmb  FOREACH P IN notes.split('\n\n') ?>
         <p><?lsmb P ?></p><?lsmb END ?>

--- a/templates/xedemo/ap_transaction.html
+++ b/templates/xedemo/ap_transaction.html
@@ -27,13 +27,11 @@ releases. No explicit versioning was applied before 2021-01-04.
   <table width="100%">
     <?lsmb INCLUDE letterhead ?>
     <tr>
-      <td width="10">&nbsp;</td>
       <th colspan="3">
         <h4 class="c1"><?lsmb text('AP Transaction') ?></h4>
       </th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" cellspacing="0" cellpadding="0">
           <tr valign="top">
@@ -88,7 +86,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table>
           <?lsmb FOREACH account ?><?lsmb loop_count = loop.count - 1 ?>
@@ -127,11 +124,9 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td><?lsmb text_amount ?>***** <?lsmb decimal ?>/100 <?lsmb currency ?></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <?lsmb  FOREACH P IN notes.split('\n\n') ?>
         <p><?lsmb P ?></p><?lsmb END ?>
@@ -176,7 +171,7 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr><?lsmb IF taxincluded ?>
     <tr>
-      <td>&nbsp;</td>
+      <td></td>
     </tr>
     <tr>
       <th colspan="3" align="left"><span class=

--- a/templates/xedemo/ar_transaction.html
+++ b/templates/xedemo/ar_transaction.html
@@ -27,13 +27,11 @@ releases. No explicit versioning was applied before 2021-01-04.
   <table width="100%">
     <?lsmb INCLUDE letterhead ?>
     <tr>
-      <td width="10">&nbsp;</td>
       <th colspan="3">
         <h4 class="c1"><?lsmb text('AR Transaction') ?></h4>
       </th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" cellspacing="0" cellpadding="0">
           <tr valign="top">
@@ -86,7 +84,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table>
           <?lsmb FOREACH account ?><?lsmb loop_count = loop.count - 1 ?>
@@ -125,18 +122,15 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td><?lsmb text_amount ?>***** <?lsmb decimal ?>/100 <?lsmb currency ?></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <?lsmb  FOREACH P IN notes.split('\n\n') ?>
         <p><?lsmb P ?></p><?lsmb END ?>
       </td>
     </tr><?lsmb IF paid_1 ?>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table>
           <tr>
@@ -172,13 +166,12 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr><?lsmb FOREACH tax ?><?lsmb loop_count = loop.count - 1 ?>
     <tr>
-      <td>&nbsp;</td>
       <th colspan="9" align="left"><span class=
       "c2"><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?>
       <?lsmb text('Registration') _ ' ' _  taxnumber.${loop_count} ?></span></th>
     </tr><?lsmb END ?><?lsmb IF taxincluded ?>
     <tr>
-      <td>&nbsp;</td>
+      <td></td>
     </tr>
     <tr>
       <th colspan="3" align="left"><span class=

--- a/templates/xedemo/bin_list.html
+++ b/templates/xedemo/bin_list.html
@@ -28,7 +28,6 @@ releases. No explicit versioning was applied before 2021-01-04.
   <table width="100%">
     <?lsmb INCLUDE letterhead ?>
     <tr>
-      <td width="10">&nbsp;</td>
       <th colspan="3">
         <h4 class="c1"><?lsmb text('Bin List') ?></h4>
       </th>
@@ -70,7 +69,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" border="1">
           <tr>
@@ -94,7 +92,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr class="c3">
@@ -123,7 +120,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <hr noshade>
       </td>

--- a/templates/xedemo/invoice.html
+++ b/templates/xedemo/invoice.html
@@ -27,14 +27,12 @@ releases. No explicit versioning was applied before 2021-01-04.
   <table width="100%">
     <?lsmb INCLUDE letterhead ?>
     <tr>
-      <td width="10">&nbsp;</td>
       <th colspan="3">
         <h4 class="c1">
         <?lsmb IF reverse; text('Credit Invoice'); ELSE; text('Invoice'); END; ?></h4>
       </th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" cellspacing="0" cellpadding="0">
           <tr class="c3">
@@ -74,7 +72,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" border="1">
           <tr>
@@ -99,7 +96,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr class="c3">
@@ -162,7 +158,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="top">
@@ -178,7 +173,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr><?lsmb IF paymentdate.0 ?>
     <tr>
-      <td>&nbsp;</td>
       <td colspan="9">
         <table width="60%">
           <tr>
@@ -208,11 +202,9 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <th><?lsmb text('Thank you for your valued business!') ?></th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="top">
@@ -227,13 +219,12 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr><?lsmb FOREACH tax ?><?lsmb loop_count = loop.count - 1 ?>
     <tr>
-      <td>&nbsp;</td>
       <th colspan="9" align="left"><span class=
       "c5"><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?>
       <?lsmb text('Registration [_1]', taxnumber.${loop_count}) ?></span></th>
     </tr><?lsmb END ?><?lsmb IF taxincluded ?>
     <tr>
-      <td>&nbsp;</td>
+      <td></td>
     </tr>
     <tr>
       <th colspan="8" align="left"><span class=

--- a/templates/xedemo/letterhead.html
+++ b/templates/xedemo/letterhead.html
@@ -10,7 +10,6 @@ releases. No explicit versioning was applied before 2021-01-04.
 
 -?>
   <tr>
-    <td width="10">&nbsp;</td>
     <td>
       <table width="100%">
         <tr>

--- a/templates/xedemo/packing_list.html
+++ b/templates/xedemo/packing_list.html
@@ -29,13 +29,11 @@ releases. No explicit versioning was applied before 2021-01-04.
   <table width="100%">
     <?lsmb INCLUDE letterhead ?>
     <tr>
-      <td width="10">&nbsp;</td>
       <th colspan="3">
         <h4 class="c1"><?lsmb text('Packing List') ?></h4>
       </th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" cellspacing="0" cellpadding="0">
           <tr class="c3">
@@ -61,7 +59,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" border="1">
           <tr>
@@ -87,7 +84,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr class="c3">
@@ -114,13 +110,11 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <hr noshade>
       </td>
     </tr><?lsmb IF notes ?>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="top">
@@ -134,7 +128,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr><?lsmb END ?>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="top">

--- a/templates/xedemo/pick_list.html
+++ b/templates/xedemo/pick_list.html
@@ -28,13 +28,11 @@ releases. No explicit versioning was applied before 2021-01-04.
   <table width="100%">
     <?lsmb INCLUDE letterhead ?>
     <tr>
-      <td width="10">&nbsp;</td>
       <th colspan="3">
         <h4 class="c1"><?lsmb text('Pick List') ?></h4>
       </th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" cellspacing="0" cellpadding="0">
           <tr class="c3">
@@ -61,7 +59,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" border="1">
           <tr>
@@ -87,7 +84,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr class="c3">
@@ -112,7 +108,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <hr noshade>
       </td>

--- a/templates/xedemo/product_receipt.html
+++ b/templates/xedemo/product_receipt.html
@@ -28,13 +28,11 @@ releases. No explicit versioning was applied before 2021-01-04.
   <table width="100%">
     <?lsmb INCLUDE letterhead ?>
     <tr>
-      <td width="10">&nbsp;</td>
       <th colspan="3">
         <h4 class="c1"><?lsmb text('Product Receipt') ?></h4>
       </th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" cellspacing="0" cellpadding="0">
           <tr class="c3">
@@ -70,7 +68,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" border="1">
           <tr>
@@ -91,7 +88,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr class="c3">
@@ -160,7 +156,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr><?lsmb IF notes ?>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="top">
@@ -174,7 +169,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr><?lsmb END ?>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="top">

--- a/templates/xedemo/request_quotation.html
+++ b/templates/xedemo/request_quotation.html
@@ -28,13 +28,11 @@ releases. No explicit versioning was applied before 2021-01-04.
   <table width="100%">
     <?lsmb INCLUDE letterhead ?>
     <tr>
-      <td width="10">&nbsp;</td>
       <th colspan="3">
         <h4 class="c1"><?lsmb text('Request for Quotation') ?></h4>
       </th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr class="c3">
@@ -70,7 +68,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" border="1">
           <tr>
@@ -96,14 +93,12 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td><?lsmb text('Please provide price and delivery time for the following items:') ?></td>
     </tr>
     <tr>
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr>
@@ -132,7 +127,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr><?lsmb IF notes ?>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="top">

--- a/templates/xedemo/sales_order.html
+++ b/templates/xedemo/sales_order.html
@@ -29,13 +29,11 @@ releases. No explicit versioning was applied before 2021-01-04.
   <table width="100%">
     <?lsmb INCLUDE letterhead ?>
     <tr>
-      <td width="10">&nbsp;</td>
       <th colspan="3">
         <h4 class="c1"><?lsmb text('Sales Order') ?></h4>
       </th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" cellspacing="0" cellpadding="0">
           <tr class="c3">
@@ -73,7 +71,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" border="1">
           <tr>
@@ -96,7 +93,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr class="c3">
@@ -156,7 +152,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="top">
@@ -172,7 +167,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="top">

--- a/templates/xedemo/sales_quotation.html
+++ b/templates/xedemo/sales_quotation.html
@@ -29,13 +29,11 @@ releases. No explicit versioning was applied before 2021-01-04.
   <table width="100%">
     <?lsmb INCLUDE letterhead ?>
     <tr>
-      <td width="10">&nbsp;</td>
       <th colspan="3" class="c1">
         <h4><?lsmb text('Quotation') ?></h4>
       </th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="top">
@@ -55,7 +53,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" border="1">
           <tr>
@@ -78,7 +75,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr class="c3">
@@ -138,7 +134,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="top">
@@ -154,7 +149,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="top">

--- a/templates/xedemo/statement.html
+++ b/templates/xedemo/statement.html
@@ -27,17 +27,14 @@ releases. No explicit versioning was applied before 2021-01-04.
   <table width="100%">
     <?lsmb INCLUDE letterhead ?>
     <tr>
-      <td width="10">&nbsp;</td>
       <th colspan="3">
         <h4 class="c1"><?lsmb text('Statement') ?></h4>
       </th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td colspan="3" align="right"><?lsmb statementdate ?></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="top">
@@ -55,7 +52,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr>
@@ -100,7 +96,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td align="right">
         <table width="50%">
           <tr>
@@ -111,7 +106,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <hr noshade>
       </td>

--- a/templates/xedemo/timecard.html
+++ b/templates/xedemo/timecard.html
@@ -26,13 +26,11 @@ releases. No explicit versioning was applied before 2021-01-04.
   <table width="100%">
     <?lsmb INCLUDE letterhead ?>
     <tr>
-      <td width="10">&nbsp;</td>
       <th colspan="3">
         <h4 class="c1"><?lsmb text('Time Card') ?></h4>
       </th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" cellspacing="0" cellpadding="0">
           <tr valign="top">
@@ -80,7 +78,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr valign="bottom">
@@ -124,7 +121,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <?lsmb  FOREACH P IN notes.split('\n\n') ?>
         <p><?lsmb P ?></p><?lsmb END ?>

--- a/templates/xedemo/work_order.html
+++ b/templates/xedemo/work_order.html
@@ -28,13 +28,11 @@ releases. No explicit versioning was applied before 2021-01-04.
   <table width="100%">
     <?lsmb INCLUDE letterhead ?>
     <tr>
-      <td width="10">&nbsp;</td>
       <th colspan="3">
         <h4 class="c1"><?lsmb text('Work Order') ?></h4>
       </th>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" cellspacing="0" cellpadding="0">
           <tr class="c3">
@@ -72,7 +70,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       <td></td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%" border="1">
           <tr>
@@ -95,7 +92,6 @@ releases. No explicit versioning was applied before 2021-01-04.
       </td>
     </tr>
     <tr>
-      <td>&nbsp;</td>
       <td>
         <table width="100%">
           <tr class="c3">
@@ -124,8 +120,7 @@ releases. No explicit versioning was applied before 2021-01-04.
         </table>
       </td>
     </tr>
-    <tr>
-      <td>&nbsp;</td><?lsmb IF notes ?>
+    <tr><?lsmb IF notes ?>
       <td>
         <?lsmb  FOREACH P IN notes.split('\n\n') ?>
         <p><?lsmb P ?></p><?lsmb END ?>


### PR DESCRIPTION
Remove the gutter from all templates. I guess the original change where
I removed the gutter from the purchase order was based on misunderstanding.
