### PR TITLE
Manual backport of 9b4816552bbd66e9c986e37f7538546b0a562feb (re #5298)

### DIFF
--- a/templates/demo/ap_transaction.html
+++ b/templates/demo/ap_transaction.html
@@ -9,9 +9,8 @@
 <table width="100%">
 
   <?lsmb INCLUDE letterhead ?>
-  
+
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -21,24 +20,23 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
         <tr valign=top>
           <td><?lsmb name ?>
           <br><?lsmb address1 ?>
-	  <?lsmb IF address2 ?>
+          <?lsmb IF address2 ?>
           <br><?lsmb address2 ?>
-	  <?lsmb END ?>
+          <?lsmb END ?>
           <br><?lsmb city ?>
-	  <?lsmb IF state ?>
-	  , <?lsmb state ?>
-	  <?lsmb END ?>
-	  <?lsmb zipcode ?>
-	  <?lsmb IF country ?>
-	  <br><?lsmb country ?>
-	  <?lsmb END ?>
+          <?lsmb IF state ?>
+          , <?lsmb state ?>
+          <?lsmb END ?>
+          <?lsmb zipcode ?>
+          <?lsmb IF country ?>
+          <br><?lsmb country ?>
+          <?lsmb END ?>
           <br>
 
           <?lsmb IF contact ?>
@@ -62,39 +60,39 @@
           <p><?lsmb text('Taxnumber: [_1]', vendortaxnumber) ?>
           <?lsmb END ?>
           </td>
-   
-	  <td align=right>
-	    <table>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Invoice #') ?></th>
-		<td><?lsmb invnumber ?></td>
-	      </tr>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Date') ?></th>
-		<td><?lsmb invdate ?></td>
-	      </tr>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Due') ?></th>
-		<td><?lsmb duedate ?></td>
-	      </tr>
-	      <?lsmb IF ponumber ?>
+
+          <td align=right>
+            <table>
+              <tr>
+                <th align=left nowrap><?lsmb text('Invoice #') ?></th>
+                <td><?lsmb invnumber ?></td>
+              </tr>
+              <tr>
+                <th align=left nowrap><?lsmb text('Date') ?></th>
+                <td><?lsmb invdate ?></td>
+              </tr>
+              <tr>
+                <th align=left nowrap><?lsmb text('Due') ?></th>
+                <td><?lsmb duedate ?></td>
+              </tr>
+              <?lsmb IF ponumber ?>
               <tr>
                 <th align=left><?lsmb text('PO #') ?></th>
-		<td><?lsmb ponumber ?>&nbsp;</td>
-	      </tr>
-	      <?lsmb END ?>
-	      <?lsmb IF ordnumber ?>
-	      <tr>
-		<th align=left><?lsmb text('Order #') ?></th>
-		<td><?lsmb ordnumber ?>&nbsp;</td>
-	      </tr>
-	      <?lsmb END ?>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Employee') ?></th>
-		<td><?lsmb employee ?>&nbsp;</td>
-	      </tr>
-	    </table>
-	  </td>
+                <td><?lsmb ponumber ?>&nbsp;</td>
+              </tr>
+              <?lsmb END ?>
+              <?lsmb IF ordnumber ?>
+              <tr>
+                <th align=left><?lsmb text('Order #') ?></th>
+                <td><?lsmb ordnumber ?>&nbsp;</td>
+              </tr>
+              <?lsmb END ?>
+              <tr>
+                <th align=left nowrap><?lsmb text('Employee') ?></th>
+                <td><?lsmb employee ?>&nbsp;</td>
+              </tr>
+            </table>
+          </td>
         </tr>
       </table>
     </td>
@@ -103,66 +101,63 @@
   <tr height=5></tr>
   
   <tr>
-    <td>&nbsp;</td>
-  
+
     <td>
       <table>
-	<?lsmb FOREACH account ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr valign=top>
-	  <td><?lsmb accno.${loop_count} ?></td>
-	  <td><?lsmb account.${loop_count} ?></td>
-	  <td width=10> </td>
-	  <td align=right><?lsmb amount.${loop_count} ?></td>
-	  <td width=10> </td>
-	  <td><?lsmb description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td width=10> </td>
-	  <td><?lsmb projectnumber.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+        <?lsmb FOREACH account ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr valign=top>
+          <td><?lsmb accno.${loop_count} ?></td>
+          <td><?lsmb account.${loop_count} ?></td>
+          <td width=10> </td>
+          <td align=right><?lsmb amount.${loop_count} ?></td>
+          <td width=10> </td>
+          <td><?lsmb description.${loop_count}.replace("\n","<br />") ?></td>
+          <td width=10> </td>
+          <td><?lsmb projectnumber.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
-	<tr>
-	  <?lsmb IF taxincluded ?>
-	  <th colspan=2 align=right><?lsmb text('Total') ?></th>
-	  <td width=10> </td>
-	  <td align=right><?lsmb invtotal ?></td>
-	  <?lsmb ELSE ?>
-	  <th colspan=2 align=right><?lsmb text('Subtotal') ?></th>
-	  <td width=10> </td>
-	  <td align=right><?lsmb subtotal ?></td>
-	  <?lsmb END ?>
-	</tr>
+        <tr>
+          <?lsmb IF taxincluded ?>
+          <th colspan=2 align=right><?lsmb text('Total') ?></th>
+          <td width=10> </td>
+          <td align=right><?lsmb invtotal ?></td>
+          <?lsmb ELSE ?>
+          <th colspan=2 align=right><?lsmb text('Subtotal') ?></th>
+          <td width=10> </td>
+          <td align=right><?lsmb subtotal ?></td>
+          <?lsmb END ?>
+        </tr>
 
-	<?lsmb FOREACH tax ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr>
-	  <th colspan=2 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
-	  <td width=10> </td>
-	  <td align=right><?lsmb tax.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
-	
-	<?lsmb IF NOT taxincluded ?>
-	<tr>
-	  <th colspan=2 align=right><?lsmb text('Total') ?></th>
-	  <td width=10> </td>
-	  <td align=right><?lsmb invtotal ?></td>
-	</tr>
-	<?lsmb END ?>
+        <?lsmb FOREACH tax ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr>
+          <th colspan=2 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+          <td width=10> </td>
+          <td align=right><?lsmb tax.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
+
+        <?lsmb IF NOT taxincluded ?>
+        <tr>
+          <th colspan=2 align=right><?lsmb text('Total') ?></th>
+          <td width=10> </td>
+          <td align=right><?lsmb invtotal ?></td>
+        </tr>
+        <?lsmb END ?>
       </table>
     </td>
   </tr>
-  
+
   <tr>
-    <td>&nbsp;</td>
-    
+
     <td>
       <?lsmb text_amount ?> ***** <?lsmb decimal ?>/100 <?lsmb currency ?>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
           <td><?lsmb  FOREACH P IN notes.split('\n\n') ?>
                     <p><?lsmb P ?></p>
@@ -171,7 +166,6 @@
 
   <?lsmb IF paid_1 ?>
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table>
@@ -185,32 +179,32 @@
           </td>
         </tr>
 
-	<tr>
-	  <td>
-	    <table>
-	      <tr>
-		<th><?lsmb text('Date') ?></th>
-		<th>&nbsp;</th>
-		<th><?lsmb text('Source') ?></th>
-		<th><?lsmb text('Memo') ?></th>
-		<th><?lsmb text('Amount') ?></th>
-	      </tr>
+        <tr>
+          <td>
+            <table>
+              <tr>
+                <th><?lsmb text('Date') ?></th>
+                <th>&nbsp;</th>
+                <th><?lsmb text('Source') ?></th>
+                <th><?lsmb text('Memo') ?></th>
+                <th><?lsmb text('Amount') ?></th>
+              </tr>
   <?lsmb END ?>
 
         <?lsmb FOREACH payment ?>
         <?lsmb loop_count = loop.count - 1 ?>
-	      <tr>
-		<td><?lsmb paymentdate.${loop_count} ?></td>
-		<td><?lsmb paymentaccount.${loop_count} ?></td>
-		<td><?lsmb paymentsource.${loop_count} ?></td>
-		<td><?lsmb paymentmemo.${loop_count} ?></td>
-		<td align=right><?lsmb payment.${loop_count} ?></td>
-	      </tr>
+              <tr>
+                <td><?lsmb paymentdate.${loop_count} ?></td>
+                <td><?lsmb paymentaccount.${loop_count} ?></td>
+                <td><?lsmb paymentsource.${loop_count} ?></td>
+                <td><?lsmb paymentmemo.${loop_count} ?></td>
+                <td align=right><?lsmb payment.${loop_count} ?></td>
+              </tr>
         <?lsmb END ?>
 
   <?lsmb IF paid_1 ?>
-	    </table>
-	  </td>
+            </table>
+          </td>
         </tr>
       </table>
     </td>
@@ -221,7 +215,6 @@
 
   <?lsmb IF taxincluded ?>
   <tr>
-    <td>&nbsp;</td>
   </tr>
 
   <tr>

--- a/templates/demo/ar_transaction.html
+++ b/templates/demo/ar_transaction.html
@@ -11,7 +11,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -20,24 +19,23 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
         <tr valign=top>
           <td><?lsmb name ?>
           <br><?lsmb address1 ?>
-	  <?lsmb IF address2 ?>
+          <?lsmb IF address2 ?>
           <br><?lsmb address2 ?>
-	  <?lsmb END ?>
+          <?lsmb END ?>
           <br><?lsmb city ?>
-	  <?lsmb IF state ?>
-	  , <?lsmb state ?>
-	  <?lsmb END ?>
-	  <?lsmb zipcode ?>
-	  <?lsmb IF country ?>
-	  <br><?lsmb country ?>
-	  <?lsmb END ?>
+          <?lsmb IF state ?>
+          , <?lsmb state ?>
+          <?lsmb END ?>
+          <?lsmb zipcode ?>
+          <?lsmb IF country ?>
+          <br><?lsmb country ?>
+          <?lsmb END ?>
           <br>
 
           <?lsmb IF contact ?>
@@ -61,99 +59,97 @@
           <br><?lsmb text('Taxnumber:') _ ' ' _ customertaxnumber ?>
           <?lsmb END ?>
           </td>
-   
-	  <td align=right>
-	    <table>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Invoice #') ?></th>
-		<td><?lsmb invnumber ?></td>
-	      </tr>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Date') ?></th>
-		<td><?lsmb invdate ?></td>
-	      </tr>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Due') ?></th>
-		<td><?lsmb duedate ?></td>
-	      </tr>
-	      <?lsmb IF ponumber ?>
+
+          <td align=right>
+            <table>
+              <tr>
+                <th align=left nowrap><?lsmb text('Invoice #') ?></th>
+                <td><?lsmb invnumber ?></td>
+              </tr>
+              <tr>
+                <th align=left nowrap><?lsmb text('Date') ?></th>
+                <td><?lsmb invdate ?></td>
+              </tr>
+              <tr>
+                <th align=left nowrap><?lsmb text('Due') ?></th>
+                <td><?lsmb duedate ?></td>
+              </tr>
+              <?lsmb IF ponumber ?>
               <tr>
                 <th align=left><?lsmb text('PO #') ?></th>
-		<td><?lsmb ponumber ?>&nbsp;</td>
-	      </tr>
-	      <?lsmb END ?>
-	      <?lsmb IF ordnumber ?>
-	      <tr>
-		<th align=left><?lsmb text('Order #') ?></th>
-		<td><?lsmb ordnumber ?>&nbsp;</td>
-	      </tr>
-	      <?lsmb END ?>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Salesperson') ?></th>
-		<td><?lsmb employee ?>&nbsp;</td>
-	      </tr>
-	    </table>
-	  </td>
+                <td><?lsmb ponumber ?>&nbsp;</td>
+              </tr>
+              <?lsmb END ?>
+              <?lsmb IF ordnumber ?>
+              <tr>
+                <th align=left><?lsmb text('Order #') ?></th>
+                <td><?lsmb ordnumber ?>&nbsp;</td>
+              </tr>
+              <?lsmb END ?>
+              <tr>
+                <th align=left nowrap><?lsmb text('Salesperson') ?></th>
+                <td><?lsmb employee ?>&nbsp;</td>
+              </tr>
+            </table>
+          </td>
         </tr>
       </table>
     </td>
   </tr>
 
   <tr height=5></tr>
-  
+
   <tr>
-    <td>&nbsp;</td>
-  
+
     <td>
       <table>
-	<?lsmb FOREACH account ?>
+        <?lsmb FOREACH account ?>
         <?lsmb loop_count = loop.count - 1 ?>
-	<tr valign=top>
-	  <td><?lsmb accno.${loop_count} ?></td>
-	  <td><?lsmb account.${loop_count} ?></td>
-	  <td width=10>&nbsp;</td>
-	  <td align=right><?lsmb amount.${loop_count} ?></td>
-	  <td width=10>&nbsp;</td>
-	  <td><?lsmb description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td width=10>&nbsp;</td>
-	  <td><?lsmb projectnumber.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+        <tr valign=top>
+          <td><?lsmb accno.${loop_count} ?></td>
+          <td><?lsmb account.${loop_count} ?></td>
+          <td width=10>&nbsp;</td>
+          <td align=right><?lsmb amount.${loop_count} ?></td>
+          <td width=10>&nbsp;</td>
+          <td><?lsmb description.${loop_count}.replace("\n","<br />") ?></td>
+          <td width=10>&nbsp;</td>
+          <td><?lsmb projectnumber.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
-	<tr>
-	  <?lsmb IF taxincluded ?>
-	  <th colspan=2 align=right><?lsmb text('Total') ?></th>
-	  <td width=10>&nbsp;</td>
-	  <td align=right><?lsmb invtotal ?></td>
-	  <?lsmb ELSE ?>
-	  <th colspan=2 align=right><?lsmb text('Subtotal') ?></th>
-	  <td width=10>&nbsp;</td>
-	  <td align=right><?lsmb subtotal ?></td>
-	  <?lsmb END ?>
-	</tr>
+        <tr>
+          <?lsmb IF taxincluded ?>
+          <th colspan=2 align=right><?lsmb text('Total') ?></th>
+          <td width=10>&nbsp;</td>
+          <td align=right><?lsmb invtotal ?></td>
+          <?lsmb ELSE ?>
+          <th colspan=2 align=right><?lsmb text('Subtotal') ?></th>
+          <td width=10>&nbsp;</td>
+          <td align=right><?lsmb subtotal ?></td>
+          <?lsmb END ?>
+        </tr>
 
-	<?lsmb FOREACH tax ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr>
-	  <th colspan=2 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
-	  <td width=10>&nbsp;</td>
-	  <td align=right><?lsmb tax.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
-	
-	<?lsmb IF NOT taxincluded ?>
-	<tr>
-	  <th colspan=2 align=right><?lsmb text('Total') ?></th>
-	  <td width=10>&nbsp;</td>
-	  <td align=right><?lsmb invtotal ?></td>
-	</tr>
-	<?lsmb END ?>
+        <?lsmb FOREACH tax ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr>
+          <th colspan=2 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+          <td width=10>&nbsp;</td>
+          <td align=right><?lsmb tax.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
+
+        <?lsmb IF NOT taxincluded ?>
+        <tr>
+          <th colspan=2 align=right><?lsmb text('Total') ?></th>
+          <td width=10>&nbsp;</td>
+          <td align=right><?lsmb invtotal ?></td>
+        </tr>
+        <?lsmb END ?>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <?lsmb text_amount ?> ***** <?lsmb decimal ?>/100 <?lsmb currency ?>
@@ -161,7 +157,6 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
           <td><?lsmb  FOREACH P IN notes.split('\n\n') ?>
                     <p><?lsmb P ?></p>
@@ -170,7 +165,6 @@
 
   <?lsmb IF paid_1 ?>
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table>
@@ -184,30 +178,30 @@
           </td>
         </tr>
 
-	<tr>
-	  <td>
-	    <table>
-	      <tr>
-		<th><?lsmb text('Date') ?></th>
-		<th>&nbsp;</th>
-		<th><?lsmb text('Source') ?></th>
-		<th><?lsmb text('Amount') ?></th>
-	      </tr>
+        <tr>
+          <td>
+            <table>
+              <tr>
+                <th><?lsmb text('Date') ?></th>
+                <th>&nbsp;</th>
+                <th><?lsmb text('Source') ?></th>
+                <th><?lsmb text('Amount') ?></th>
+              </tr>
   <?lsmb END ?>
 
         <?lsmb FOREACH payment ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	      <tr>
-		<td><?lsmb paymentdate.${loop_count} ?></td>
-		<td><?lsmb paymentaccount.${loop_count} ?></td>
-		<td><?lsmb paymentsource.${loop_count} ?></td>
-		<td align=right><?lsmb payment.${loop_count} ?></td>
-	      </tr>
+        <?lsmb loop_count = loop.count - 1 ?>
+              <tr>
+                <td><?lsmb paymentdate.${loop_count} ?></td>
+                <td><?lsmb paymentaccount.${loop_count} ?></td>
+                <td><?lsmb paymentsource.${loop_count} ?></td>
+                <td align=right><?lsmb payment.${loop_count} ?></td>
+              </tr>
         <?lsmb END ?>
 
   <?lsmb IF paid_1 ?>
-	    </table>
-	  </td>
+            </table>
+          </td>
         </tr>
       </table>
     </td>
@@ -219,7 +213,6 @@
   <?lsmb FOREACH tax ?>
   <?lsmb loop_count = loop.count - 1 ?>
   <tr>
-    <td>&nbsp;</td>
 
     <th colspan=9 align=left><font size=-2><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> <?lsmb text('Registration') _ ' ' _  taxnumber.${loop_count} ?></th>
   </tr>
@@ -227,7 +220,6 @@
 
   <?lsmb IF taxincluded ?>
   <tr>
-    <td>&nbsp;</td>
   </tr>
 
   <tr>

--- a/templates/demo/bin_list.html
+++ b/templates/demo/bin_list.html
@@ -11,7 +11,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -20,79 +19,78 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
-	<tr bgcolor=000000>
-	  <th align=left width="50%"><font color=ffffff><?lsmb text('From') ?>
+        <tr bgcolor=000000>
+          <th align=left width="50%"><font color=ffffff><?lsmb text('From') ?>
           </th>
-	  <th align=left width="50%"><font color=ffffff><?lsmb text('Ship To') ?>
+          <th align=left width="50%"><font color=ffffff><?lsmb text('Ship To') ?>
           </th>
-	</tr>
+        </tr>
 
-	<tr valign=top>
-	  <td><?lsmb name ?>
-	  <br><?lsmb address1 ?>
-	  <?lsmb IF address2 ?>
+        <tr valign=top>
+          <td><?lsmb name ?>
+          <br><?lsmb address1 ?>
+          <?lsmb IF address2 ?>
           <br><?lsmb address2 ?>
           <?lsmb END ?>
-	  <br><?lsmb city ?>
-	  <?lsmb IF state ?>
-	  , <?lsmb state ?>
-	  <?lsmb END ?>
-	  <?lsmb zipcode ?>
-	  <?lsmb IF country ?>
+          <br><?lsmb city ?>
+          <?lsmb IF state ?>
+          , <?lsmb state ?>
+          <?lsmb END ?>
+          <?lsmb zipcode ?>
+          <?lsmb IF country ?>
           <?lsmb country ?>
           <?lsmb END ?>
-	  <br>
+          <br>
 
-	  <?lsmb IF contact ?>
-	  <br><?lsmb text('Attn: [_1]', contact) ?>
-	  <?lsmb END ?>
+          <?lsmb IF contact ?>
+          <br><?lsmb text('Attn: [_1]', contact) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF vendorphone ?>
-	  <br><?lsmb text('Tel: [_1]', vendorphone) ?>
-	  <?lsmb END ?>
+          <?lsmb IF vendorphone ?>
+          <br><?lsmb text('Tel: [_1]', vendorphone) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF vendorfax ?>
-	  <br><?lsmb text('Fax: [_1]', vendorfax) ?>
-	  <?lsmb END ?>
+          <?lsmb IF vendorfax ?>
+          <br><?lsmb text('Fax: [_1]', vendorfax) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF email ?>
-	  <br><?lsmb email ?>
-	  <?lsmb END ?>
+          <?lsmb IF email ?>
+          <br><?lsmb email ?>
+          <?lsmb END ?>
 
-	  </td>
+          </td>
 
-	  <td><?lsmb shiptoname ?>
-	  <br><?lsmb shiptoaddress1 ?>
-	  <?lsmb IF shiptoaddress2 ?>
+          <td><?lsmb shiptoname ?>
+          <br><?lsmb shiptoaddress1 ?>
+          <?lsmb IF shiptoaddress2 ?>
           <br><?lsmb shiptoaddress2 ?>
           <?lsmb END ?>
-	  <br><?lsmb shiptocity ?>
-	  <?lsmb IF shiptostate ?>
-	  , <?lsmb shiptostate ?>
-	  <?lsmb END ?>
-	  <?lsmb shiptozipcode ?>
-	  <?lsmb IF shiptocountry ?>
+          <br><?lsmb shiptocity ?>
+          <?lsmb IF shiptostate ?>
+          , <?lsmb shiptostate ?>
+          <?lsmb END ?>
+          <?lsmb shiptozipcode ?>
+          <?lsmb IF shiptocountry ?>
           <?lsmb shiptocountry ?>
           <?lsmb END ?>
 
-	  <br>
-	  <?lsmb IF shiptocontact ?>
-	  <br><?lsmb text('Attn: [_1]', shiptocontact) ?>
-	  <?lsmb END ?>
+          <br>
+          <?lsmb IF shiptocontact ?>
+          <br><?lsmb text('Attn: [_1]', shiptocontact) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF shiptophone ?>
-	  <br><?lsmb text('Tel: [_1]', shiptophone) ?>
-	  <?lsmb END ?>
+          <?lsmb IF shiptophone ?>
+          <br><?lsmb text('Tel: [_1]', shiptophone) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF shiptofax ?>
-	  <br><?lsmb text('Fax: [_1]', shiptofax) ?>
-	  <?lsmb END ?>
-	  </td>
-	</tr>
+          <?lsmb IF shiptofax ?>
+          <br><?lsmb text('Fax: [_1]', shiptofax) ?>
+          <?lsmb END ?>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -100,81 +98,78 @@
   <tr height=5></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% border=1>
-	<tr>
-	  <th width=17% align=left nowrap><?lsmb text('Order #') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Date') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Contact') ?></th>
-	  <?lsmb IF warehouse ?>
-	  <th width=17% align=left nowrap><?lsmb text('Warehouse') ?></th>
-	  <?lsmb END ?>
-	  <th width=17% align=left><?lsmb text('Shipping Point') ?></th>
-	  <th width=15% align=left><?lsmb text('Ship via') ?></th>
-	</tr>
+        <tr>
+          <th width=17% align=left nowrap><?lsmb text('Order #') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Date') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Contact') ?></th>
+          <?lsmb IF warehouse ?>
+          <th width=17% align=left nowrap><?lsmb text('Warehouse') ?></th>
+          <?lsmb END ?>
+          <th width=17% align=left><?lsmb text('Shipping Point') ?></th>
+          <th width=15% align=left><?lsmb text('Ship via') ?></th>
+        </tr>
 
-	<tr>
-	  <td><?lsmb ordnumber ?>&nbsp;</td>
+        <tr>
+          <td><?lsmb ordnumber ?>&nbsp;</td>
 
-	  <?lsmb IF shippingdate ?>
-	  <td><?lsmb shippingdate ?></td>
-	  <?lsmb ELSE ?>
-	  <td><?lsmb orddate ?></td>
-	  <?lsmb END ?>
+          <?lsmb IF shippingdate ?>
+          <td><?lsmb shippingdate ?></td>
+          <?lsmb ELSE ?>
+          <td><?lsmb orddate ?></td>
+          <?lsmb END ?>
 
-	  <td><?lsmb employee ?>&nbsp;</td>
+          <td><?lsmb employee ?>&nbsp;</td>
 
-	  <?lsmb IF warehouse ?>
-	  <td><?lsmb warehouse ?></td>
-	  <?lsmb END ?>
+          <?lsmb IF warehouse ?>
+          <td><?lsmb warehouse ?></td>
+          <?lsmb END ?>
 
-	  <td><?lsmb shippingpoint ?>&nbsp;</td>
-	  <td><?lsmb shipvia ?>&nbsp;</td>
-	</tr>
+          <td><?lsmb shippingpoint ?>&nbsp;</td>
+          <td><?lsmb shipvia ?>&nbsp;</td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr bgcolor=000000>
-	  <th align=left><font color=ffffff><?lsmb text('Item') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
-	  <th><font color=ffffff><?lsmb text('Serialnumber') ?></th>
-	  <th>&nbsp;</th>
-	  <th><font color=ffffff><?lsmb text('Qty') ?></th>
-	  <th><font color=ffffff><?lsmb text('Recd') ?></th>
-	  <th>&nbsp;</th>
-	  <th><font color=ffffff><?lsmb text('Bin') ?></th>
-	</tr>
+        <tr bgcolor=000000>
+          <th align=left><font color=ffffff><?lsmb text('Item') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
+          <th><font color=ffffff><?lsmb text('Serialnumber') ?></th>
+          <th>&nbsp;</th>
+          <th><font color=ffffff><?lsmb text('Qty') ?></th>
+          <th><font color=ffffff><?lsmb text('Recd') ?></th>
+          <th>&nbsp;</th>
+          <th><font color=ffffff><?lsmb text('Bin') ?></th>
+        </tr>
 
-	<?lsmb FOREACH number ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr valign=top>
-	  <td><?lsmb runningnumber.${loop_count} ?></td>
-	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td><?lsmb serialnumber.${loop_count} ?></td>
-	  <td><?lsmb deliverydate.${loop_count} ?></td>
-	  <td align=right><?lsmb qty.${loop_count} ?></td>
-	  <td align=right><?lsmb ship.${loop_count} ?></td>
-	  <td><?lsmb unit.${loop_count} ?></td>
-	  <td><?lsmb bin.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+        <?lsmb FOREACH number ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr valign=top>
+          <td><?lsmb runningnumber.${loop_count} ?></td>
+          <td><?lsmb number.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
+          <td><?lsmb serialnumber.${loop_count} ?></td>
+          <td><?lsmb deliverydate.${loop_count} ?></td>
+          <td align=right><?lsmb qty.${loop_count} ?></td>
+          <td align=right><?lsmb ship.${loop_count} ?></td>
+          <td><?lsmb unit.${loop_count} ?></td>
+          <td><?lsmb bin.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td><hr noshade></td>
   </tr>

--- a/templates/demo/invoice.html
+++ b/templates/demo/invoice.html
@@ -8,9 +8,8 @@
 <table width="100%">
 
   <?lsmb INCLUDE letterhead ?>
-  
+
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -19,7 +18,6 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
@@ -101,10 +99,9 @@
   </tr>
 
   <tr height=5></tr>
-  
+
   <tr>
-    <td>&nbsp;</td>
-  
+
     <td>
       <table width=100% border=1>
         <tr>
@@ -131,8 +128,7 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
-  
+
     <td>
       <table width="100%">
         <tr bgcolor=000000>
@@ -209,7 +205,6 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
@@ -232,7 +227,6 @@
 
   <?lsmb IF paymentdate.0 ?>
   <tr>
-    <td>&nbsp;</td>
 
     <td colspan=9>
       <table width="60%">
@@ -272,7 +266,6 @@
   <tr height=10></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <th>
     <?lsmb text('Thank you for your valued business!') ?>
@@ -280,7 +273,6 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
@@ -302,7 +294,6 @@
   <?lsmb FOREACH tax ?>
   <?lsmb loop_count = loop.count - 1 ?>
   <tr>
-    <td>&nbsp;</td>
 
     <th colspan=9 align=left><font size=-2><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> <?lsmb text('Registration [_1]', taxnumber.${loop_count}) ?></th>
   </tr>
@@ -310,7 +301,6 @@
 
   <?lsmb IF taxincluded ?>
   <tr>
-    <td>&nbsp;</td>
   </tr>
 
   <tr>

--- a/templates/demo/letterhead.html
+++ b/templates/demo/letterhead.html
@@ -1,5 +1,4 @@
   <tr>
-    <td width=10>&nbsp;</td>
 
     <td>
       <table width="100%">
@@ -11,7 +10,7 @@
             </h4>
           </td>
           <!-- Commenting out the image tag for now.  In general, folks can
-               customize this to their servers, but if the server is behind a 
+               customize this to their servers, but if the server is behind a
                firewall, then this won't work.  Recommend that if people do this,
                they hardwire in a link to a publically accessible image. - CT -->
           <th><!-- <img src=<?lsmb images ?>/logo.png border=0 height=58> --></th>
@@ -26,7 +25,7 @@
 
         <tr>
           <td colspan=3>
-	    <hr noshade>
+            <hr noshade>
           </td>
         </tr>
       </table>

--- a/templates/demo/packing_list.html
+++ b/templates/demo/packing_list.html
@@ -11,7 +11,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -20,49 +19,48 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
-	<tr bgcolor=000000>
-	  <th width=50% align=left><font color=ffffff>
+        <tr bgcolor=000000>
+          <th width=50% align=left><font color=ffffff>
                <?lsmb text('Ship To:') ?>
           </th>
-	  <th width="50%">&nbsp;</th>
-	</tr>
+          <th width="50%">&nbsp;</th>
+        </tr>
 
-	<tr valign=top>
-	  <td><?lsmb shiptoname ?>
-	  <br><?lsmb shiptoaddress1 ?>
-	  <?lsmb IF shiptoaddress2 ?>
-	  <br><?lsmb shiptoaddress2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb shiptocity ?>
-	  <?lsmb IF shiptostate ?>
-	  , <?lsmb shiptostate ?>
-	  <?lsmb END ?>
-	  <?lsmb shiptozipcode ?>
-	  <?lsmb IF shiptocountry ?>
-	  <br><?lsmb shiptocountry ?>
-	  <?lsmb END ?>
-	  </td>
+        <tr valign=top>
+          <td><?lsmb shiptoname ?>
+          <br><?lsmb shiptoaddress1 ?>
+          <?lsmb IF shiptoaddress2 ?>
+          <br><?lsmb shiptoaddress2 ?>
+          <?lsmb END ?>
+          <br><?lsmb shiptocity ?>
+          <?lsmb IF shiptostate ?>
+          , <?lsmb shiptostate ?>
+          <?lsmb END ?>
+          <?lsmb shiptozipcode ?>
+          <?lsmb IF shiptocountry ?>
+          <br><?lsmb shiptocountry ?>
+          <?lsmb END ?>
+          </td>
 
-	  <td>
-	  <?lsmb IF shiptocontact ?>
-	  <br><?lsmb text('Attn: [_1]', shiptocontact) ?>
-	  <?lsmb END ?>
+          <td>
+          <?lsmb IF shiptocontact ?>
+          <br><?lsmb text('Attn: [_1]', shiptocontact) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF shiptophone ?>
-	  <br><?lsmb text('Tel: [_1]', shiptophone) ?>
-	  <?lsmb END ?>
+          <?lsmb IF shiptophone ?>
+          <br><?lsmb text('Tel: [_1]', shiptophone) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF shiptofax ?>
-	  <br><?lsmb text('Fax: [_1]', shiptofax) ?>
-	  <?lsmb END ?>
+          <?lsmb IF shiptofax ?>
+          <br><?lsmb text('Fax: [_1]', shiptofax) ?>
+          <?lsmb END ?>
 
-	  <?lsmb shiptoemail ?>
-	  </td>
-	</tr>
+          <?lsmb shiptoemail ?>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -70,116 +68,111 @@
   <tr height=5></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% border=1>
-	<tr>
-	  <th width=17% align=left><?lsmb text('Invoice #') ?></th>
-	  <th width=17% align=left><?lsmb text('Order #') ?></th>
-	  <th width=17% align=left><?lsmb text('Date') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Contact') ?></th>
-	  <?lsmb IF warehouse ?>
-	  <th width=17% align=left><?lsmb text('Warehouse') ?></th>
-	  <?lsmb END ?>
-	  <th width=17% align=left><?lsmb text('Shipping Point') ?></th>
-	  <th width=15% align=left><?lsmb text('Ship via') ?></th>
-	</tr>
+        <tr>
+          <th width=17% align=left><?lsmb text('Invoice #') ?></th>
+          <th width=17% align=left><?lsmb text('Order #') ?></th>
+          <th width=17% align=left><?lsmb text('Date') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Contact') ?></th>
+          <?lsmb IF warehouse ?>
+          <th width=17% align=left><?lsmb text('Warehouse') ?></th>
+          <?lsmb END ?>
+          <th width=17% align=left><?lsmb text('Shipping Point') ?></th>
+          <th width=15% align=left><?lsmb text('Ship via') ?></th>
+        </tr>
 
         <tr>
-	  <td><?lsmb invnumber ?>&nbsp;</td>
-	  <td><?lsmb ordnumber ?>&nbsp;</td>
+          <td><?lsmb invnumber ?>&nbsp;</td>
+          <td><?lsmb ordnumber ?>&nbsp;</td>
 
-	  <?lsmb IF shippingdate ?>
-	  <td><?lsmb shippingdate ?></td>
-	  <?lsmb ELSE ?>
-	  <td><?lsmb transdate ?></td>
-	  <?lsmb END ?>
+          <?lsmb IF shippingdate ?>
+          <td><?lsmb shippingdate ?></td>
+          <?lsmb ELSE ?>
+          <td><?lsmb transdate ?></td>
+          <?lsmb END ?>
 
           <td><?lsmb employee ?>&nbsp;</td>
 
-	  <?lsmb IF warehouse ?>
-	  <td><?lsmb warehouse ?>&nbsp;</td>
-	  <?lsmb END ?>
+          <?lsmb IF warehouse ?>
+          <td><?lsmb warehouse ?>&nbsp;</td>
+          <?lsmb END ?>
 
-	  <td><?lsmb shippingpoint ?>&nbsp;</td>
-	  <td><?lsmb shipvia ?>&nbsp;</td>
-	</tr>
+          <td><?lsmb shippingpoint ?>&nbsp;</td>
+          <td><?lsmb shipvia ?>&nbsp;</td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr bgcolor=000000>
-	  <th align=left><font color=ffffff><?lsmb text('Item') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Serial #') ?></th>
-	  <th>&nbsp;</th>
-	  <th><font color=ffffff><?lsmb text('Qty') ?></th>
-	  <th><font color=ffffff><?lsmb text('Ship') ?></th>
-	  <th>&nbsp;</th>
-	</tr>
+        <tr bgcolor=000000>
+          <th align=left><font color=ffffff><?lsmb text('Item') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Serial #') ?></th>
+          <th>&nbsp;</th>
+          <th><font color=ffffff><?lsmb text('Qty') ?></th>
+          <th><font color=ffffff><?lsmb text('Ship') ?></th>
+          <th>&nbsp;</th>
+        </tr>
 
-	<?lsmb FOREACH number ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr valign=top>
-	  <td><?lsmb runningnumber.${loop_count} ?></td>
-	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td><?lsmb serialnumber.${loop_count} ?></td>
-	  <td><?lsmb deliverydate.${loop_count} ?></td>
-	  <td align=right><?lsmb qty.${loop_count} ?></td>
-	  <td align=right><?lsmb ship.${loop_count} ?></td>
-	  <td><?lsmb unit.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+        <?lsmb FOREACH number ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr valign=top>
+          <td><?lsmb runningnumber.${loop_count} ?></td>
+          <td><?lsmb number.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
+          <td><?lsmb serialnumber.${loop_count} ?></td>
+          <td><?lsmb deliverydate.${loop_count} ?></td>
+          <td align=right><?lsmb qty.${loop_count} ?></td>
+          <td align=right><?lsmb ship.${loop_count} ?></td>
+          <td><?lsmb unit.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td><hr noshade></td>
   </tr>
 
   <?lsmb IF notes ?>
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr valign=top>
-	  <td>Notes</td>
+        <tr valign=top>
+          <td>Notes</td>
           <td><?lsmb  FOREACH P IN notes.split('\n\n') ?>
                     <p><?lsmb P ?></p>
                <?lsmb END ?></td>
-	</tr>
+        </tr>
       </table>
     </td>
   </tr>
   <?lsmb END ?>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr valign=top>
-	  <td width="70%"><font size=-3>
-	  <?lsmb text('Items returned are subject to a 10% restocking charge. A return authorization must be obtained from [_1] before goods are returned. Returns must be shipped prepaid and properly insured. [_1] will not be responsible for damages during transit.', company) ?>
-	  </font>
-	  </td>
-	  <td width="30%">
-	  X <hr noshade>
-	  </td>
-	</tr>
+        <tr valign=top>
+          <td width="70%"><font size=-3>
+          <?lsmb text('Items returned are subject to a 10% restocking charge. A return authorization must be obtained from [_1] before goods are returned. Returns must be shipped prepaid and properly insured. [_1] will not be responsible for damages during transit.', company) ?>
+          </font>
+          </td>
+          <td width="30%">
+          X <hr noshade>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>

--- a/templates/demo/pick_list.html
+++ b/templates/demo/pick_list.html
@@ -11,7 +11,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -20,48 +19,47 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
         <tr bgcolor=000000>
-	  <th width=50% align=left><font color=ffffff><?lsmb text('Ship To:')
+          <th width=50% align=left><font color=ffffff><?lsmb text('Ship To:')
           ?></th>
-	  <th width="50%">&nbsp;</th>
-	</tr>
+          <th width="50%">&nbsp;</th>
+        </tr>
 
-	<tr valign=top>
-	  <td><?lsmb shiptoname ?>
-	  <br><?lsmb shiptoaddress1 ?>
-	  <?lsmb IF shiptoaddress2 ?>
-	  <br><?lsmb shiptoaddress2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb shiptocity ?>
-	  <?lsmb IF shiptostate ?>
-	  , <?lsmb shiptostate ?>
-	  <?lsmb END ?>
-	  <?lsmb shiptozipcode ?>
-	  <?lsmb IF shiptocountry ?>
-	  <br><?lsmb shiptocountry ?>
-	  <?lsmb END ?>
-	  </td>
+        <tr valign=top>
+          <td><?lsmb shiptoname ?>
+          <br><?lsmb shiptoaddress1 ?>
+          <?lsmb IF shiptoaddress2 ?>
+          <br><?lsmb shiptoaddress2 ?>
+          <?lsmb END ?>
+          <br><?lsmb shiptocity ?>
+          <?lsmb IF shiptostate ?>
+          , <?lsmb shiptostate ?>
+          <?lsmb END ?>
+          <?lsmb shiptozipcode ?>
+          <?lsmb IF shiptocountry ?>
+          <br><?lsmb shiptocountry ?>
+          <?lsmb END ?>
+          </td>
 
-	  <td>
-	  <?lsmb IF shiptocontact ?>
-	  <br><?lsmb text('Attn: [_1]', shiptocontact) ?>
-	  <?lsmb END ?>
+          <td>
+          <?lsmb IF shiptocontact ?>
+          <br><?lsmb text('Attn: [_1]', shiptocontact) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF shiptophone ?>
-	  <br><?lsmb text('Tel: [_1]', shiptophone) ?>
-	  <?lsmb END ?>
+          <?lsmb IF shiptophone ?>
+          <br><?lsmb text('Tel: [_1]', shiptophone) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF shiptofax ?>
-	  <br><?lsmb text('Fax: [_1]', shiptofax) ?>
-	  <?lsmb END ?>
+          <?lsmb IF shiptofax ?>
+          <br><?lsmb text('Fax: [_1]', shiptofax) ?>
+          <?lsmb END ?>
 
-	  <?lsmb shiptoemail ?>
-	  </td>
-	</tr>
+          <?lsmb shiptoemail ?>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -69,71 +67,68 @@
   <tr height=5></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% border=1>
         <tr>
-	  <th width=15% align=left><?lsmb text('Invoice #') ?></th>
-	  <th width=15% align=left><?lsmb text('Order #') ?></th>
-	  <th width=10% align=left><?lsmb text('Date') ?></th>
-	  <th width=15% align=left nowrap><?lsmb text('Contact') ?></th>
-	  <th width=15% align=left><?lsmb text('Warehouse') ?></th>
-	  <th width=10% align=left><?lsmb text('Shipping Point') ?></th>
-	  <th width=10% align=left><?lsmb text('Ship via') ?></th>
-	</tr>
+          <th width=15% align=left><?lsmb text('Invoice #') ?></th>
+          <th width=15% align=left><?lsmb text('Order #') ?></th>
+          <th width=10% align=left><?lsmb text('Date') ?></th>
+          <th width=15% align=left nowrap><?lsmb text('Contact') ?></th>
+          <th width=15% align=left><?lsmb text('Warehouse') ?></th>
+          <th width=10% align=left><?lsmb text('Shipping Point') ?></th>
+          <th width=10% align=left><?lsmb text('Ship via') ?></th>
+        </tr>
 
         <tr>
-	  <td><?lsmb invnumber ?>&nbsp;</td>
-	  <td><?lsmb ordnumber ?>&nbsp;</td>
+          <td><?lsmb invnumber ?>&nbsp;</td>
+          <td><?lsmb ordnumber ?>&nbsp;</td>
           <?lsmb IF shippingdate ?>
-	  <td><?lsmb shippingdate ?></td>
+          <td><?lsmb shippingdate ?></td>
           <?lsmb ELSE ?>
-	  <td><?lsmb transdate ?></td>
-	  <?lsmb END ?>
+          <td><?lsmb transdate ?></td>
+          <?lsmb END ?>
 
-	  <td><?lsmb employee ?>&nbsp;</td>
-	  <td><?lsmb warehouse ?>&nbsp;</td>
-	  <td><?lsmb shippingpoint ?>&nbsp;</td>
-	  <td><?lsmb shipvia ?>&nbsp;</td>
-	</tr>
+          <td><?lsmb employee ?>&nbsp;</td>
+          <td><?lsmb warehouse ?>&nbsp;</td>
+          <td><?lsmb shippingpoint ?>&nbsp;</td>
+          <td><?lsmb shipvia ?>&nbsp;</td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr bgcolor=000000>
-	  <th align=left><font color=ffffff><?lsmb text('Item') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
-	  <th><font color=ffffff><?lsmb text('Qty') ?></th>
-	  <th><font color=ffffff><?lsmb text('Ship') ?></th>
-	  <th>&nbsp;</th>
-	  <th><font color=ffffff><?lsmb text('Bin') ?></th>
-	</tr>
+        <tr bgcolor=000000>
+          <th align=left><font color=ffffff><?lsmb text('Item') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
+          <th><font color=ffffff><?lsmb text('Qty') ?></th>
+          <th><font color=ffffff><?lsmb text('Ship') ?></th>
+          <th>&nbsp;</th>
+          <th><font color=ffffff><?lsmb text('Bin') ?></th>
+        </tr>
 
         <?lsmb FOREACH number ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr valign=top>
-	  <td><?lsmb runningnumber.${loop_count} ?></td>
-	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td align=right><?lsmb qty.${loop_count} ?></td>
-	  <td align=right>[&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]</td>
-	  <td><?lsmb unit.${loop_count} ?></td>
-	  <td align=right><?lsmb bin.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr valign=top>
+          <td><?lsmb runningnumber.${loop_count} ?></td>
+          <td><?lsmb number.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
+          <td align=right><?lsmb qty.${loop_count} ?></td>
+          <td align=right>[&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]</td>
+          <td><?lsmb unit.${loop_count} ?></td>
+          <td align=right><?lsmb bin.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td><hr noshade></td>
   </tr>

--- a/templates/demo/product_receipt.html
+++ b/templates/demo/product_receipt.html
@@ -11,7 +11,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -21,7 +20,6 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
@@ -94,7 +92,6 @@
   <tr height=5></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% border=1>
@@ -118,7 +115,6 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
@@ -211,7 +207,6 @@
 
   <?lsmb IF notes ?>
   <tr>
-    <td>&nbsp;</td>
 
     <td>
     <table width="100%">
@@ -228,7 +223,6 @@
   <?lsmb END ?>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">

--- a/templates/demo/request_quotation.html
+++ b/templates/demo/request_quotation.html
@@ -11,7 +11,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -20,74 +19,73 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr bgcolor=000000>
-	  <th align=left width="50%"><font color=ffffff><?lsmb text('To:') ?>
+        <tr bgcolor=000000>
+          <th align=left width="50%"><font color=ffffff><?lsmb text('To:') ?>
          </th>
-	  <th align=left width="50%"><font color=ffffff><?lsmb text('Ship To:') ?>
+          <th align=left width="50%"><font color=ffffff><?lsmb text('Ship To:') ?>
          </th>
-	</tr>
+        </tr>
 
-	<tr valign=top>
-	  <td><?lsmb name ?>
-	  <br><?lsmb address1 ?>
-	  <?lsmb IF address2 ?>
-	  <br><?lsmb address2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb city ?>
-	  <?lsmb IF state ?>
-	  , <?lsmb state ?>
-	  <?lsmb END ?>
-	  <?lsmb zipcode ?>
-	  <?lsmb IF country ?>
-	  <br><?lsmb country ?>
-	  <?lsmb END ?>
+        <tr valign=top>
+          <td><?lsmb name ?>
+          <br><?lsmb address1 ?>
+          <?lsmb IF address2 ?>
+          <br><?lsmb address2 ?>
+          <?lsmb END ?>
+          <br><?lsmb city ?>
+          <?lsmb IF state ?>
+          , <?lsmb state ?>
+          <?lsmb END ?>
+          <?lsmb zipcode ?>
+          <?lsmb IF country ?>
+          <br><?lsmb country ?>
+          <?lsmb END ?>
           <br>
 
-	  <?lsmb IF contact ?>
-	  <br><?lsmb text('Attn: [_1]', contact) ?>
-	  <?lsmb END ?>
+          <?lsmb IF contact ?>
+          <br><?lsmb text('Attn: [_1]', contact) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF vendorphone ?>
-	  <br><?lsmb text('Tel: [_1]', vendorphone) ?>
-	  <?lsmb END ?>
+          <?lsmb IF vendorphone ?>
+          <br><?lsmb text('Tel: [_1]', vendorphone) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF vendorfax ?>
-	  <br><?lsmb text('Fax: [_1]', vendorfax) ?>
-	  <?lsmb END ?>
-	  </td>
+          <?lsmb IF vendorfax ?>
+          <br><?lsmb text('Fax: [_1]', vendorfax) ?>
+          <?lsmb END ?>
+          </td>
 
-	  <td><?lsmb shiptoname ?>
-	  <br><?lsmb shiptoaddress1 ?>
-	  <?lsmb IF shiptoaddress2 ?>
-	  <br><?lsmb shiptoaddr2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb shiptocity ?>
-	  <?lsmb IF shiptostate ?>
-	  , <?lsmb shiptostate ?>
-	  <?lsmb END ?>
-	  <?lsmb shiptozipcode ?>
-	  <?lsmb IF shiptocountry ?>
-	  <br><?lsmb shiptocountry ?>
-	  <?lsmb END ?>
+          <td><?lsmb shiptoname ?>
+          <br><?lsmb shiptoaddress1 ?>
+          <?lsmb IF shiptoaddress2 ?>
+          <br><?lsmb shiptoaddr2 ?>
+          <?lsmb END ?>
+          <br><?lsmb shiptocity ?>
+          <?lsmb IF shiptostate ?>
+          , <?lsmb shiptostate ?>
+          <?lsmb END ?>
+          <?lsmb shiptozipcode ?>
+          <?lsmb IF shiptocountry ?>
+          <br><?lsmb shiptocountry ?>
+          <?lsmb END ?>
           <br>
 
-	  <?lsmb IF shiptocontact ?>
-	  <br><?lsmb text('Attn: [_1]', shiptocontact) ?>
-	  <?lsmb END ?>
+          <?lsmb IF shiptocontact ?>
+          <br><?lsmb text('Attn: [_1]', shiptocontact) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF shiptophone ?>
-	  <br><?lsmb text('Tel: [_1]', shiptophone) ?>
-	  <?lsmb END ?>
+          <?lsmb IF shiptophone ?>
+          <br><?lsmb text('Tel: [_1]', shiptophone) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF shiptofax ?>
-	  <br><?lsmb text('Fax: [_1]', shiptofax) ?>
-	  <?lsmb END ?>
-	  </td>
-	</tr>
+          <?lsmb IF shiptofax ?>
+          <br><?lsmb text('Fax: [_1]', shiptofax) ?>
+          <?lsmb END ?>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -95,27 +93,26 @@
   <tr height=5></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% border=1>
-	<tr>
-	  <th width=17% align=left><?lsmb text('RFQ #') ?></th>
-	  <th width=17% align=left><?lsmb text('Date') ?></th>
-	  <th width=17% align=left><?lsmb text('Required by') ?></th>
-	  <th width=17% align=left><?lsmb text('Contact') ?></th>
-	  <th width=17% align=left><?lsmb text('Shipping Point') ?></th>
-	  <th width=15% align=left><?lsmb text('Ship via') ?></th>
-	</tr>
+        <tr>
+          <th width=17% align=left><?lsmb text('RFQ #') ?></th>
+          <th width=17% align=left><?lsmb text('Date') ?></th>
+          <th width=17% align=left><?lsmb text('Required by') ?></th>
+          <th width=17% align=left><?lsmb text('Contact') ?></th>
+          <th width=17% align=left><?lsmb text('Shipping Point') ?></th>
+          <th width=15% align=left><?lsmb text('Ship via') ?></th>
+        </tr>
 
-	<tr>
-	  <td><?lsmb quonumber ?></td>
-	  <td><?lsmb quodate ?></td>
-	  <td><?lsmb reqdate ?>&nbsp;</td>
-	  <td><?lsmb employee ?></td>
-	  <td><?lsmb shippingpoint ?>&nbsp;</td>
-	  <td><?lsmb shipvia ?>&nbsp;</td>
-	</tr>
+        <tr>
+          <td><?lsmb quonumber ?></td>
+          <td><?lsmb quodate ?></td>
+          <td><?lsmb reqdate ?>&nbsp;</td>
+          <td><?lsmb employee ?></td>
+          <td><?lsmb shippingpoint ?>&nbsp;</td>
+          <td><?lsmb shipvia ?>&nbsp;</td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -123,7 +120,6 @@
   <tr height="10"></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td><?lsmb text('Please provide price and delivery time for the following items:') ?></td>
   </tr>
@@ -131,35 +127,34 @@
   <tr height="10"></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr>
-	  <th align=right><?lsmb text('Item') ?></th>
-	  <th align=left><?lsmb text('Number') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
-	  <th><?lsmb text('Qty') ?></th>
-	  <th>&nbsp;</th>
-	  <th><?lsmb text('Delivery') ?></th>
-	  <th<?lsmb text('Unit Price') ?></th>
-	  <th<?lsmb text('Extended') ?></th>
-	</tr>
+        <tr>
+          <th align=right><?lsmb text('Item') ?></th>
+          <th align=left><?lsmb text('Number') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
+          <th><?lsmb text('Qty') ?></th>
+          <th>&nbsp;</th>
+          <th><?lsmb text('Delivery') ?></th>
+          <th<?lsmb text('Unit Price') ?></th>
+          <th<?lsmb text('Extended') ?></th>
+        </tr>
 
         <?lsmb FOREACH number ?>
-	<?lsmb loop_count = loop.count - 1 ?>
+        <?lsmb loop_count = loop.count - 1 ?>
         <tr valign=top>
           <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
-	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td align=right><?lsmb qty.${loop_count} ?></td>
-	  <td><?lsmb unit.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+          <td><?lsmb number.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
+          <td align=right><?lsmb qty.${loop_count} ?></td>
+          <td><?lsmb unit.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
-	<tr>
-	  <td colspan=8><hr noshade></td>
-	</tr>
+        <tr>
+          <td colspan=8><hr noshade></td>
+        </tr>
 
       </table>
     </td>
@@ -167,16 +162,15 @@
 
   <?lsmb IF notes ?>
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr valign=top>
-	  <td<?lsmb text('Notes') ?></td>
+        <tr valign=top>
+          <td<?lsmb text('Notes') ?></td>
           <td><?lsmb  FOREACH P IN notes.split('\n\n') ?>
                     <p><?lsmb P ?></p>
                <?lsmb END ?></td>
-	</tr>
+        </tr>
 
       </table>
     </td>

--- a/templates/demo/sales_order.html
+++ b/templates/demo/sales_order.html
@@ -11,7 +11,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -20,73 +19,72 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
-	<tr bgcolor=000000>
-	  <th align=left width="50%"><font color=ffffff><?lsmb text('To') ?></th>
-	  <th align=left width="50%"><font color=ffffff><?lsmb text('Ship To') ?>
+        <tr bgcolor=000000>
+          <th align=left width="50%"><font color=ffffff><?lsmb text('To') ?></th>
+          <th align=left width="50%"><font color=ffffff><?lsmb text('Ship To') ?>
           </th>
-	</tr>
+        </tr>
 
-	<tr valign=top>
-	  <td><?lsmb name ?>
-	  <br><?lsmb address1 ?>
-	  <?lsmb IF address2 ?>
-	  <br><?lsmb address2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb city ?>
-	  <?lsmb IF state ?>
-	  , <?lsmb state ?>
-	  <?lsmb END ?>
+        <tr valign=top>
+          <td><?lsmb name ?>
+          <br><?lsmb address1 ?>
+          <?lsmb IF address2 ?>
+          <br><?lsmb address2 ?>
+          <?lsmb END ?>
+          <br><?lsmb city ?>
+          <?lsmb IF state ?>
+          , <?lsmb state ?>
+          <?lsmb END ?>
           <?lsmb zipcode ?>
-	  <?lsmb IF country ?>
-	  <br><?lsmb country ?>
-	  <?lsmb END ?>
+          <?lsmb IF country ?>
+          <br><?lsmb country ?>
+          <?lsmb END ?>
           <br>
-	  <?lsmb IF contact ?>
-	  <br><?lsmb text('Attn: [_1]', contact) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF customerphone ?>
-	  <br><?lsmb text('Tel: [_1]', customerphone) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF customerfax ?>
-	  <br><?lsmb text('Fax: [_1]', customerfax) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF email ?>
-	  <br><?lsmb email ?>
-	  <?lsmb END ?>
-	  </td>
+          <?lsmb IF contact ?>
+          <br><?lsmb text('Attn: [_1]', contact) ?>
+          <?lsmb END ?>
+          <?lsmb IF customerphone ?>
+          <br><?lsmb text('Tel: [_1]', customerphone) ?>
+          <?lsmb END ?>
+          <?lsmb IF customerfax ?>
+          <br><?lsmb text('Fax: [_1]', customerfax) ?>
+          <?lsmb END ?>
+          <?lsmb IF email ?>
+          <br><?lsmb email ?>
+          <?lsmb END ?>
+          </td>
 
-	  <td><?lsmb shiptoname ?>
-	  <br><?lsmb shiptoaddress1 ?>
-	  <?lsmb IF shiptoaddress2 ?>
-	  <br><?lsmb shiptoaddress2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb shiptocity ?>
-	  <?lsmb IF shiptostate ?>
-	  , <?lsmb shiptostate ?>
-	  <?lsmb END ?>
+          <td><?lsmb shiptoname ?>
+          <br><?lsmb shiptoaddress1 ?>
+          <?lsmb IF shiptoaddress2 ?>
+          <br><?lsmb shiptoaddress2 ?>
+          <?lsmb END ?>
+          <br><?lsmb shiptocity ?>
+          <?lsmb IF shiptostate ?>
+          , <?lsmb shiptostate ?>
+          <?lsmb END ?>
           <?lsmb shiptozipcode ?>
-	  <?lsmb IF shiptocountry ?>
-	  <br><?lsmb shiptocountry ?>
-	  <?lsmb END ?>
-	  <br>
+          <?lsmb IF shiptocountry ?>
+          <br><?lsmb shiptocountry ?>
+          <?lsmb END ?>
+          <br>
           <?lsmb IF shiptocontact ?>
           <br><?lsmb shiptocontact ?>
           <?lsmb END ?>
-	  <?lsmb IF shiptophone ?>
-	  <br><?lsmb text('Tel: [_1]', shiptophone) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF shiptofax ?>
-	  <br><?lsmb text('Fax: [_1]', shiptofax) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF shiptoemail ?>
-	  <br><?lsmb shiptoemail ?>
-	  <?lsmb END ?>
-	  </td>
-	</tr>
+          <?lsmb IF shiptophone ?>
+          <br><?lsmb text('Tel: [_1]', shiptophone) ?>
+          <?lsmb END ?>
+          <?lsmb IF shiptofax ?>
+          <br><?lsmb text('Fax: [_1]', shiptofax) ?>
+          <?lsmb END ?>
+          <?lsmb IF shiptoemail ?>
+          <br><?lsmb shiptoemail ?>
+          <?lsmb END ?>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -94,141 +92,137 @@
   <tr height=5></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% border=1>
-	<tr>
-	  <th width=17% align=left nowrap><?lsmb text('Order #') ?></th>
-	  <th width=17% align=left><?lsmb text('Order Date') ?></th>
-	  <th width=17% align=left><?lsmb text('Required by') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Salesperson') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Shipping Point') ?></th>
-	  <th width=15% align=left nowrap><?lsmb text('Ship Via') ?></th>
-	</tr>
+        <tr>
+          <th width=17% align=left nowrap><?lsmb text('Order #') ?></th>
+          <th width=17% align=left><?lsmb text('Order Date') ?></th>
+          <th width=17% align=left><?lsmb text('Required by') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Salesperson') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Shipping Point') ?></th>
+          <th width=15% align=left nowrap><?lsmb text('Ship Via') ?></th>
+        </tr>
 
-	<tr>
-	  <td><?lsmb ordnumber ?></td>
-	  <td><?lsmb orddate ?></td>
-	  <td><?lsmb reqdate ?></td>
-	  <td><?lsmb employee ?></td>
-	  <td><?lsmb shippingpoint ?>&nbsp;</td>
-	  <td><?lsmb shipvia ?>&nbsp;</td>
-	</tr>
+        <tr>
+          <td><?lsmb ordnumber ?></td>
+          <td><?lsmb orddate ?></td>
+          <td><?lsmb reqdate ?></td>
+          <td><?lsmb employee ?></td>
+          <td><?lsmb shippingpoint ?>&nbsp;</td>
+          <td><?lsmb shipvia ?>&nbsp;</td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr bgcolor=000000>
-	  <th align=right><font color=ffffff><?lsmb text('Item') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
-	  <th><font color=ffffff><?lsmb text('Qty') ?></th>
-	  <th>&nbsp;</th>
-	  <th><font color=ffffff><?lsmb text('Price') ?></th>
-	  <th><font color=ffffff><?lsmb text('Disc %') ?></th>
-	  <th><font color=ffffff><?lsmb text('Amount') ?></th>
-	</tr>
+        <tr bgcolor=000000>
+          <th align=right><font color=ffffff><?lsmb text('Item') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
+          <th><font color=ffffff><?lsmb text('Qty') ?></th>
+          <th>&nbsp;</th>
+          <th><font color=ffffff><?lsmb text('Price') ?></th>
+          <th><font color=ffffff><?lsmb text('Disc %') ?></th>
+          <th><font color=ffffff><?lsmb text('Amount') ?></th>
+        </tr>
 
-	<?lsmb FOREACH number ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr valign=top>
+        <?lsmb FOREACH number ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr valign=top>
           <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
-	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td align=right><?lsmb qty.${loop_count} ?></td>
-	  <td><?lsmb unit.${loop_count} ?></td>
-	  <td align=right><?lsmb sellprice.${loop_count} ?></td>
-	  <td align=right><?lsmb discountrate.${loop_count} ?></td>
-	  <td align=right><?lsmb linetotal.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+          <td><?lsmb number.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
+          <td align=right><?lsmb qty.${loop_count} ?></td>
+          <td><?lsmb unit.${loop_count} ?></td>
+          <td align=right><?lsmb sellprice.${loop_count} ?></td>
+          <td align=right><?lsmb discountrate.${loop_count} ?></td>
+          <td align=right><?lsmb linetotal.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
-	<tr>
-	  <td colspan=8><hr noshade></td>
-	</tr>
+        <tr>
+          <td colspan=8><hr noshade></td>
+        </tr>
 
-	<tr>
-	  <?lsmb IF taxincluded ?>
-	  <th colspan=6 align=right><?lsmb text('Total') ?></th>
-	  <td colspan=2 align=right><?lsmb invtotal ?></td>
-	  <?lsmb ELSE ?>
-	  <th colspan=6 align=right><?lsmb text('Subtotal') ?></th>
-	  <td colspan=2 align=right><?lsmb subtotal ?></td>
-	  <?lsmb END ?>
-	</tr>
+        <tr>
+          <?lsmb IF taxincluded ?>
+          <th colspan=6 align=right><?lsmb text('Total') ?></th>
+          <td colspan=2 align=right><?lsmb invtotal ?></td>
+          <?lsmb ELSE ?>
+          <th colspan=6 align=right><?lsmb text('Subtotal') ?></th>
+          <td colspan=2 align=right><?lsmb subtotal ?></td>
+          <?lsmb END ?>
+        </tr>
 
-	<?lsmb FOREACH tax ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr>
-	  <th colspan=6 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
-	  <td colspan=2 align=right><?lsmb tax.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+        <?lsmb FOREACH tax ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr>
+          <th colspan=6 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+          <td colspan=2 align=right><?lsmb tax.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
-	<tr>
-	  <td colspan=4>&nbsp;</td>
-	  <td colspan=4><hr noshade></td>
-	</tr>
+        <tr>
+          <td colspan=4>&nbsp;</td>
+          <td colspan=4><hr noshade></td>
+        </tr>
 
-	<tr>
-	  <td colspan=4>
+        <tr>
+          <td colspan=4>
           <?lsmb text_amount ?> ***** <?lsmb decimal ?>/100
-	  <?lsmb IF terms ?>
-	  <br><?lsmb text('Terms Net [_1] days', terms) ?>
-	  <?lsmb END ?>
-	  </td>
-	  <th colspan=2 align=right><?lsmb text('Total') ?></th>
-	  <th colspan=2 align=right><?lsmb ordtotal ?></th>
-	</tr>
+          <?lsmb IF terms ?>
+          <br><?lsmb text('Terms Net [_1] days', terms) ?>
+          <?lsmb END ?>
+          </td>
+          <th colspan=2 align=right><?lsmb text('Total') ?></th>
+          <th colspan=2 align=right><?lsmb ordtotal ?></th>
+        </tr>
 
-	<tr>
-	  <td>&nbsp;</td>
-	</tr>
+        <tr>
+          <td>&nbsp;</td>
+        </tr>
 
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr valign=top>
-	  <?lsmb IF notes ?>
-	  <td><?lsmb text('Notes') ?></td>
+        <tr valign=top>
+          <?lsmb IF notes ?>
+          <td><?lsmb text('Notes') ?></td>
           <td><?lsmb  FOREACH P IN notes.split('\n\n') ?>
                     <p><?lsmb P ?></p>
                <?lsmb END ?></td>
-	  <?lsmb END ?>
-	  <td align=right nowrap>
-	  <?lsmb text('All prices in [_1] Funds', currency) ?>
-	  </td>
-	</tr>
+          <?lsmb END ?>
+          <td align=right nowrap>
+          <?lsmb text('All prices in [_1] Funds', currency) ?>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr valign=top>
-	  <td width="60%"><font size=-3>
-	  <?lsmb text('Special order items are subject to a 10% order cancellation fee.') ?>
-	  </font>
-	  </td>
-	  <td width="40%">
-	  X <hr noshade>
-	  </td>
-	</tr>
+        <tr valign=top>
+          <td width="60%"><font size=-3>
+          <?lsmb text('Special order items are subject to a 10% order cancellation fee.') ?>
+          </font>
+          </td>
+          <td width="40%">
+          X <hr noshade>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>

--- a/templates/demo/sales_quotation.html
+++ b/templates/demo/sales_quotation.html
@@ -11,7 +11,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3 style="text-transform:uppercase">
       <h4><?lsmb text('Quotation') ?></h4>
@@ -19,186 +18,181 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
 
-	<tr valign=top>
-	  <td><?lsmb name ?>
-	  <br><?lsmb address1 ?>
-	  <?lsmb IF address2 ?>
-	  <br><?lsmb address2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb city ?>
-	  <?lsmb IF state ?>
-	  , <?lsmb state ?>
-	  <?lsmb END ?>
-	  <?lsmb zipcode ?>
-	  <?lsmb IF country ?>
-	  <br><?lsmb country ?>
-	  <?lsmb END ?>
+        <tr valign=top>
+          <td><?lsmb name ?>
+          <br><?lsmb address1 ?>
+          <?lsmb IF address2 ?>
+          <br><?lsmb address2 ?>
+          <?lsmb END ?>
+          <br><?lsmb city ?>
+          <?lsmb IF state ?>
+          , <?lsmb state ?>
+          <?lsmb END ?>
+          <?lsmb zipcode ?>
+          <?lsmb IF country ?>
+          <br><?lsmb country ?>
+          <?lsmb END ?>
 
-	  <br>
-	  <?lsmb IF contact ?>
-	  <br><?lsmb text('Attn: [_1]', contact) ?>
-	  <?lsmb END ?>
+          <br>
+          <?lsmb IF contact ?>
+          <br><?lsmb text('Attn: [_1]', contact) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF customerphone ?>
-	  <br><?lsmb text('Tel: [_1]', customerphone) ?>
-	  <?lsmb END ?>
+          <?lsmb IF customerphone ?>
+          <br><?lsmb text('Tel: [_1]', customerphone) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF customerfax ?>
-	  <br><?lsmb text('Fax: [_1]', customerfax) ?>
-	  <?lsmb END ?>
+          <?lsmb IF customerfax ?>
+          <br><?lsmb text('Fax: [_1]', customerfax) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF email ?>
-	  <br><?lsmb email ?>
-	  <?lsmb END ?>
-	  </td>
+          <?lsmb IF email ?>
+          <br><?lsmb email ?>
+          <?lsmb END ?>
+          </td>
 
-	</tr>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% border=1>
-	<tr>
-	  <th width=17% align=left nowrap><?lsmb text('Number') ?></th>
-	  <th width=17% align=left><?lsmb text('Date') ?></th>
-	  <th width=17% align=left><?lsmb text('Valid until') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Contact') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Shipping Point') ?></th>
-	  <th width=15% align=left nowrap><?lsmb text('Ship via') ?></th>
-	</tr>
+        <tr>
+          <th width=17% align=left nowrap><?lsmb text('Number') ?></th>
+          <th width=17% align=left><?lsmb text('Date') ?></th>
+          <th width=17% align=left><?lsmb text('Valid until') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Contact') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Shipping Point') ?></th>
+          <th width=15% align=left nowrap><?lsmb text('Ship via') ?></th>
+        </tr>
 
-	<tr>
-	  <td><?lsmb quonumber ?></td>
-	  <td><?lsmb quodate ?></td>
-	  <td><?lsmb reqdate ?></td>
-	  <td><?lsmb employee ?></td>
-	  <td><?lsmb shippingpoint ?>&nbsp;</td>
-	  <td><?lsmb shipvia ?>&nbsp;</td>
-	</tr>
+        <tr>
+          <td><?lsmb quonumber ?></td>
+          <td><?lsmb quodate ?></td>
+          <td><?lsmb reqdate ?></td>
+          <td><?lsmb employee ?></td>
+          <td><?lsmb shippingpoint ?>&nbsp;</td>
+          <td><?lsmb shipvia ?>&nbsp;</td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr bgcolor=000000>
-	  <th align=right><font color=ffffff><?lsmb text('Item') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
-	  <th><font color=ffffff><?lsmb text('Qty') ?></th>
-	  <th>&nbsp;</th>
-	  <th><font color=ffffff><?lsmb text('Price') ?></th>
-	  <th><font color=ffffff><?lsmb text('Disc %') ?></th>
-	  <th><font color=ffffff><?lsmb text('Amount') ?></th>
-	</tr>
+        <tr bgcolor=000000>
+          <th align=right><font color=ffffff><?lsmb text('Item') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
+          <th><font color=ffffff><?lsmb text('Qty') ?></th>
+          <th>&nbsp;</th>
+          <th><font color=ffffff><?lsmb text('Price') ?></th>
+          <th><font color=ffffff><?lsmb text('Disc %') ?></th>
+          <th><font color=ffffff><?lsmb text('Amount') ?></th>
+        </tr>
 
         <?lsmb FOREACH number ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr valign=top>
-	  <td align=right><?lsmb runningnumber.${loop_count} ?></td>
-	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td align=right><?lsmb qty.${loop_count} ?></td>
-	  <td><?lsmb unit.${loop_count} ?></td>
-	  <td align=right><?lsmb sellprice.${loop_count} ?></td>
-	  <td align=right><?lsmb discountrate.${loop_count} ?></td>
-	  <td align=right><?lsmb linetotal.${loop_count} ?></td>
-	</tr>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr valign=top>
+          <td align=right><?lsmb runningnumber.${loop_count} ?></td>
+          <td><?lsmb number.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
+          <td align=right><?lsmb qty.${loop_count} ?></td>
+          <td><?lsmb unit.${loop_count} ?></td>
+          <td align=right><?lsmb sellprice.${loop_count} ?></td>
+          <td align=right><?lsmb discountrate.${loop_count} ?></td>
+          <td align=right><?lsmb linetotal.${loop_count} ?></td>
+        </tr>
         <?lsmb END ?>
 
-	<tr>
-	  <td colspan=8><hr noshade></td>
-	</tr>
+        <tr>
+          <td colspan=8><hr noshade></td>
+        </tr>
 
-	<tr>
-	  <?lsmb IF taxincluded ?>
-	  <th colspan=6 align=right><?lsmb text('Total') ?></th>
-	  <td colspan=2 align=right><?lsmb invtotal ?></td>
-	  <?lsmb ELSE ?>
-	  <th colspan=6 align=right><?lsmb text('Subtotal') ?></th>
-	  <td colspan=2 align=right><?lsmb subtotal ?></td>
-	  <?lsmb END ?>
-	</tr>
+        <tr>
+          <?lsmb IF taxincluded ?>
+          <th colspan=6 align=right><?lsmb text('Total') ?></th>
+          <td colspan=2 align=right><?lsmb invtotal ?></td>
+          <?lsmb ELSE ?>
+          <th colspan=6 align=right><?lsmb text('Subtotal') ?></th>
+          <td colspan=2 align=right><?lsmb subtotal ?></td>
+          <?lsmb END ?>
+        </tr>
 
-	<?lsmb FOREACH tax ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr>
-	  <th colspan=6 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
-	  <td colspan=2 align=right><?lsmb tax.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+        <?lsmb FOREACH tax ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr>
+          <th colspan=6 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+          <td colspan=2 align=right><?lsmb tax.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
-	<tr>
-	  <td colspan=4>&nbsp;</td>
-	  <td colspan=4><hr noshade></td>
-	</tr>
+        <tr>
+          <td colspan=4>&nbsp;</td>
+          <td colspan=4><hr noshade></td>
+        </tr>
 
-	<tr>
-	  <td colspan=4>&nbsp;
-	  <?lsmb IF terms ?>
-	  <?lsmb text('Terms Net [_1] days', terms) ?>
-	  <?lsmb END ?>
-	  </td>
-	  <th colspan=2 align=right><?lsmb text('Total') ?></th>
-	  <th colspan=2 align=right><?lsmb quototal ?></th>
-	</tr>
+        <tr>
+          <td colspan=4>&nbsp;
+          <?lsmb IF terms ?>
+          <?lsmb text('Terms Net [_1] days', terms) ?>
+          <?lsmb END ?>
+          </td>
+          <th colspan=2 align=right><?lsmb text('Total') ?></th>
+          <th colspan=2 align=right><?lsmb quototal ?></th>
+        </tr>
 
-	<tr>
-	  <td>&nbsp;</td>
-	</tr>
+        <tr>
+          <td>&nbsp;</td>
+        </tr>
 
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr valign=top>
+        <tr valign=top>
           <?lsmb IF notes ?>
-	  <td><?lsmb text('Notes') ?></td>
+          <td><?lsmb text('Notes') ?></td>
           <td><?lsmb  FOREACH P IN notes.split('\n\n') ?>
                     <p><?lsmb P ?></p>
                <?lsmb END ?></td>
           <?lsmb END ?>
-	  <td align=right>
-	  <?lsmb text('All prices in [_1] Funds', currency) ?>
-	  </td>
-	</tr>
+          <td align=right>
+          <?lsmb text('All prices in [_1] Funds', currency) ?>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr valign=top>
-	  <td width="60%"><font size=-3>
-	  <?lsmb
+        <tr valign=top>
+          <td width="60%"><font size=-3>
+          <?lsmb
              text('Special order items are subject to a 10% cancellation fee.')
            ?>
-	  </font>
-	  </td>
-	  <td width="40%">
-	  X <hr noshade>
-	  </td>
-	</tr>
+          </font>
+          </td>
+          <td width="40%">
+          X <hr noshade>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>

--- a/templates/demo/statement.html
+++ b/templates/demo/statement.html
@@ -13,7 +13,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3><h4 style="text-transform:uppercase">
          <?lsmb text('Statement') ?></h4></th>
@@ -21,30 +20,28 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td colspan=3 align=right><?lsmb statementdate ?></td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr valign=top>
-	  <td><?lsmb statement.entity.name ?>
-	  <br><?lsmb statement.address.line_one ?>
-	  <?lsmb IF statement.address.line_two ?>
-	  <br><?lsmb statement.address.line_two ?>
-	  <?lsmb END ?>
-	  <br><?lsmb statement.address.city ?>
-	  <?lsmb IF statement.address.state ?>
-	  , <?lsmb statement.address.state ?>
-	  <?lsmb END ?>
-	  <?lsmb statement.address.mail_code ?>
-	  <br>
-	  </td>
-	</tr>
+        <tr valign=top>
+          <td><?lsmb statement.entity.name ?>
+          <br><?lsmb statement.address.line_one ?>
+          <?lsmb IF statement.address.line_two ?>
+          <br><?lsmb statement.address.line_two ?>
+          <?lsmb END ?>
+          <br><?lsmb statement.address.city ?>
+          <?lsmb IF statement.address.state ?>
+          , <?lsmb statement.address.state ?>
+          <?lsmb END ?>
+          <?lsmb statement.address.mail_code ?>
+          <br>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -52,48 +49,47 @@
   <tr height=10></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
         <tr>
-	  <th align=left><?lsmb text('Invoice #') ?></th>
+          <th align=left><?lsmb text('Invoice #') ?></th>
           <th align=left><?lsmb text('Order #') ?></th>
-	  <th width="10%"><?lsmb text('Date') ?></th>
-	  <th width="10%"><?lsmb text('Due') ?></th>
-	  <th width="10%"><?lsmb text('Current') ?></th>
-	  <th width="10%"><?lsmb text('30') ?></th>
-	  <th width="10%"><?lsmb text('60') ?></th>
-	  <th width="10%"><?lsmb text('90') ?></th>
-	</tr>
+          <th width="10%"><?lsmb text('Date') ?></th>
+          <th width="10%"><?lsmb text('Due') ?></th>
+          <th width="10%"><?lsmb text('Current') ?></th>
+          <th width="10%"><?lsmb text('30') ?></th>
+          <th width="10%"><?lsmb text('60') ?></th>
+          <th width="10%"><?lsmb text('90') ?></th>
+        </tr>
 
-	<?lsmb- FOREACH invoice IN statement.aging.rows ?>
-	<tr>
-	  <td><?lsmb invoice.invnumber ?></td>
+        <?lsmb- FOREACH invoice IN statement.aging.rows ?>
+        <tr>
+          <td><?lsmb invoice.invnumber ?></td>
           <td><?lsmb invoice.ordnumber ?></td>
-	  <td><?lsmb invoice.transdate ?></td>
-	  <td><?lsmb invoice.duedate ?></td>
-	  <td align=right><?lsmb invoice.c0 ?></td>
-	  <td align=right><?lsmb invoice.c30 ?></td>
-	  <td align=right><?lsmb invoice.c60 ?></td>
-	  <td align=right><?lsmb invoice.c90 ?></td>
-	</tr>
+          <td><?lsmb invoice.transdate ?></td>
+          <td><?lsmb invoice.duedate ?></td>
+          <td align=right><?lsmb invoice.c0 ?></td>
+          <td align=right><?lsmb invoice.c30 ?></td>
+          <td align=right><?lsmb invoice.c60 ?></td>
+          <td align=right><?lsmb invoice.c90 ?></td>
+        </tr>
         <?lsmb END -?>
 
         <tr>
-	  <td colspan=8><hr size=1></td>
-	</tr>
+          <td colspan=8><hr size=1></td>
+        </tr>
 
-	<tr>
-	  <td>&nbsp;</td>
-	  <td>&nbsp;</td>
+        <tr>
           <td>&nbsp;</td>
           <td>&nbsp;</td>
-	  <th align=right><?lsmb statement.aging.c0total ?></td>
-	  <th align=right><?lsmb statement.aging.c30total ?></td>
-	  <th align=right><?lsmb statement.aging.c60total ?></td>
-	  <th align=right><?lsmb statement.aging.c90total ?></td>
-	</tr>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+          <th align=right><?lsmb statement.aging.c0total ?></td>
+          <th align=right><?lsmb statement.aging.c30total ?></td>
+          <th align=right><?lsmb statement.aging.c60total ?></td>
+          <th align=right><?lsmb statement.aging.c90total ?></td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -101,20 +97,18 @@
   <tr height=10></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td align=right>
       <table width="50%">
         <tr>
-	  <th><?lsmb text('Total Outstanding') ?></th>
+          <th><?lsmb text('Total Outstanding') ?></th>
           <th align=right><?lsmb statement.aging.total ?></th>
-	</tr>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td><hr noshade></td>
   </tr>

--- a/templates/demo/timecard.html
+++ b/templates/demo/timecard.html
@@ -9,9 +9,8 @@
 <table width="100%">
 
   <?lsmb INCLUDE letterhead ?>
-  
+
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -20,103 +19,100 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
         <tr valign=top>
-	  <td>
-	    <table>
-	      <tr>
-		<th align=left><?lsmb text('Employee') ?></th>
-		<td><?lsmb employee ?></td>
-	      </tr>
-	      <tr>
-		<th align=left><?lsmb text('ID') ?></th>
-		<td><?lsmb employee_id ?></td>
-	      </tr>
-	    </table>
-	  </td>
-   
-	  <td align=right>
-	    <table>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Card ID') ?></th>
-		<td><?lsmb id ?></td>
-	      </tr>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Date') ?></th>
-		<td><?lsmb transdate ?></td>
-	      </tr>
-	      <tr>
-		<th align=left nowrap><?lsmb text('In') ?></th>
-		<td><?lsmb checkedin ?></td>
-	      </tr>
+          <td>
+            <table>
+              <tr>
+                <th align=left><?lsmb text('Employee') ?></th>
+                <td><?lsmb employee ?></td>
+              </tr>
+              <tr>
+                <th align=left><?lsmb text('ID') ?></th>
+                <td><?lsmb employee_id ?></td>
+              </tr>
+            </table>
+          </td>
+
+          <td align=right>
+            <table>
+              <tr>
+                <th align=left nowrap><?lsmb text('Card ID') ?></th>
+                <td><?lsmb id ?></td>
+              </tr>
+              <tr>
+                <th align=left nowrap><?lsmb text('Date') ?></th>
+                <td><?lsmb transdate ?></td>
+              </tr>
+              <tr>
+                <th align=left nowrap><?lsmb text('In') ?></th>
+                <td><?lsmb checkedin ?></td>
+              </tr>
               <tr>
                 <th align=left><?lsmb text('Out') ?></th>
-		<td><?lsmb checkedout ?></td>
-	      </tr>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Hours') ?></th>
-		<td><?lsmb qty ?></td>
-	      </tr>
-	    </table>
-	  </td>
+                <td><?lsmb checkedout ?></td>
+              </tr>
+              <tr>
+                <th align=left nowrap><?lsmb text('Hours') ?></th>
+                <td><?lsmb qty ?></td>
+              </tr>
+            </table>
+          </td>
         </tr>
       </table>
     </td>
   </tr>
 
   <tr height=5></tr>
-  
+
   <tr>
-    <td>&nbsp;</td>
-  
+
     <td>
       <table width="100%">
         <tr valign=bottom>
-	  <td>
-	    <table>
-	      <tr valign=top>
-	        <th align=left><?lsmb text('Job/Project #') ?></th>
-		<td><?lsmb projectnumber ?></td>
-	      </tr>
-	      <tr>
-	        <th align=left><?lsmb text('Description') ?></th>
-		<td><?lsmb projectdescription ?></td>
-	      </tr>
-	      <tr valign=top>
-	        <th align=left><?lsmb text('Labor/Service Code') ?></th>
-		<td><?lsmb partnumber ?></td>
-	      </tr>
-	      <tr>
-	        <th align=left><?lsmb text('Description') ?></th>
-		<td><?lsmb description ?></td>
-	      </tr>
-	    </table>
-	  </td>
-	  <td align=right>
-	    <table>
-	      <tr>
-	        <th align=right><?lsmb text('Rate') ?></th>
-		<td><?lsmb sellprice ?></td>
-	      </tr>
-	      <tr>
-		<th align=right><?lsmb text('Total') ?></th>
-		<td><?lsmb total ?></td>
-	      </tr>
-	    </table>
-	  </td>
-	</tr>
+          <td>
+            <table>
+              <tr valign=top>
+                <th align=left><?lsmb text('Job/Project #') ?></th>
+                <td><?lsmb projectnumber ?></td>
+              </tr>
+              <tr>
+                <th align=left><?lsmb text('Description') ?></th>
+                <td><?lsmb projectdescription ?></td>
+              </tr>
+              <tr valign=top>
+                <th align=left><?lsmb text('Labor/Service Code') ?></th>
+                <td><?lsmb partnumber ?></td>
+              </tr>
+              <tr>
+                <th align=left><?lsmb text('Description') ?></th>
+                <td><?lsmb description ?></td>
+              </tr>
+            </table>
+          </td>
+          <td align=right>
+            <table>
+              <tr>
+                <th align=right><?lsmb text('Rate') ?></th>
+                <td><?lsmb sellprice ?></td>
+              </tr>
+              <tr>
+                <th align=right><?lsmb text('Total') ?></th>
+                <td><?lsmb total ?></td>
+              </tr>
+            </table>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <?lsmb IF notes ?>
   <tr height=5></tr>
-  
+
   <tr>
-    <td>&nbsp;</td>
 
           <td><?lsmb  FOREACH P IN notes.split('\n\n') ?>
                     <p><?lsmb P ?></p>

--- a/templates/demo/work_order.html
+++ b/templates/demo/work_order.html
@@ -11,82 +11,80 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
-	<?lsmb text('Work Order') ?></h4>
+        <?lsmb text('Work Order') ?></h4>
     </th>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
-	<tr bgcolor=000000>
-	  <th align=left width="50%"><font color=ffffff><?lsmb text('To') ?></th>
-	  <th align=left width="50%"><font color=ffffff><?lsmb text('Ship To') ?>
+        <tr bgcolor=000000>
+          <th align=left width="50%"><font color=ffffff><?lsmb text('To') ?></th>
+          <th align=left width="50%"><font color=ffffff><?lsmb text('Ship To') ?>
           </th>
-	</tr>
+        </tr>
 
-	<tr valign=top>
-	  <td><?lsmb name ?>
-	  <br><?lsmb address1 ?>
-	  <?lsmb IF address2 ?>
-	  <br><?lsmb address2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb city ?>
-	  <?lsmb IF state ?>
-	  , <?lsmb state ?>
-	  <?lsmb END ?>
+        <tr valign=top>
+          <td><?lsmb name ?>
+          <br><?lsmb address1 ?>
+          <?lsmb IF address2 ?>
+          <br><?lsmb address2 ?>
+          <?lsmb END ?>
+          <br><?lsmb city ?>
+          <?lsmb IF state ?>
+          , <?lsmb state ?>
+          <?lsmb END ?>
           <?lsmb zipcode ?>
-	  <?lsmb IF country ?>
-	  <br><?lsmb country ?>
-	  <?lsmb END ?>
+          <?lsmb IF country ?>
+          <br><?lsmb country ?>
+          <?lsmb END ?>
           <br>
-	  <?lsmb IF contact ?>
-	  <br><?lsmb text('Attn: [_1]', contact) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF customerphone ?>
-	  <br><?lsmb text('Tel: [_1]', customerphone) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF customerfax ?>
-	  <br><?lsmb text('Fax: [_1]', customerfax) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF email ?>
-	  <br><?lsmb email ?>
-	  <?lsmb END ?>
-	  </td>
+          <?lsmb IF contact ?>
+          <br><?lsmb text('Attn: [_1]', contact) ?>
+          <?lsmb END ?>
+          <?lsmb IF customerphone ?>
+          <br><?lsmb text('Tel: [_1]', customerphone) ?>
+          <?lsmb END ?>
+          <?lsmb IF customerfax ?>
+          <br><?lsmb text('Fax: [_1]', customerfax) ?>
+          <?lsmb END ?>
+          <?lsmb IF email ?>
+          <br><?lsmb email ?>
+          <?lsmb END ?>
+          </td>
 
-	  <td><?lsmb shiptoname ?>
-	  <br><?lsmb shiptoaddress1 ?>
-	  <?lsmb IF shiptoaddress2 ?>
-	  <br><?lsmb shiptoaddress2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb shiptocity ?>
-	  <?lsmb IF shiptostate ?>
-	  , <?lsmb shiptostate ?>
-	  <?lsmb END ?>
+          <td><?lsmb shiptoname ?>
+          <br><?lsmb shiptoaddress1 ?>
+          <?lsmb IF shiptoaddress2 ?>
+          <br><?lsmb shiptoaddress2 ?>
+          <?lsmb END ?>
+          <br><?lsmb shiptocity ?>
+          <?lsmb IF shiptostate ?>
+          , <?lsmb shiptostate ?>
+          <?lsmb END ?>
           <?lsmb shiptozipcode ?>
-	  <?lsmb IF shiptocountry ?>
-	  <br><?lsmb shiptocountry ?>
-	  <?lsmb END ?>
-	  <br>
+          <?lsmb IF shiptocountry ?>
+          <br><?lsmb shiptocountry ?>
+          <?lsmb END ?>
+          <br>
           <?lsmb IF shiptocontact ?>
           <br><?lsmb shiptocontact ?>
           <?lsmb END ?>
-	  <?lsmb IF shiptophone ?>
-	  <br><?lsmb text('Tel: [_1]', shiptophone) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF shiptofax ?>
-	  <br><?lsmb text('Fax: [_1]', shiptofax) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF shiptoemail ?>
-	  <br><?lsmb shiptoemail ?>
-	  <?lsmb END ?>
-	  </td>
-	</tr>
+          <?lsmb IF shiptophone ?>
+          <br><?lsmb text('Tel: [_1]', shiptophone) ?>
+          <?lsmb END ?>
+          <?lsmb IF shiptofax ?>
+          <br><?lsmb text('Fax: [_1]', shiptofax) ?>
+          <?lsmb END ?>
+          <?lsmb IF shiptoemail ?>
+          <br><?lsmb shiptoemail ?>
+          <?lsmb END ?>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -94,69 +92,66 @@
   <tr height=5></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% border=1>
-	<tr>
-	  <th width=17% align=left nowrap><?lsmb text('Order #') ?></th>
-	  <th width=17% align=left><?lsmb text('Order Date') ?></th>
-	  <th width=17% align=left><?lsmb text('Required by') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Salesperson') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Shipping Point') ?></th>
-	  <th width=15% align=left nowrap><?lsmb text('Ship Via') ?></th>
-	</tr>
+        <tr>
+          <th width=17% align=left nowrap><?lsmb text('Order #') ?></th>
+          <th width=17% align=left><?lsmb text('Order Date') ?></th>
+          <th width=17% align=left><?lsmb text('Required by') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Salesperson') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Shipping Point') ?></th>
+          <th width=15% align=left nowrap><?lsmb text('Ship Via') ?></th>
+        </tr>
 
-	<tr>
-	  <td><?lsmb ordnumber ?></td>
-	  <td><?lsmb orddate ?></td>
-	  <td><?lsmb reqdate ?></td>
-	  <td><?lsmb employee ?></td>
-	  <td><?lsmb shippingpoint ?>&nbsp;</td>
-	  <td><?lsmb shipvia ?>&nbsp;</td>
-	</tr>
+        <tr>
+          <td><?lsmb ordnumber ?></td>
+          <td><?lsmb orddate ?></td>
+          <td><?lsmb reqdate ?></td>
+          <td><?lsmb employee ?></td>
+          <td><?lsmb shippingpoint ?>&nbsp;</td>
+          <td><?lsmb shipvia ?>&nbsp;</td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr bgcolor=000000>
-	  <th align=right><font color=ffffff><?lsmb text('Item') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
-	  <th><font color=ffffff><?lsmb text('Qty') ?></th>
-	  <th>&nbsp;</th>
+        <tr bgcolor=000000>
+          <th align=right><font color=ffffff><?lsmb text('Item') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
+          <th><font color=ffffff><?lsmb text('Qty') ?></th>
+          <th>&nbsp;</th>
            <th><font color=ffffff><?lsmb text('Bin') ?></th>
-	  <th><font color=ffffff><?lsmb text('Serial #') ?></th>
-	</tr>
+          <th><font color=ffffff><?lsmb text('Serial #') ?></th>
+        </tr>
 
-	<?lsmb FOREACH number ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr valign=top>
+        <?lsmb FOREACH number ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr valign=top>
           <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
-	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td align=right><?lsmb qty.${loop_count} ?></td>
-	  <td><?lsmb unit.${loop_count} ?></td>
+          <td><?lsmb number.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
+          <td align=right><?lsmb qty.${loop_count} ?></td>
+          <td><?lsmb unit.${loop_count} ?></td>
            <td><?lsmb bin.${loop_count} ?></td>
-	  <td><?lsmb serialnumber.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+          <td><?lsmb serialnumber.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
-	<tr>
-	  <td colspan=7><hr noshade></td>
-	</tr>
+        <tr>
+          <td colspan=7><hr noshade></td>
+        </tr>
 
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <?lsmb IF notes ?>
           <td><?lsmb  FOREACH P IN notes.split('\n\n') ?>

--- a/templates/demo_with_images/ap_transaction.html
+++ b/templates/demo_with_images/ap_transaction.html
@@ -9,9 +9,8 @@
 <table width="100%">
 
   <?lsmb INCLUDE letterhead ?>
-  
+
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -21,24 +20,23 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
         <tr valign=top>
           <td><?lsmb name ?>
           <br><?lsmb address1 ?>
-	  <?lsmb IF address2 ?>
+          <?lsmb IF address2 ?>
           <br><?lsmb address2 ?>
-	  <?lsmb END ?>
+          <?lsmb END ?>
           <br><?lsmb city ?>
-	  <?lsmb IF state ?>
-	  , <?lsmb state ?>
-	  <?lsmb END ?>
-	  <?lsmb zipcode ?>
-	  <?lsmb IF country ?>
-	  <br><?lsmb country ?>
-	  <?lsmb END ?>
+          <?lsmb IF state ?>
+          , <?lsmb state ?>
+          <?lsmb END ?>
+          <?lsmb zipcode ?>
+          <?lsmb IF country ?>
+          <br><?lsmb country ?>
+          <?lsmb END ?>
           <br>
 
           <?lsmb IF contact ?>
@@ -62,107 +60,104 @@
           <p><?lsmb text('Taxnumber: [_1]', vendortaxnumber) ?>
           <?lsmb END ?>
           </td>
-   
-	  <td align=right>
-	    <table>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Invoice #') ?></th>
-		<td><?lsmb invnumber ?></td>
-	      </tr>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Date') ?></th>
-		<td><?lsmb invdate ?></td>
-	      </tr>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Due') ?></th>
-		<td><?lsmb duedate ?></td>
-	      </tr>
-	      <?lsmb IF ponumber ?>
+
+          <td align=right>
+            <table>
+              <tr>
+                <th align=left nowrap><?lsmb text('Invoice #') ?></th>
+                <td><?lsmb invnumber ?></td>
+              </tr>
+              <tr>
+                <th align=left nowrap><?lsmb text('Date') ?></th>
+                <td><?lsmb invdate ?></td>
+              </tr>
+              <tr>
+                <th align=left nowrap><?lsmb text('Due') ?></th>
+                <td><?lsmb duedate ?></td>
+              </tr>
+              <?lsmb IF ponumber ?>
               <tr>
                 <th align=left><?lsmb text('PO #') ?></th>
-		<td><?lsmb ponumber ?>&nbsp;</td>
-	      </tr>
-	      <?lsmb END ?>
-	      <?lsmb IF ordnumber ?>
-	      <tr>
-		<th align=left><?lsmb text('Order #') ?></th>
-		<td><?lsmb ordnumber ?>&nbsp;</td>
-	      </tr>
-	      <?lsmb END ?>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Employee') ?></th>
-		<td><?lsmb employee ?>&nbsp;</td>
-	      </tr>
-	    </table>
-	  </td>
+                <td><?lsmb ponumber ?>&nbsp;</td>
+              </tr>
+              <?lsmb END ?>
+              <?lsmb IF ordnumber ?>
+              <tr>
+                <th align=left><?lsmb text('Order #') ?></th>
+                <td><?lsmb ordnumber ?>&nbsp;</td>
+              </tr>
+              <?lsmb END ?>
+              <tr>
+                <th align=left nowrap><?lsmb text('Employee') ?></th>
+                <td><?lsmb employee ?>&nbsp;</td>
+              </tr>
+            </table>
+          </td>
         </tr>
       </table>
     </td>
   </tr>
 
   <tr height=5></tr>
-  
+
   <tr>
-    <td>&nbsp;</td>
-  
+
     <td>
       <table>
-	<?lsmb FOREACH account ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr valign=top>
-	  <td><?lsmb accno.${loop_count} ?></td>
-	  <td><?lsmb account.${loop_count} ?></td>
-	  <td width=10> </td>
-	  <td align=right><?lsmb amount.${loop_count} ?></td>
-	  <td width=10> </td>
-	  <td><?lsmb description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td width=10> </td>
-	  <td><?lsmb projectnumber.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+        <?lsmb FOREACH account ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr valign=top>
+          <td><?lsmb accno.${loop_count} ?></td>
+          <td><?lsmb account.${loop_count} ?></td>
+          <td width=10> </td>
+          <td align=right><?lsmb amount.${loop_count} ?></td>
+          <td width=10> </td>
+          <td><?lsmb description.${loop_count}.replace("\n","<br />") ?></td>
+          <td width=10> </td>
+          <td><?lsmb projectnumber.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
-	<tr>
-	  <?lsmb IF taxincluded ?>
-	  <th colspan=2 align=right><?lsmb text('Total') ?></th>
-	  <td width=10> </td>
-	  <td align=right><?lsmb invtotal ?></td>
-	  <?lsmb ELSE ?>
-	  <th colspan=2 align=right><?lsmb text('Subtotal') ?></th>
-	  <td width=10> </td>
-	  <td align=right><?lsmb subtotal ?></td>
-	  <?lsmb END ?>
-	</tr>
+        <tr>
+          <?lsmb IF taxincluded ?>
+          <th colspan=2 align=right><?lsmb text('Total') ?></th>
+          <td width=10> </td>
+          <td align=right><?lsmb invtotal ?></td>
+          <?lsmb ELSE ?>
+          <th colspan=2 align=right><?lsmb text('Subtotal') ?></th>
+          <td width=10> </td>
+          <td align=right><?lsmb subtotal ?></td>
+          <?lsmb END ?>
+        </tr>
 
-	<?lsmb FOREACH tax ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr>
-	  <th colspan=2 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
-	  <td width=10> </td>
-	  <td align=right><?lsmb tax.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
-	
-	<?lsmb IF NOT taxincluded ?>
-	<tr>
-	  <th colspan=2 align=right><?lsmb text('Total') ?></th>
-	  <td width=10> </td>
-	  <td align=right><?lsmb invtotal ?></td>
-	</tr>
-	<?lsmb END ?>
+        <?lsmb FOREACH tax ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr>
+          <th colspan=2 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+          <td width=10> </td>
+          <td align=right><?lsmb tax.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
+
+        <?lsmb IF NOT taxincluded ?>
+        <tr>
+          <th colspan=2 align=right><?lsmb text('Total') ?></th>
+          <td width=10> </td>
+          <td align=right><?lsmb invtotal ?></td>
+        </tr>
+        <?lsmb END ?>
       </table>
     </td>
   </tr>
-  
+
   <tr>
-    <td>&nbsp;</td>
-    
+
     <td>
       <?lsmb text_amount ?> ***** <?lsmb decimal ?>/100 <?lsmb currency ?>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
           <td><?lsmb  FOREACH P IN notes.split('\n\n') ?>
                     <p><?lsmb P ?></p>
@@ -171,7 +166,6 @@
 
   <?lsmb IF paid_1 ?>
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table>
@@ -185,32 +179,32 @@
           </td>
         </tr>
 
-	<tr>
-	  <td>
-	    <table>
-	      <tr>
-		<th><?lsmb text('Date') ?></th>
-		<th>&nbsp;</th>
-		<th><?lsmb text('Source') ?></th>
-		<th><?lsmb text('Memo') ?></th>
-		<th><?lsmb text('Amount') ?></th>
-	      </tr>
+        <tr>
+          <td>
+            <table>
+              <tr>
+                <th><?lsmb text('Date') ?></th>
+                <th>&nbsp;</th>
+                <th><?lsmb text('Source') ?></th>
+                <th><?lsmb text('Memo') ?></th>
+                <th><?lsmb text('Amount') ?></th>
+              </tr>
   <?lsmb END ?>
 
         <?lsmb FOREACH payment ?>
         <?lsmb loop_count = loop.count - 1 ?>
-	      <tr>
-		<td><?lsmb paymentdate.${loop_count} ?></td>
-		<td><?lsmb paymentaccount.${loop_count} ?></td>
-		<td><?lsmb paymentsource.${loop_count} ?></td>
-		<td><?lsmb paymentmemo.${loop_count} ?></td>
-		<td align=right><?lsmb payment.${loop_count} ?></td>
-	      </tr>
+              <tr>
+                <td><?lsmb paymentdate.${loop_count} ?></td>
+                <td><?lsmb paymentaccount.${loop_count} ?></td>
+                <td><?lsmb paymentsource.${loop_count} ?></td>
+                <td><?lsmb paymentmemo.${loop_count} ?></td>
+                <td align=right><?lsmb payment.${loop_count} ?></td>
+              </tr>
         <?lsmb END ?>
 
   <?lsmb IF paid_1 ?>
-	    </table>
-	  </td>
+            </table>
+          </td>
         </tr>
       </table>
     </td>
@@ -221,7 +215,6 @@
 
   <?lsmb IF taxincluded ?>
   <tr>
-    <td>&nbsp;</td>
   </tr>
 
   <tr>

--- a/templates/demo_with_images/ar_transaction.html
+++ b/templates/demo_with_images/ar_transaction.html
@@ -11,7 +11,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -20,24 +19,23 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
         <tr valign=top>
           <td><?lsmb name ?>
           <br><?lsmb address1 ?>
-	  <?lsmb IF address2 ?>
+          <?lsmb IF address2 ?>
           <br><?lsmb address2 ?>
-	  <?lsmb END ?>
+          <?lsmb END ?>
           <br><?lsmb city ?>
-	  <?lsmb IF state ?>
-	  , <?lsmb state ?>
-	  <?lsmb END ?>
-	  <?lsmb zipcode ?>
-	  <?lsmb IF country ?>
-	  <br><?lsmb country ?>
-	  <?lsmb END ?>
+          <?lsmb IF state ?>
+          , <?lsmb state ?>
+          <?lsmb END ?>
+          <?lsmb zipcode ?>
+          <?lsmb IF country ?>
+          <br><?lsmb country ?>
+          <?lsmb END ?>
           <br>
 
           <?lsmb IF contact ?>
@@ -61,99 +59,97 @@
           <br><?lsmb text('Taxnumber:') _ ' ' _ customertaxnumber ?>
           <?lsmb END ?>
           </td>
-   
-	  <td align=right>
-	    <table>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Invoice #') ?></th>
-		<td><?lsmb invnumber ?></td>
-	      </tr>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Date') ?></th>
-		<td><?lsmb invdate ?></td>
-	      </tr>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Due') ?></th>
-		<td><?lsmb duedate ?></td>
-	      </tr>
-	      <?lsmb IF ponumber ?>
+
+          <td align=right>
+            <table>
+              <tr>
+                <th align=left nowrap><?lsmb text('Invoice #') ?></th>
+                <td><?lsmb invnumber ?></td>
+              </tr>
+              <tr>
+                <th align=left nowrap><?lsmb text('Date') ?></th>
+                <td><?lsmb invdate ?></td>
+              </tr>
+              <tr>
+                <th align=left nowrap><?lsmb text('Due') ?></th>
+                <td><?lsmb duedate ?></td>
+              </tr>
+              <?lsmb IF ponumber ?>
               <tr>
                 <th align=left><?lsmb text('PO #') ?></th>
-		<td><?lsmb ponumber ?>&nbsp;</td>
-	      </tr>
-	      <?lsmb END ?>
-	      <?lsmb IF ordnumber ?>
-	      <tr>
-		<th align=left><?lsmb text('Order #') ?></th>
-		<td><?lsmb ordnumber ?>&nbsp;</td>
-	      </tr>
-	      <?lsmb END ?>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Salesperson') ?></th>
-		<td><?lsmb employee ?>&nbsp;</td>
-	      </tr>
-	    </table>
-	  </td>
+                <td><?lsmb ponumber ?>&nbsp;</td>
+              </tr>
+              <?lsmb END ?>
+              <?lsmb IF ordnumber ?>
+              <tr>
+                <th align=left><?lsmb text('Order #') ?></th>
+                <td><?lsmb ordnumber ?>&nbsp;</td>
+              </tr>
+              <?lsmb END ?>
+              <tr>
+                <th align=left nowrap><?lsmb text('Salesperson') ?></th>
+                <td><?lsmb employee ?>&nbsp;</td>
+              </tr>
+            </table>
+          </td>
         </tr>
       </table>
     </td>
   </tr>
 
   <tr height=5></tr>
-  
+
   <tr>
-    <td>&nbsp;</td>
-  
+
     <td>
       <table>
-	<?lsmb FOREACH account ?>
+        <?lsmb FOREACH account ?>
         <?lsmb loop_count = loop.count - 1 ?>
-	<tr valign=top>
-	  <td><?lsmb accno.${loop_count} ?></td>
-	  <td><?lsmb account.${loop_count} ?></td>
-	  <td width=10>&nbsp;</td>
-	  <td align=right><?lsmb amount.${loop_count} ?></td>
-	  <td width=10>&nbsp;</td>
-	  <td><?lsmb description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td width=10>&nbsp;</td>
-	  <td><?lsmb projectnumber.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+        <tr valign=top>
+          <td><?lsmb accno.${loop_count} ?></td>
+          <td><?lsmb account.${loop_count} ?></td>
+          <td width=10>&nbsp;</td>
+          <td align=right><?lsmb amount.${loop_count} ?></td>
+          <td width=10>&nbsp;</td>
+          <td><?lsmb description.${loop_count}.replace("\n","<br />") ?></td>
+          <td width=10>&nbsp;</td>
+          <td><?lsmb projectnumber.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
-	<tr>
-	  <?lsmb IF taxincluded ?>
-	  <th colspan=2 align=right><?lsmb text('Total') ?></th>
-	  <td width=10>&nbsp;</td>
-	  <td align=right><?lsmb invtotal ?></td>
-	  <?lsmb ELSE ?>
-	  <th colspan=2 align=right><?lsmb text('Subtotal') ?></th>
-	  <td width=10>&nbsp;</td>
-	  <td align=right><?lsmb subtotal ?></td>
-	  <?lsmb END ?>
-	</tr>
+        <tr>
+          <?lsmb IF taxincluded ?>
+          <th colspan=2 align=right><?lsmb text('Total') ?></th>
+          <td width=10>&nbsp;</td>
+          <td align=right><?lsmb invtotal ?></td>
+          <?lsmb ELSE ?>
+          <th colspan=2 align=right><?lsmb text('Subtotal') ?></th>
+          <td width=10>&nbsp;</td>
+          <td align=right><?lsmb subtotal ?></td>
+          <?lsmb END ?>
+        </tr>
 
-	<?lsmb FOREACH tax ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr>
-	  <th colspan=2 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
-	  <td width=10>&nbsp;</td>
-	  <td align=right><?lsmb tax.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
-	
-	<?lsmb IF NOT taxincluded ?>
-	<tr>
-	  <th colspan=2 align=right><?lsmb text('Total') ?></th>
-	  <td width=10>&nbsp;</td>
-	  <td align=right><?lsmb invtotal ?></td>
-	</tr>
-	<?lsmb END ?>
+        <?lsmb FOREACH tax ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr>
+          <th colspan=2 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+          <td width=10>&nbsp;</td>
+          <td align=right><?lsmb tax.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
+
+        <?lsmb IF NOT taxincluded ?>
+        <tr>
+          <th colspan=2 align=right><?lsmb text('Total') ?></th>
+          <td width=10>&nbsp;</td>
+          <td align=right><?lsmb invtotal ?></td>
+        </tr>
+        <?lsmb END ?>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <?lsmb text_amount ?> ***** <?lsmb decimal ?>/100 <?lsmb currency ?>
@@ -161,7 +157,6 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
           <td><?lsmb  FOREACH P IN notes.split('\n\n') ?>
                     <p><?lsmb P ?></p>
@@ -170,7 +165,6 @@
 
   <?lsmb IF paid_1 ?>
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table>
@@ -184,30 +178,30 @@
           </td>
         </tr>
 
-	<tr>
-	  <td>
-	    <table>
-	      <tr>
-		<th><?lsmb text('Date') ?></th>
-		<th>&nbsp;</th>
-		<th><?lsmb text('Source') ?></th>
-		<th><?lsmb text('Amount') ?></th>
-	      </tr>
+        <tr>
+          <td>
+            <table>
+              <tr>
+                <th><?lsmb text('Date') ?></th>
+                <th>&nbsp;</th>
+                <th><?lsmb text('Source') ?></th>
+                <th><?lsmb text('Amount') ?></th>
+              </tr>
   <?lsmb END ?>
 
         <?lsmb FOREACH payment ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	      <tr>
-		<td><?lsmb paymentdate.${loop_count} ?></td>
-		<td><?lsmb paymentaccount.${loop_count} ?></td>
-		<td><?lsmb paymentsource.${loop_count} ?></td>
-		<td align=right><?lsmb payment.${loop_count} ?></td>
-	      </tr>
+        <?lsmb loop_count = loop.count - 1 ?>
+              <tr>
+                <td><?lsmb paymentdate.${loop_count} ?></td>
+                <td><?lsmb paymentaccount.${loop_count} ?></td>
+                <td><?lsmb paymentsource.${loop_count} ?></td>
+                <td align=right><?lsmb payment.${loop_count} ?></td>
+              </tr>
         <?lsmb END ?>
 
   <?lsmb IF paid_1 ?>
-	    </table>
-	  </td>
+            </table>
+          </td>
         </tr>
       </table>
     </td>
@@ -219,7 +213,6 @@
   <?lsmb FOREACH tax ?>
   <?lsmb loop_count = loop.count - 1 ?>
   <tr>
-    <td>&nbsp;</td>
 
     <th colspan=9 align=left><font size=-2><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> <?lsmb text('Registration') _ ' ' _  taxnumber.${loop_count} ?></th>
   </tr>
@@ -227,7 +220,6 @@
 
   <?lsmb IF taxincluded ?>
   <tr>
-    <td>&nbsp;</td>
   </tr>
 
   <tr>

--- a/templates/demo_with_images/bin_list.html
+++ b/templates/demo_with_images/bin_list.html
@@ -11,7 +11,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -20,79 +19,78 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
-	<tr bgcolor=000000>
-	  <th align=left width="50%"><font color=ffffff><?lsmb text('From') ?>
+        <tr bgcolor=000000>
+          <th align=left width="50%"><font color=ffffff><?lsmb text('From') ?>
           </th>
-	  <th align=left width="50%"><font color=ffffff><?lsmb text('Ship To') ?>
+          <th align=left width="50%"><font color=ffffff><?lsmb text('Ship To') ?>
           </th>
-	</tr>
+        </tr>
 
-	<tr valign=top>
-	  <td><?lsmb name ?>
-	  <br><?lsmb address1 ?>
-	  <?lsmb IF address2 ?>
+        <tr valign=top>
+          <td><?lsmb name ?>
+          <br><?lsmb address1 ?>
+          <?lsmb IF address2 ?>
           <br><?lsmb address2 ?>
           <?lsmb END ?>
-	  <br><?lsmb city ?>
-	  <?lsmb IF state ?>
-	  , <?lsmb state ?>
-	  <?lsmb END ?>
-	  <?lsmb zipcode ?>
-	  <?lsmb IF country ?>
+          <br><?lsmb city ?>
+          <?lsmb IF state ?>
+          , <?lsmb state ?>
+          <?lsmb END ?>
+          <?lsmb zipcode ?>
+          <?lsmb IF country ?>
           <?lsmb country ?>
           <?lsmb END ?>
-	  <br>
+          <br>
 
-	  <?lsmb IF contact ?>
-	  <br><?lsmb text('Attn: [_1]', contact) ?>
-	  <?lsmb END ?>
+          <?lsmb IF contact ?>
+          <br><?lsmb text('Attn: [_1]', contact) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF vendorphone ?>
-	  <br><?lsmb text('Tel: [_1]', vendorphone) ?>
-	  <?lsmb END ?>
+          <?lsmb IF vendorphone ?>
+          <br><?lsmb text('Tel: [_1]', vendorphone) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF vendorfax ?>
-	  <br><?lsmb text('Fax: [_1]', vendorfax) ?>
-	  <?lsmb END ?>
+          <?lsmb IF vendorfax ?>
+          <br><?lsmb text('Fax: [_1]', vendorfax) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF email ?>
-	  <br><?lsmb email ?>
-	  <?lsmb END ?>
+          <?lsmb IF email ?>
+          <br><?lsmb email ?>
+          <?lsmb END ?>
 
-	  </td>
+          </td>
 
-	  <td><?lsmb shiptoname ?>
-	  <br><?lsmb shiptoaddress1 ?>
-	  <?lsmb IF shiptoaddress2 ?>
+          <td><?lsmb shiptoname ?>
+          <br><?lsmb shiptoaddress1 ?>
+          <?lsmb IF shiptoaddress2 ?>
           <br><?lsmb shiptoaddress2 ?>
           <?lsmb END ?>
-	  <br><?lsmb shiptocity ?>
-	  <?lsmb IF shiptostate ?>
-	  , <?lsmb shiptostate ?>
-	  <?lsmb END ?>
-	  <?lsmb shiptozipcode ?>
-	  <?lsmb IF shiptocountry ?>
+          <br><?lsmb shiptocity ?>
+          <?lsmb IF shiptostate ?>
+          , <?lsmb shiptostate ?>
+          <?lsmb END ?>
+          <?lsmb shiptozipcode ?>
+          <?lsmb IF shiptocountry ?>
           <?lsmb shiptocountry ?>
           <?lsmb END ?>
 
-	  <br>
-	  <?lsmb IF shiptocontact ?>
-	  <br><?lsmb text('Attn: [_1]', shiptocontact) ?>
-	  <?lsmb END ?>
+          <br>
+          <?lsmb IF shiptocontact ?>
+          <br><?lsmb text('Attn: [_1]', shiptocontact) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF shiptophone ?>
-	  <br><?lsmb text('Tel: [_1]', shiptophone) ?>
-	  <?lsmb END ?>
+          <?lsmb IF shiptophone ?>
+          <br><?lsmb text('Tel: [_1]', shiptophone) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF shiptofax ?>
-	  <br><?lsmb text('Fax: [_1]', shiptofax) ?>
-	  <?lsmb END ?>
-	  </td>
-	</tr>
+          <?lsmb IF shiptofax ?>
+          <br><?lsmb text('Fax: [_1]', shiptofax) ?>
+          <?lsmb END ?>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -100,81 +98,78 @@
   <tr height=5></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% border=1>
-	<tr>
-	  <th width=17% align=left nowrap><?lsmb text('Order #') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Date') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Contact') ?></th>
-	  <?lsmb IF warehouse ?>
-	  <th width=17% align=left nowrap><?lsmb text('Warehouse') ?></th>
-	  <?lsmb END ?>
-	  <th width=17% align=left><?lsmb text('Shipping Point') ?></th>
-	  <th width=15% align=left><?lsmb text('Ship via') ?></th>
-	</tr>
+        <tr>
+          <th width=17% align=left nowrap><?lsmb text('Order #') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Date') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Contact') ?></th>
+          <?lsmb IF warehouse ?>
+          <th width=17% align=left nowrap><?lsmb text('Warehouse') ?></th>
+          <?lsmb END ?>
+          <th width=17% align=left><?lsmb text('Shipping Point') ?></th>
+          <th width=15% align=left><?lsmb text('Ship via') ?></th>
+        </tr>
 
-	<tr>
-	  <td><?lsmb ordnumber ?>&nbsp;</td>
+        <tr>
+          <td><?lsmb ordnumber ?>&nbsp;</td>
 
-	  <?lsmb IF shippingdate ?>
-	  <td><?lsmb shippingdate ?></td>
-	  <?lsmb ELSE ?>
-	  <td><?lsmb orddate ?></td>
-	  <?lsmb END ?>
+          <?lsmb IF shippingdate ?>
+          <td><?lsmb shippingdate ?></td>
+          <?lsmb ELSE ?>
+          <td><?lsmb orddate ?></td>
+          <?lsmb END ?>
 
-	  <td><?lsmb employee ?>&nbsp;</td>
+          <td><?lsmb employee ?>&nbsp;</td>
 
-	  <?lsmb IF warehouse ?>
-	  <td><?lsmb warehouse ?></td>
-	  <?lsmb END ?>
+          <?lsmb IF warehouse ?>
+          <td><?lsmb warehouse ?></td>
+          <?lsmb END ?>
 
-	  <td><?lsmb shippingpoint ?>&nbsp;</td>
-	  <td><?lsmb shipvia ?>&nbsp;</td>
-	</tr>
+          <td><?lsmb shippingpoint ?>&nbsp;</td>
+          <td><?lsmb shipvia ?>&nbsp;</td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr bgcolor=000000>
-	  <th align=left><font color=ffffff><?lsmb text('Item') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
-	  <th><font color=ffffff><?lsmb text('Serialnumber') ?></th>
-	  <th>&nbsp;</th>
-	  <th><font color=ffffff><?lsmb text('Qty') ?></th>
-	  <th><font color=ffffff><?lsmb text('Recd') ?></th>
-	  <th>&nbsp;</th>
-	  <th><font color=ffffff><?lsmb text('Bin') ?></th>
-	</tr>
+        <tr bgcolor=000000>
+          <th align=left><font color=ffffff><?lsmb text('Item') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
+          <th><font color=ffffff><?lsmb text('Serialnumber') ?></th>
+          <th>&nbsp;</th>
+          <th><font color=ffffff><?lsmb text('Qty') ?></th>
+          <th><font color=ffffff><?lsmb text('Recd') ?></th>
+          <th>&nbsp;</th>
+          <th><font color=ffffff><?lsmb text('Bin') ?></th>
+        </tr>
 
-	<?lsmb FOREACH number ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr valign=top>
-	  <td><?lsmb runningnumber.${loop_count} ?></td>
-	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td><?lsmb serialnumber.${loop_count} ?></td>
-	  <td><?lsmb deliverydate.${loop_count} ?></td>
-	  <td align=right><?lsmb qty.${loop_count} ?></td>
-	  <td align=right><?lsmb ship.${loop_count} ?></td>
-	  <td><?lsmb unit.${loop_count} ?></td>
-	  <td><?lsmb bin.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+        <?lsmb FOREACH number ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr valign=top>
+          <td><?lsmb runningnumber.${loop_count} ?></td>
+          <td><?lsmb number.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
+          <td><?lsmb serialnumber.${loop_count} ?></td>
+          <td><?lsmb deliverydate.${loop_count} ?></td>
+          <td align=right><?lsmb qty.${loop_count} ?></td>
+          <td align=right><?lsmb ship.${loop_count} ?></td>
+          <td><?lsmb unit.${loop_count} ?></td>
+          <td><?lsmb bin.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td><hr noshade></td>
   </tr>

--- a/templates/demo_with_images/invoice.html
+++ b/templates/demo_with_images/invoice.html
@@ -8,9 +8,8 @@
 <table width="100%">
 
   <?lsmb INCLUDE letterhead ?>
-  
+
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -21,7 +20,6 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
@@ -103,10 +101,9 @@
   </tr>
 
   <tr height=5></tr>
-  
+
   <tr>
-    <td>&nbsp;</td>
-  
+
     <td>
       <table width=100% border=1>
         <tr>
@@ -133,8 +130,7 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
-  
+
     <td>
       <table width="100%">
         <tr bgcolor=000000>
@@ -212,7 +208,6 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
@@ -224,7 +219,7 @@
           <?lsmb END ?>
 
           <td><?lsmb text_amount ?> ***** <?lsmb decimal ?>/100</td>
-          
+
           <td align=right nowrap>
           <?lsmb text('All prices in [_1]', currency) ?>
           </td>
@@ -235,7 +230,6 @@
 
   <?lsmb IF paymentdate.0 ?>
   <tr>
-    <td>&nbsp;</td>
 
     <td colspan=9>
       <table width="60%">
@@ -275,7 +269,6 @@
   <tr height=10></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <th>
     <?lsmb text('Thank you for your valued business!') ?>
@@ -283,7 +276,6 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
@@ -305,7 +297,6 @@
   <?lsmb FOREACH tax ?>
   <?lsmb loop_count = loop.count - 1 ?>
   <tr>
-    <td>&nbsp;</td>
 
     <th colspan=9 align=left><font size=-2><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> <?lsmb text('Registration [_1]', taxnumber.${loop_count}) ?></th>
   </tr>
@@ -313,7 +304,6 @@
 
   <?lsmb IF taxincluded ?>
   <tr>
-    <td>&nbsp;</td>
   </tr>
 
   <tr>

--- a/templates/demo_with_images/letterhead.html
+++ b/templates/demo_with_images/letterhead.html
@@ -1,5 +1,4 @@
   <tr>
-    <td width=10>&nbsp;</td>
 
     <td>
       <table width="100%">
@@ -11,7 +10,7 @@
             </h4>
           </td>
           <!-- Commenting out the image tag for now.  In general, folks can
-               customize this to their servers, but if the server is behind a 
+               customize this to their servers, but if the server is behind a
                firewall, then this won't work.  Recommend that if people do this,
                they hardwire in a link to a publically accessible image. - CT -->
           <th><!-- <img src=<?lsmb images ?>/logo.png border=0 height=58> --></th>
@@ -26,7 +25,7 @@
 
         <tr>
           <td colspan=3>
-	    <hr noshade>
+            <hr noshade>
           </td>
         </tr>
       </table>

--- a/templates/demo_with_images/packing_list.html
+++ b/templates/demo_with_images/packing_list.html
@@ -11,7 +11,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -20,49 +19,48 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
-	<tr bgcolor=000000>
-	  <th width=50% align=left><font color=ffffff>
+        <tr bgcolor=000000>
+          <th width=50% align=left><font color=ffffff>
                <?lsmb text('Ship To:') ?>
           </th>
-	  <th width="50%">&nbsp;</th>
-	</tr>
+          <th width="50%">&nbsp;</th>
+        </tr>
 
-	<tr valign=top>
-	  <td><?lsmb shiptoname ?>
-	  <br><?lsmb shiptoaddress1 ?>
-	  <?lsmb IF shiptoaddress2 ?>
-	  <br><?lsmb shiptoaddress2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb shiptocity ?>
-	  <?lsmb IF shiptostate ?>
-	  , <?lsmb shiptostate ?>
-	  <?lsmb END ?>
-	  <?lsmb shiptozipcode ?>
-	  <?lsmb IF shiptocountry ?>
-	  <br><?lsmb shiptocountry ?>
-	  <?lsmb END ?>
-	  </td>
+        <tr valign=top>
+          <td><?lsmb shiptoname ?>
+          <br><?lsmb shiptoaddress1 ?>
+          <?lsmb IF shiptoaddress2 ?>
+          <br><?lsmb shiptoaddress2 ?>
+          <?lsmb END ?>
+          <br><?lsmb shiptocity ?>
+          <?lsmb IF shiptostate ?>
+          , <?lsmb shiptostate ?>
+          <?lsmb END ?>
+          <?lsmb shiptozipcode ?>
+          <?lsmb IF shiptocountry ?>
+          <br><?lsmb shiptocountry ?>
+          <?lsmb END ?>
+          </td>
 
-	  <td>
-	  <?lsmb IF shiptocontact ?>
-	  <br><?lsmb text('Attn: [_1]', shiptocontact) ?>
-	  <?lsmb END ?>
+          <td>
+          <?lsmb IF shiptocontact ?>
+          <br><?lsmb text('Attn: [_1]', shiptocontact) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF shiptophone ?>
-	  <br><?lsmb text('Tel: [_1]', shiptophone) ?>
-	  <?lsmb END ?>
+          <?lsmb IF shiptophone ?>
+          <br><?lsmb text('Tel: [_1]', shiptophone) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF shiptofax ?>
-	  <br><?lsmb text('Fax: [_1]', shiptofax) ?>
-	  <?lsmb END ?>
+          <?lsmb IF shiptofax ?>
+          <br><?lsmb text('Fax: [_1]', shiptofax) ?>
+          <?lsmb END ?>
 
-	  <?lsmb shiptoemail ?>
-	  </td>
-	</tr>
+          <?lsmb shiptoemail ?>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -70,116 +68,111 @@
   <tr height=5></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% border=1>
-	<tr>
-	  <th width=17% align=left><?lsmb text('Invoice #') ?></th>
-	  <th width=17% align=left><?lsmb text('Order #') ?></th>
-	  <th width=17% align=left><?lsmb text('Date') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Contact') ?></th>
-	  <?lsmb IF warehouse ?>
-	  <th width=17% align=left><?lsmb text('Warehouse') ?></th>
-	  <?lsmb END ?>
-	  <th width=17% align=left><?lsmb text('Shipping Point') ?></th>
-	  <th width=15% align=left><?lsmb text('Ship via') ?></th>
-	</tr>
+        <tr>
+          <th width=17% align=left><?lsmb text('Invoice #') ?></th>
+          <th width=17% align=left><?lsmb text('Order #') ?></th>
+          <th width=17% align=left><?lsmb text('Date') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Contact') ?></th>
+          <?lsmb IF warehouse ?>
+          <th width=17% align=left><?lsmb text('Warehouse') ?></th>
+          <?lsmb END ?>
+          <th width=17% align=left><?lsmb text('Shipping Point') ?></th>
+          <th width=15% align=left><?lsmb text('Ship via') ?></th>
+        </tr>
 
         <tr>
-	  <td><?lsmb invnumber ?>&nbsp;</td>
-	  <td><?lsmb ordnumber ?>&nbsp;</td>
+          <td><?lsmb invnumber ?>&nbsp;</td>
+          <td><?lsmb ordnumber ?>&nbsp;</td>
 
-	  <?lsmb IF shippingdate ?>
-	  <td><?lsmb shippingdate ?></td>
-	  <?lsmb ELSE ?>
-	  <td><?lsmb transdate ?></td>
-	  <?lsmb END ?>
+          <?lsmb IF shippingdate ?>
+          <td><?lsmb shippingdate ?></td>
+          <?lsmb ELSE ?>
+          <td><?lsmb transdate ?></td>
+          <?lsmb END ?>
 
           <td><?lsmb employee ?>&nbsp;</td>
 
-	  <?lsmb IF warehouse ?>
-	  <td><?lsmb warehouse ?>&nbsp;</td>
-	  <?lsmb END ?>
+          <?lsmb IF warehouse ?>
+          <td><?lsmb warehouse ?>&nbsp;</td>
+          <?lsmb END ?>
 
-	  <td><?lsmb shippingpoint ?>&nbsp;</td>
-	  <td><?lsmb shipvia ?>&nbsp;</td>
-	</tr>
+          <td><?lsmb shippingpoint ?>&nbsp;</td>
+          <td><?lsmb shipvia ?>&nbsp;</td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr bgcolor=000000>
-	  <th align=left><font color=ffffff><?lsmb text('Item') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Serial #') ?></th>
-	  <th>&nbsp;</th>
-	  <th><font color=ffffff><?lsmb text('Qty') ?></th>
-	  <th><font color=ffffff><?lsmb text('Ship') ?></th>
-	  <th>&nbsp;</th>
-	</tr>
+        <tr bgcolor=000000>
+          <th align=left><font color=ffffff><?lsmb text('Item') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Serial #') ?></th>
+          <th>&nbsp;</th>
+          <th><font color=ffffff><?lsmb text('Qty') ?></th>
+          <th><font color=ffffff><?lsmb text('Ship') ?></th>
+          <th>&nbsp;</th>
+        </tr>
 
-	<?lsmb FOREACH number ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr valign=top>
-	  <td><?lsmb runningnumber.${loop_count} ?></td>
-	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td><?lsmb serialnumber.${loop_count} ?></td>
-	  <td><?lsmb deliverydate.${loop_count} ?></td>
-	  <td align=right><?lsmb qty.${loop_count} ?></td>
-	  <td align=right><?lsmb ship.${loop_count} ?></td>
-	  <td><?lsmb unit.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+        <?lsmb FOREACH number ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr valign=top>
+          <td><?lsmb runningnumber.${loop_count} ?></td>
+          <td><?lsmb number.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
+          <td><?lsmb serialnumber.${loop_count} ?></td>
+          <td><?lsmb deliverydate.${loop_count} ?></td>
+          <td align=right><?lsmb qty.${loop_count} ?></td>
+          <td align=right><?lsmb ship.${loop_count} ?></td>
+          <td><?lsmb unit.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td><hr noshade></td>
   </tr>
 
   <?lsmb IF notes ?>
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr valign=top>
-	  <td>Notes</td>
+        <tr valign=top>
+          <td>Notes</td>
           <td><?lsmb  FOREACH P IN notes.split('\n\n') ?>
                     <p><?lsmb P ?></p>
                <?lsmb END ?></td>
-	</tr>
+        </tr>
       </table>
     </td>
   </tr>
   <?lsmb END ?>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr valign=top>
-	  <td width="70%"><font size=-3>
-	  <?lsmb text('Items returned are subject to a 10% restocking charge. A return authorization must be obtained from [_1] before goods are returned. Returns must be shipped prepaid and properly insured. [_1] will not be responsible for damages during transit.', company) ?>
-	  </font>
-	  </td>
-	  <td width="30%">
-	  X <hr noshade>
-	  </td>
-	</tr>
+        <tr valign=top>
+          <td width="70%"><font size=-3>
+          <?lsmb text('Items returned are subject to a 10% restocking charge. A return authorization must be obtained from [_1] before goods are returned. Returns must be shipped prepaid and properly insured. [_1] will not be responsible for damages during transit.', company) ?>
+          </font>
+          </td>
+          <td width="30%">
+          X <hr noshade>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>

--- a/templates/demo_with_images/pick_list.html
+++ b/templates/demo_with_images/pick_list.html
@@ -11,7 +11,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -20,48 +19,47 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
         <tr bgcolor=000000>
-	  <th width=50% align=left><font color=ffffff><?lsmb text('Ship To:')
+          <th width=50% align=left><font color=ffffff><?lsmb text('Ship To:')
           ?></th>
-	  <th width="50%">&nbsp;</th>
-	</tr>
+          <th width="50%">&nbsp;</th>
+        </tr>
 
-	<tr valign=top>
-	  <td><?lsmb shiptoname ?>
-	  <br><?lsmb shiptoaddress1 ?>
-	  <?lsmb IF shiptoaddress2 ?>
-	  <br><?lsmb shiptoaddress2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb shiptocity ?>
-	  <?lsmb IF shiptostate ?>
-	  , <?lsmb shiptostate ?>
-	  <?lsmb END ?>
-	  <?lsmb shiptozipcode ?>
-	  <?lsmb IF shiptocountry ?>
-	  <br><?lsmb shiptocountry ?>
-	  <?lsmb END ?>
-	  </td>
+        <tr valign=top>
+          <td><?lsmb shiptoname ?>
+          <br><?lsmb shiptoaddress1 ?>
+          <?lsmb IF shiptoaddress2 ?>
+          <br><?lsmb shiptoaddress2 ?>
+          <?lsmb END ?>
+          <br><?lsmb shiptocity ?>
+          <?lsmb IF shiptostate ?>
+          , <?lsmb shiptostate ?>
+          <?lsmb END ?>
+          <?lsmb shiptozipcode ?>
+          <?lsmb IF shiptocountry ?>
+          <br><?lsmb shiptocountry ?>
+          <?lsmb END ?>
+          </td>
 
-	  <td>
-	  <?lsmb IF shiptocontact ?>
-	  <br><?lsmb text('Attn: [_1]', shiptocontact) ?>
-	  <?lsmb END ?>
+          <td>
+          <?lsmb IF shiptocontact ?>
+          <br><?lsmb text('Attn: [_1]', shiptocontact) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF shiptophone ?>
-	  <br><?lsmb text('Tel: [_1]', shiptophone) ?>
-	  <?lsmb END ?>
+          <?lsmb IF shiptophone ?>
+          <br><?lsmb text('Tel: [_1]', shiptophone) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF shiptofax ?>
-	  <br><?lsmb text('Fax: [_1]', shiptofax) ?>
-	  <?lsmb END ?>
+          <?lsmb IF shiptofax ?>
+          <br><?lsmb text('Fax: [_1]', shiptofax) ?>
+          <?lsmb END ?>
 
-	  <?lsmb shiptoemail ?>
-	  </td>
-	</tr>
+          <?lsmb shiptoemail ?>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -69,71 +67,68 @@
   <tr height=5></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% border=1>
         <tr>
-	  <th width=15% align=left><?lsmb text('Invoice #') ?></th>
-	  <th width=15% align=left><?lsmb text('Order #') ?></th>
-	  <th width=10% align=left><?lsmb text('Date') ?></th>
-	  <th width=15% align=left nowrap><?lsmb text('Contact') ?></th>
-	  <th width=15% align=left><?lsmb text('Warehouse') ?></th>
-	  <th width=10% align=left><?lsmb text('Shipping Point') ?></th>
-	  <th width=10% align=left><?lsmb text('Ship via') ?></th>
-	</tr>
+          <th width=15% align=left><?lsmb text('Invoice #') ?></th>
+          <th width=15% align=left><?lsmb text('Order #') ?></th>
+          <th width=10% align=left><?lsmb text('Date') ?></th>
+          <th width=15% align=left nowrap><?lsmb text('Contact') ?></th>
+          <th width=15% align=left><?lsmb text('Warehouse') ?></th>
+          <th width=10% align=left><?lsmb text('Shipping Point') ?></th>
+          <th width=10% align=left><?lsmb text('Ship via') ?></th>
+        </tr>
 
         <tr>
-	  <td><?lsmb invnumber ?>&nbsp;</td>
-	  <td><?lsmb ordnumber ?>&nbsp;</td>
+          <td><?lsmb invnumber ?>&nbsp;</td>
+          <td><?lsmb ordnumber ?>&nbsp;</td>
           <?lsmb IF shippingdate ?>
-	  <td><?lsmb shippingdate ?></td>
+          <td><?lsmb shippingdate ?></td>
           <?lsmb ELSE ?>
-	  <td><?lsmb transdate ?></td>
-	  <?lsmb END ?>
+          <td><?lsmb transdate ?></td>
+          <?lsmb END ?>
 
-	  <td><?lsmb employee ?>&nbsp;</td>
-	  <td><?lsmb warehouse ?>&nbsp;</td>
-	  <td><?lsmb shippingpoint ?>&nbsp;</td>
-	  <td><?lsmb shipvia ?>&nbsp;</td>
-	</tr>
+          <td><?lsmb employee ?>&nbsp;</td>
+          <td><?lsmb warehouse ?>&nbsp;</td>
+          <td><?lsmb shippingpoint ?>&nbsp;</td>
+          <td><?lsmb shipvia ?>&nbsp;</td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr bgcolor=000000>
-	  <th align=left><font color=ffffff><?lsmb text('Item') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
-	  <th><font color=ffffff><?lsmb text('Qty') ?></th>
-	  <th><font color=ffffff><?lsmb text('Ship') ?></th>
-	  <th>&nbsp;</th>
-	  <th><font color=ffffff><?lsmb text('Bin') ?></th>
-	</tr>
+        <tr bgcolor=000000>
+          <th align=left><font color=ffffff><?lsmb text('Item') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
+          <th><font color=ffffff><?lsmb text('Qty') ?></th>
+          <th><font color=ffffff><?lsmb text('Ship') ?></th>
+          <th>&nbsp;</th>
+          <th><font color=ffffff><?lsmb text('Bin') ?></th>
+        </tr>
 
         <?lsmb FOREACH number ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr valign=top>
-	  <td><?lsmb runningnumber.${loop_count} ?></td>
-	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td align=right><?lsmb qty.${loop_count} ?></td>
-	  <td align=right>[&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]</td>
-	  <td><?lsmb unit.${loop_count} ?></td>
-	  <td align=right><?lsmb bin.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr valign=top>
+          <td><?lsmb runningnumber.${loop_count} ?></td>
+          <td><?lsmb number.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
+          <td align=right><?lsmb qty.${loop_count} ?></td>
+          <td align=right>[&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]</td>
+          <td><?lsmb unit.${loop_count} ?></td>
+          <td align=right><?lsmb bin.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td><hr noshade></td>
   </tr>

--- a/templates/demo_with_images/product_receipt.html
+++ b/templates/demo_with_images/product_receipt.html
@@ -11,7 +11,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -21,7 +20,6 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
@@ -94,7 +92,6 @@
   <tr height=5></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% border=1>
@@ -118,7 +115,6 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
@@ -211,7 +207,6 @@
 
   <?lsmb IF notes ?>
   <tr>
-    <td>&nbsp;</td>
 
     <td>
     <table width="100%">
@@ -228,7 +223,6 @@
   <?lsmb END ?>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">

--- a/templates/demo_with_images/purchase_order.html
+++ b/templates/demo_with_images/purchase_order.html
@@ -11,7 +11,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -21,72 +20,71 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
-	<tr bgcolor=000000>
-	  <th align=left width="50%"><font color=ffffff><?lsmb text('To:') ?></th>
-	  <th align=left width="50%"><font color=ffffff><?lsmb text('Ship To:') ?></th>
-	</tr>
+        <tr bgcolor=000000>
+          <th align=left width="50%"><font color=ffffff><?lsmb text('To:') ?></th>
+          <th align=left width="50%"><font color=ffffff><?lsmb text('Ship To:') ?></th>
+        </tr>
 
-	<tr valign=top>
-	  <td><?lsmb name ?>
-	  <br><?lsmb address1 ?>
-	  <?lsmb IF address2 ?>
-	  <br><?lsmb address2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb city ?>
-	  <?lsmb IF state ?>
-	  , <?lsmb state ?>
-	  <?lsmb END ?>
-	  <?lsmb zipcode ?>
-	  <?lsmb IF country ?>
-	  <br><?lsmb country ?>
-	  <?lsmb END ?>
+        <tr valign=top>
+          <td><?lsmb name ?>
+          <br><?lsmb address1 ?>
+          <?lsmb IF address2 ?>
+          <br><?lsmb address2 ?>
+          <?lsmb END ?>
+          <br><?lsmb city ?>
+          <?lsmb IF state ?>
+          , <?lsmb state ?>
+          <?lsmb END ?>
+          <?lsmb zipcode ?>
+          <?lsmb IF country ?>
+          <br><?lsmb country ?>
+          <?lsmb END ?>
           <br>
 
-	  <?lsmb IF contact ?>
-	  <br><?lsmb text('Attn: [_1]', contact) ?>
-	  <?lsmb END ?>
+          <?lsmb IF contact ?>
+          <br><?lsmb text('Attn: [_1]', contact) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF vendorphone ?>
-	  <br><?lsmb text('Tel: [_1]', vendorphone) ?>
-	  <?lsmb END ?>
+          <?lsmb IF vendorphone ?>
+          <br><?lsmb text('Tel: [_1]', vendorphone) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF vendorfax ?>
-	  <br><?lsmb text('Fax: [_1]', vendorfax) ?>
-	  <?lsmb END ?>
-	  </td>
+          <?lsmb IF vendorfax ?>
+          <br><?lsmb text('Fax: [_1]', vendorfax) ?>
+          <?lsmb END ?>
+          </td>
 
-	  <td><?lsmb shiptoname ?>
-	  <br><?lsmb shiptoaddress1 ?>
-	  <?lsmb IF shiptoaddress2 ?>
-	  <br><?lsmb shiptoaddress2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb shiptocity ?>
-	  <?lsmb IF shiptostate ?>
-	  , <?lsmb shiptostate ?>
-	  <?lsmb END ?>
-	  <?lsmb shiptozipcode ?>
-	  <?lsmb IF shiptocountry ?>
-	  <br><?lsmb shiptocountry ?>
-	  <?lsmb END ?>
+          <td><?lsmb shiptoname ?>
+          <br><?lsmb shiptoaddress1 ?>
+          <?lsmb IF shiptoaddress2 ?>
+          <br><?lsmb shiptoaddress2 ?>
+          <?lsmb END ?>
+          <br><?lsmb shiptocity ?>
+          <?lsmb IF shiptostate ?>
+          , <?lsmb shiptostate ?>
+          <?lsmb END ?>
+          <?lsmb shiptozipcode ?>
+          <?lsmb IF shiptocountry ?>
+          <br><?lsmb shiptocountry ?>
+          <?lsmb END ?>
           <br>
 
-	  <?lsmb IF shiptocontact ?>
-	  <br><?lsmb text('Attn: [_1]', shiptocontact) ?>
-	  <?lsmb END ?>
+          <?lsmb IF shiptocontact ?>
+          <br><?lsmb text('Attn: [_1]', shiptocontact) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF shiptophone ?>
-	  <br><?lsmb text('Tel: [_1]', shiptophone) ?>
-	  <?lsmb END ?>
+          <?lsmb IF shiptophone ?>
+          <br><?lsmb text('Tel: [_1]', shiptophone) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF shiptofax ?>
-	  <br><?lsmb text('Fax: [_1]', shiptofax) ?>
-	  <?lsmb END ?>
-	  </td>
-	</tr>
+          <?lsmb IF shiptofax ?>
+          <br><?lsmb text('Fax: [_1]', shiptofax) ?>
+          <?lsmb END ?>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -94,27 +92,26 @@
   <tr height=5></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% border=1>
-	<tr>
-	  <th width=17% align=left><?lsmb text('Order #') ?></th>
-	  <th width=17% align=left><?lsmb text('Order Date') ?></th>
-	  <th width=17% align=left><?lsmb text('Required by') ?></th>
-	  <th width=17% align=left><?lsmb text('Contact') ?></th>
-	  <th width=17% align=left><?lsmb text('Shipping Point') ?></th>
-	  <th width=15% align=left><?lsmb text('Ship Via') ?></th>
-	</tr>
+        <tr>
+          <th width=17% align=left><?lsmb text('Order #') ?></th>
+          <th width=17% align=left><?lsmb text('Order Date') ?></th>
+          <th width=17% align=left><?lsmb text('Required by') ?></th>
+          <th width=17% align=left><?lsmb text('Contact') ?></th>
+          <th width=17% align=left><?lsmb text('Shipping Point') ?></th>
+          <th width=15% align=left><?lsmb text('Ship Via') ?></th>
+        </tr>
 
-	<tr>
-	  <td><?lsmb ordnumber ?></td>
-	  <td><?lsmb orddate ?></td>
-	  <td><?lsmb reqdate ?></td>
-	  <td><?lsmb employee ?></td>
-	  <td><?lsmb shippingpoint ?>&nbsp;</td>
-	  <td><?lsmb shipvia ?>&nbsp;</td>
-	</tr>
+        <tr>
+          <td><?lsmb ordnumber ?></td>
+          <td><?lsmb orddate ?></td>
+          <td><?lsmb reqdate ?></td>
+          <td><?lsmb employee ?></td>
+          <td><?lsmb shippingpoint ?>&nbsp;</td>
+          <td><?lsmb shipvia ?>&nbsp;</td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -122,87 +119,87 @@
   <tr>
     <td>
       <table width="100%">
-	<tr bgcolor=000000>
-	  <th align=right><font color=ffffff><?lsmb text('Item') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
-	  <th><font color=ffffff><?lsmb text('Qty') ?></th>
-	  <th>&nbsp;</th>
-	  <th><font color=ffffff><?lsmb text('Price') ?></th>
-	  <th><font color=ffffff>%</th>
-	  <th><font color=ffffff><?lsmb text('Amount') ?></th>
-	</tr>
+        <tr bgcolor=000000>
+          <th align=right><font color=ffffff><?lsmb text('Item') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
+          <th><font color=ffffff><?lsmb text('Qty') ?></th>
+          <th>&nbsp;</th>
+          <th><font color=ffffff><?lsmb text('Price') ?></th>
+          <th><font color=ffffff>%</th>
+          <th><font color=ffffff><?lsmb text('Amount') ?></th>
+        </tr>
 
         <?lsmb FOREACH number ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr valign=top>
-	  <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
-	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td align=right><?lsmb qty.${loop_count} ?></td>
-	  <td><?lsmb unit.${loop_count} ?></td>
-	  <td align=right><?lsmb sellprice.${loop_count} ?></td>
-	  <td align=right><?lsmb discountrate.${loop_count} ?></th>
-	  <td align=right><?lsmb linetotal.${loop_count} ?></td>
-	</tr>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr valign=top>
+          <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
+          <td><?lsmb number.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
+          <td align=right><?lsmb qty.${loop_count} ?></td>
+          <td><?lsmb unit.${loop_count} ?></td>
+          <td align=right><?lsmb sellprice.${loop_count} ?></td>
+          <td align=right><?lsmb discountrate.${loop_count} ?></th>
+          <td align=right><?lsmb linetotal.${loop_count} ?></td>
+        </tr>
         <?lsmb END ?>
 
-	<tr>
-	  <td colspan=8><hr noshade></td>
-	</tr>
+        <tr>
+          <td colspan=8><hr noshade></td>
+        </tr>
 
-	<tr>
+        <tr>
           <?lsmb IF taxincluded ?>
-	  <th colspan=7 align=right><?lsmb text('Total') ?></th>
-	  <th colspan=1 align=right><?lsmb ordtotal ?></th>
+          <th colspan=7 align=right><?lsmb text('Total') ?></th>
+          <th colspan=1 align=right><?lsmb ordtotal ?></th>
           <?lsmb ELSE ?>
-	  <th colspan=7 align=right><?lsmb text('Subtotal') ?></th>
-	  <td colspan=1 align=right><?lsmb subtotal ?></td>
+          <th colspan=7 align=right><?lsmb text('Subtotal') ?></th>
+          <td colspan=1 align=right><?lsmb subtotal ?></td>
           <?lsmb END ?>
-	</tr>
+        </tr>
 
         <?lsmb FOREACH tax ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr>
-	  <th colspan=7 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
-	  <td colspan=1 align=right><?lsmb tax.${loop_count} ?></td>
-	</tr>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr>
+          <th colspan=7 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+          <td colspan=1 align=right><?lsmb tax.${loop_count} ?></td>
+        </tr>
         <?lsmb END ?>
 
-	<tr>
-	  <td colspan=4>&nbsp;</td>
-	  <td colspan=4><hr noshade></td>
-	</tr>
+        <tr>
+          <td colspan=4>&nbsp;</td>
+          <td colspan=4><hr noshade></td>
+        </tr>
 
         <?lsmb IF NOT taxincluded ?>
-	  <th colspan=7 align=right><?lsmb text('Total') ?></th>
-	  <td colspan=1 align=right><?lsmb ordtotal ?></td>
+          <th colspan=7 align=right><?lsmb text('Total') ?></th>
+          <td colspan=1 align=right><?lsmb ordtotal ?></td>
         <?lsmb END ?>
 
         <?lsmb IF terms ?>
-	<tr>
-	  <td colspan=4><?lsmb text('Terms Net [_1] days', terms) ?></td>
-	  <th colspan=3 align=right><?lsmb text('Total') ?></th>
-	  <th colspan=1 align=right><?lsmb ordtotal ?></th>
-	</tr>
+        <tr>
+          <td colspan=4><?lsmb text('Terms Net [_1] days', terms) ?></td>
+          <th colspan=3 align=right><?lsmb text('Total') ?></th>
+          <th colspan=1 align=right><?lsmb ordtotal ?></th>
+        </tr>
         <?lsmb END ?>
 
         <?lsmb IF taxincluded ?>
-	<tr>
-	  <td colspan=2><?lsmb text('Tax included') ?></td>
-	</tr>
+        <tr>
+          <td colspan=2><?lsmb text('Tax included') ?></td>
+        </tr>
         <?lsmb END ?>
 
-	<tr>
-	  <td>&nbsp;</td>
-	</tr>
+        <tr>
+          <td>&nbsp;</td>
+        </tr>
 
         <?lsmb IF ordtotal ?>
-	<tr>
-	  <td colspan=8 align=right>
-	  <?lsmb text('All prices in [_1] funds', currency) ?>
-	  </td>
-	</tr>
+        <tr>
+          <td colspan=8 align=right>
+          <?lsmb text('All prices in [_1] funds', currency) ?>
+          </td>
+        </tr>
         <?lsmb END ?>
 
       </table>
@@ -211,12 +208,11 @@
 
   <?lsmb IF notes ?>
   <tr>
-    <td>&nbsp;</td>
 
     <td>
     <table width="100%">
       <tr valign=top>
-	<td><?lsmb text('Notes') ?></td>
+        <td><?lsmb text('Notes') ?></td>
           <td><?lsmb  FOREACH P IN notes.split('\n\n') ?>
                     <p><?lsmb P ?></p>
                <?lsmb END ?></td>
@@ -228,17 +224,16 @@
   <?lsmb END ?>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr valign=top>
-	  <td width="70%">&nbsp;</td>
+        <tr valign=top>
+          <td width="70%">&nbsp;</td>
 
-	  <td width="30%">
-	  X <hr noshade>
-	  </td>
-	</tr>
+          <td width="30%">
+          X <hr noshade>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>

--- a/templates/demo_with_images/request_quotation.html
+++ b/templates/demo_with_images/request_quotation.html
@@ -11,7 +11,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -20,74 +19,73 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr bgcolor=000000>
-	  <th align=left width="50%"><font color=ffffff><?lsmb text('To:') ?>
+        <tr bgcolor=000000>
+          <th align=left width="50%"><font color=ffffff><?lsmb text('To:') ?>
          </th>
-	  <th align=left width="50%"><font color=ffffff><?lsmb text('Ship To:') ?>
+          <th align=left width="50%"><font color=ffffff><?lsmb text('Ship To:') ?>
          </th>
-	</tr>
+        </tr>
 
-	<tr valign=top>
-	  <td><?lsmb name ?>
-	  <br><?lsmb address1 ?>
-	  <?lsmb IF address2 ?>
-	  <br><?lsmb address2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb city ?>
-	  <?lsmb IF state ?>
-	  , <?lsmb state ?>
-	  <?lsmb END ?>
-	  <?lsmb zipcode ?>
-	  <?lsmb IF country ?>
-	  <br><?lsmb country ?>
-	  <?lsmb END ?>
+        <tr valign=top>
+          <td><?lsmb name ?>
+          <br><?lsmb address1 ?>
+          <?lsmb IF address2 ?>
+          <br><?lsmb address2 ?>
+          <?lsmb END ?>
+          <br><?lsmb city ?>
+          <?lsmb IF state ?>
+          , <?lsmb state ?>
+          <?lsmb END ?>
+          <?lsmb zipcode ?>
+          <?lsmb IF country ?>
+          <br><?lsmb country ?>
+          <?lsmb END ?>
           <br>
 
-	  <?lsmb IF contact ?>
-	  <br><?lsmb text('Attn: [_1]', contact) ?>
-	  <?lsmb END ?>
+          <?lsmb IF contact ?>
+          <br><?lsmb text('Attn: [_1]', contact) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF vendorphone ?>
-	  <br><?lsmb text('Tel: [_1]', vendorphone) ?>
-	  <?lsmb END ?>
+          <?lsmb IF vendorphone ?>
+          <br><?lsmb text('Tel: [_1]', vendorphone) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF vendorfax ?>
-	  <br><?lsmb text('Fax: [_1]', vendorfax) ?>
-	  <?lsmb END ?>
-	  </td>
+          <?lsmb IF vendorfax ?>
+          <br><?lsmb text('Fax: [_1]', vendorfax) ?>
+          <?lsmb END ?>
+          </td>
 
-	  <td><?lsmb shiptoname ?>
-	  <br><?lsmb shiptoaddress1 ?>
-	  <?lsmb IF shiptoaddress2 ?>
-	  <br><?lsmb shiptoaddr2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb shiptocity ?>
-	  <?lsmb IF shiptostate ?>
-	  , <?lsmb shiptostate ?>
-	  <?lsmb END ?>
-	  <?lsmb shiptozipcode ?>
-	  <?lsmb IF shiptocountry ?>
-	  <br><?lsmb shiptocountry ?>
-	  <?lsmb END ?>
+          <td><?lsmb shiptoname ?>
+          <br><?lsmb shiptoaddress1 ?>
+          <?lsmb IF shiptoaddress2 ?>
+          <br><?lsmb shiptoaddr2 ?>
+          <?lsmb END ?>
+          <br><?lsmb shiptocity ?>
+          <?lsmb IF shiptostate ?>
+          , <?lsmb shiptostate ?>
+          <?lsmb END ?>
+          <?lsmb shiptozipcode ?>
+          <?lsmb IF shiptocountry ?>
+          <br><?lsmb shiptocountry ?>
+          <?lsmb END ?>
           <br>
 
-	  <?lsmb IF shiptocontact ?>
-	  <br><?lsmb text('Attn: [_1]', shiptocontact) ?>
-	  <?lsmb END ?>
+          <?lsmb IF shiptocontact ?>
+          <br><?lsmb text('Attn: [_1]', shiptocontact) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF shiptophone ?>
-	  <br><?lsmb text('Tel: [_1]', shiptophone) ?>
-	  <?lsmb END ?>
+          <?lsmb IF shiptophone ?>
+          <br><?lsmb text('Tel: [_1]', shiptophone) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF shiptofax ?>
-	  <br><?lsmb text('Fax: [_1]', shiptofax) ?>
-	  <?lsmb END ?>
-	  </td>
-	</tr>
+          <?lsmb IF shiptofax ?>
+          <br><?lsmb text('Fax: [_1]', shiptofax) ?>
+          <?lsmb END ?>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -95,27 +93,26 @@
   <tr height=5></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% border=1>
-	<tr>
-	  <th width=17% align=left><?lsmb text('RFQ #') ?></th>
-	  <th width=17% align=left><?lsmb text('Date') ?></th>
-	  <th width=17% align=left><?lsmb text('Required by') ?></th>
-	  <th width=17% align=left><?lsmb text('Contact') ?></th>
-	  <th width=17% align=left><?lsmb text('Shipping Point') ?></th>
-	  <th width=15% align=left><?lsmb text('Ship via') ?></th>
-	</tr>
+        <tr>
+          <th width=17% align=left><?lsmb text('RFQ #') ?></th>
+          <th width=17% align=left><?lsmb text('Date') ?></th>
+          <th width=17% align=left><?lsmb text('Required by') ?></th>
+          <th width=17% align=left><?lsmb text('Contact') ?></th>
+          <th width=17% align=left><?lsmb text('Shipping Point') ?></th>
+          <th width=15% align=left><?lsmb text('Ship via') ?></th>
+        </tr>
 
-	<tr>
-	  <td><?lsmb quonumber ?></td>
-	  <td><?lsmb quodate ?></td>
-	  <td><?lsmb reqdate ?>&nbsp;</td>
-	  <td><?lsmb employee ?></td>
-	  <td><?lsmb shippingpoint ?>&nbsp;</td>
-	  <td><?lsmb shipvia ?>&nbsp;</td>
-	</tr>
+        <tr>
+          <td><?lsmb quonumber ?></td>
+          <td><?lsmb quodate ?></td>
+          <td><?lsmb reqdate ?>&nbsp;</td>
+          <td><?lsmb employee ?></td>
+          <td><?lsmb shippingpoint ?>&nbsp;</td>
+          <td><?lsmb shipvia ?>&nbsp;</td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -123,7 +120,6 @@
   <tr height="10"></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td><?lsmb text('Please provide price and delivery time for the following items:') ?></td>
   </tr>
@@ -131,35 +127,34 @@
   <tr height="10"></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr>
-	  <th align=right><?lsmb text('Item') ?></th>
-	  <th align=left><?lsmb text('Number') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
-	  <th><?lsmb text('Qty') ?></th>
-	  <th>&nbsp;</th>
-	  <th><?lsmb text('Delivery') ?></th>
-	  <th<?lsmb text('Unit Price') ?></th>
-	  <th<?lsmb text('Extended') ?></th>
-	</tr>
+        <tr>
+          <th align=right><?lsmb text('Item') ?></th>
+          <th align=left><?lsmb text('Number') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
+          <th><?lsmb text('Qty') ?></th>
+          <th>&nbsp;</th>
+          <th><?lsmb text('Delivery') ?></th>
+          <th<?lsmb text('Unit Price') ?></th>
+          <th<?lsmb text('Extended') ?></th>
+        </tr>
 
         <?lsmb FOREACH number ?>
-	<?lsmb loop_count = loop.count - 1 ?>
+        <?lsmb loop_count = loop.count - 1 ?>
         <tr valign=top>
           <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
-	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td align=right><?lsmb qty.${loop_count} ?></td>
-	  <td><?lsmb unit.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+          <td><?lsmb number.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
+          <td align=right><?lsmb qty.${loop_count} ?></td>
+          <td><?lsmb unit.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
-	<tr>
-	  <td colspan=8><hr noshade></td>
-	</tr>
+        <tr>
+          <td colspan=8><hr noshade></td>
+        </tr>
 
       </table>
     </td>
@@ -167,16 +162,15 @@
 
   <?lsmb IF notes ?>
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr valign=top>
-	  <td<?lsmb text('Notes') ?></td>
+        <tr valign=top>
+          <td<?lsmb text('Notes') ?></td>
           <td><?lsmb  FOREACH P IN notes.split('\n\n') ?>
                     <p><?lsmb P ?></p>
                <?lsmb END ?></td>
-	</tr>
+        </tr>
 
       </table>
     </td>

--- a/templates/demo_with_images/sales_order.html
+++ b/templates/demo_with_images/sales_order.html
@@ -11,7 +11,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -20,73 +19,72 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
-	<tr bgcolor=000000>
-	  <th align=left width="50%"><font color=ffffff><?lsmb text('To') ?></th>
-	  <th align=left width="50%"><font color=ffffff><?lsmb text('Ship To') ?>
+        <tr bgcolor=000000>
+          <th align=left width="50%"><font color=ffffff><?lsmb text('To') ?></th>
+          <th align=left width="50%"><font color=ffffff><?lsmb text('Ship To') ?>
           </th>
-	</tr>
+        </tr>
 
-	<tr valign=top>
-	  <td><?lsmb name ?>
-	  <br><?lsmb address1 ?>
-	  <?lsmb IF address2 ?>
-	  <br><?lsmb address2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb city ?>
-	  <?lsmb IF state ?>
-	  , <?lsmb state ?>
-	  <?lsmb END ?>
+        <tr valign=top>
+          <td><?lsmb name ?>
+          <br><?lsmb address1 ?>
+          <?lsmb IF address2 ?>
+          <br><?lsmb address2 ?>
+          <?lsmb END ?>
+          <br><?lsmb city ?>
+          <?lsmb IF state ?>
+          , <?lsmb state ?>
+          <?lsmb END ?>
           <?lsmb zipcode ?>
-	  <?lsmb IF country ?>
-	  <br><?lsmb country ?>
-	  <?lsmb END ?>
+          <?lsmb IF country ?>
+          <br><?lsmb country ?>
+          <?lsmb END ?>
           <br>
-	  <?lsmb IF contact ?>
-	  <br><?lsmb text('Attn: [_1]', contact) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF customerphone ?>
-	  <br><?lsmb text('Tel: [_1]', customerphone) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF customerfax ?>
-	  <br><?lsmb text('Fax: [_1]', customerfax) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF email ?>
-	  <br><?lsmb email ?>
-	  <?lsmb END ?>
-	  </td>
+          <?lsmb IF contact ?>
+          <br><?lsmb text('Attn: [_1]', contact) ?>
+          <?lsmb END ?>
+          <?lsmb IF customerphone ?>
+          <br><?lsmb text('Tel: [_1]', customerphone) ?>
+          <?lsmb END ?>
+          <?lsmb IF customerfax ?>
+          <br><?lsmb text('Fax: [_1]', customerfax) ?>
+          <?lsmb END ?>
+          <?lsmb IF email ?>
+          <br><?lsmb email ?>
+          <?lsmb END ?>
+          </td>
 
-	  <td><?lsmb shiptoname ?>
-	  <br><?lsmb shiptoaddress1 ?>
-	  <?lsmb IF shiptoaddress2 ?>
-	  <br><?lsmb shiptoaddress2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb shiptocity ?>
-	  <?lsmb IF shiptostate ?>
-	  , <?lsmb shiptostate ?>
-	  <?lsmb END ?>
+          <td><?lsmb shiptoname ?>
+          <br><?lsmb shiptoaddress1 ?>
+          <?lsmb IF shiptoaddress2 ?>
+          <br><?lsmb shiptoaddress2 ?>
+          <?lsmb END ?>
+          <br><?lsmb shiptocity ?>
+          <?lsmb IF shiptostate ?>
+          , <?lsmb shiptostate ?>
+          <?lsmb END ?>
           <?lsmb shiptozipcode ?>
-	  <?lsmb IF shiptocountry ?>
-	  <br><?lsmb shiptocountry ?>
-	  <?lsmb END ?>
-	  <br>
+          <?lsmb IF shiptocountry ?>
+          <br><?lsmb shiptocountry ?>
+          <?lsmb END ?>
+          <br>
           <?lsmb IF shiptocontact ?>
           <br><?lsmb shiptocontact ?>
           <?lsmb END ?>
-	  <?lsmb IF shiptophone ?>
-	  <br><?lsmb text('Tel: [_1]', shiptophone) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF shiptofax ?>
-	  <br><?lsmb text('Fax: [_1]', shiptofax) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF shiptoemail ?>
-	  <br><?lsmb shiptoemail ?>
-	  <?lsmb END ?>
-	  </td>
-	</tr>
+          <?lsmb IF shiptophone ?>
+          <br><?lsmb text('Tel: [_1]', shiptophone) ?>
+          <?lsmb END ?>
+          <?lsmb IF shiptofax ?>
+          <br><?lsmb text('Fax: [_1]', shiptofax) ?>
+          <?lsmb END ?>
+          <?lsmb IF shiptoemail ?>
+          <br><?lsmb shiptoemail ?>
+          <?lsmb END ?>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -94,141 +92,137 @@
   <tr height=5></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% border=1>
-	<tr>
-	  <th width=17% align=left nowrap><?lsmb text('Order #') ?></th>
-	  <th width=17% align=left><?lsmb text('Order Date') ?></th>
-	  <th width=17% align=left><?lsmb text('Required by') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Salesperson') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Shipping Point') ?></th>
-	  <th width=15% align=left nowrap><?lsmb text('Ship Via') ?></th>
-	</tr>
+        <tr>
+          <th width=17% align=left nowrap><?lsmb text('Order #') ?></th>
+          <th width=17% align=left><?lsmb text('Order Date') ?></th>
+          <th width=17% align=left><?lsmb text('Required by') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Salesperson') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Shipping Point') ?></th>
+          <th width=15% align=left nowrap><?lsmb text('Ship Via') ?></th>
+        </tr>
 
-	<tr>
-	  <td><?lsmb ordnumber ?></td>
-	  <td><?lsmb orddate ?></td>
-	  <td><?lsmb reqdate ?></td>
-	  <td><?lsmb employee ?></td>
-	  <td><?lsmb shippingpoint ?>&nbsp;</td>
-	  <td><?lsmb shipvia ?>&nbsp;</td>
-	</tr>
+        <tr>
+          <td><?lsmb ordnumber ?></td>
+          <td><?lsmb orddate ?></td>
+          <td><?lsmb reqdate ?></td>
+          <td><?lsmb employee ?></td>
+          <td><?lsmb shippingpoint ?>&nbsp;</td>
+          <td><?lsmb shipvia ?>&nbsp;</td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr bgcolor=000000>
-	  <th align=right><font color=ffffff><?lsmb text('Item') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
-	  <th><font color=ffffff><?lsmb text('Qty') ?></th>
-	  <th>&nbsp;</th>
-	  <th><font color=ffffff><?lsmb text('Price') ?></th>
-	  <th><font color=ffffff><?lsmb text('Disc %') ?></th>
-	  <th><font color=ffffff><?lsmb text('Amount') ?></th>
-	</tr>
+        <tr bgcolor=000000>
+          <th align=right><font color=ffffff><?lsmb text('Item') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
+          <th><font color=ffffff><?lsmb text('Qty') ?></th>
+          <th>&nbsp;</th>
+          <th><font color=ffffff><?lsmb text('Price') ?></th>
+          <th><font color=ffffff><?lsmb text('Disc %') ?></th>
+          <th><font color=ffffff><?lsmb text('Amount') ?></th>
+        </tr>
 
-	<?lsmb FOREACH number ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr valign=top>
+        <?lsmb FOREACH number ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr valign=top>
           <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
-	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td align=right><?lsmb qty.${loop_count} ?></td>
-	  <td><?lsmb unit.${loop_count} ?></td>
-	  <td align=right><?lsmb sellprice.${loop_count} ?></td>
-	  <td align=right><?lsmb discountrate.${loop_count} ?></td>
-	  <td align=right><?lsmb linetotal.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+          <td><?lsmb number.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
+          <td align=right><?lsmb qty.${loop_count} ?></td>
+          <td><?lsmb unit.${loop_count} ?></td>
+          <td align=right><?lsmb sellprice.${loop_count} ?></td>
+          <td align=right><?lsmb discountrate.${loop_count} ?></td>
+          <td align=right><?lsmb linetotal.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
-	<tr>
-	  <td colspan=8><hr noshade></td>
-	</tr>
+        <tr>
+          <td colspan=8><hr noshade></td>
+        </tr>
 
-	<tr>
-	  <?lsmb IF taxincluded ?>
-	  <th colspan=6 align=right><?lsmb text('Total') ?></th>
-	  <td colspan=2 align=right><?lsmb invtotal ?></td>
-	  <?lsmb ELSE ?>
-	  <th colspan=6 align=right><?lsmb text('Subtotal') ?></th>
-	  <td colspan=2 align=right><?lsmb subtotal ?></td>
-	  <?lsmb END ?>
-	</tr>
+        <tr>
+          <?lsmb IF taxincluded ?>
+          <th colspan=6 align=right><?lsmb text('Total') ?></th>
+          <td colspan=2 align=right><?lsmb invtotal ?></td>
+          <?lsmb ELSE ?>
+          <th colspan=6 align=right><?lsmb text('Subtotal') ?></th>
+          <td colspan=2 align=right><?lsmb subtotal ?></td>
+          <?lsmb END ?>
+        </tr>
 
-	<?lsmb FOREACH tax ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr>
-	  <th colspan=6 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
-	  <td colspan=2 align=right><?lsmb tax.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+        <?lsmb FOREACH tax ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr>
+          <th colspan=6 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+          <td colspan=2 align=right><?lsmb tax.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
-	<tr>
-	  <td colspan=4>&nbsp;</td>
-	  <td colspan=4><hr noshade></td>
-	</tr>
+        <tr>
+          <td colspan=4>&nbsp;</td>
+          <td colspan=4><hr noshade></td>
+        </tr>
 
-	<tr>
-	  <td colspan=4>
+        <tr>
+          <td colspan=4>
           <?lsmb text_amount ?> ***** <?lsmb decimal ?>/100
-	  <?lsmb IF terms ?>
-	  <br><?lsmb text('Terms Net [_1] days', terms) ?>
-	  <?lsmb END ?>
-	  </td>
-	  <th colspan=2 align=right><?lsmb text('Total') ?></th>
-	  <th colspan=2 align=right><?lsmb ordtotal ?></th>
-	</tr>
+          <?lsmb IF terms ?>
+          <br><?lsmb text('Terms Net [_1] days', terms) ?>
+          <?lsmb END ?>
+          </td>
+          <th colspan=2 align=right><?lsmb text('Total') ?></th>
+          <th colspan=2 align=right><?lsmb ordtotal ?></th>
+        </tr>
 
-	<tr>
-	  <td>&nbsp;</td>
-	</tr>
+        <tr>
+          <td>&nbsp;</td>
+        </tr>
 
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr valign=top>
-	  <?lsmb IF notes ?>
-	  <td><?lsmb text('Notes') ?></td>
+        <tr valign=top>
+          <?lsmb IF notes ?>
+          <td><?lsmb text('Notes') ?></td>
           <td><?lsmb  FOREACH P IN notes.split('\n\n') ?>
                     <p><?lsmb P ?></p>
                <?lsmb END ?></td>
-	  <?lsmb END ?>
-	  <td align=right nowrap>
-	  <?lsmb text('All prices in [_1] Funds', currency) ?>
-	  </td>
-	</tr>
+          <?lsmb END ?>
+          <td align=right nowrap>
+          <?lsmb text('All prices in [_1] Funds', currency) ?>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr valign=top>
-	  <td width="60%"><font size=-3>
-	  <?lsmb text('Special order items are subject to a 10% order cancellation fee.') ?>
-	  </font>
-	  </td>
-	  <td width="40%">
-	  X <hr noshade>
-	  </td>
-	</tr>
+        <tr valign=top>
+          <td width="60%"><font size=-3>
+          <?lsmb text('Special order items are subject to a 10% order cancellation fee.') ?>
+          </font>
+          </td>
+          <td width="40%">
+          X <hr noshade>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>

--- a/templates/demo_with_images/sales_quotation.html
+++ b/templates/demo_with_images/sales_quotation.html
@@ -11,7 +11,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3 style="text-transform:uppercase">
       <h4><?lsmb text('Quotation') ?></h4>
@@ -19,186 +18,181 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
 
-	<tr valign=top>
-	  <td><?lsmb name ?>
-	  <br><?lsmb address1 ?>
-	  <?lsmb IF address2 ?>
-	  <br><?lsmb address2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb city ?>
-	  <?lsmb IF state ?>
-	  , <?lsmb state ?>
-	  <?lsmb END ?>
-	  <?lsmb zipcode ?>
-	  <?lsmb IF country ?>
-	  <br><?lsmb country ?>
-	  <?lsmb END ?>
+        <tr valign=top>
+          <td><?lsmb name ?>
+          <br><?lsmb address1 ?>
+          <?lsmb IF address2 ?>
+          <br><?lsmb address2 ?>
+          <?lsmb END ?>
+          <br><?lsmb city ?>
+          <?lsmb IF state ?>
+          , <?lsmb state ?>
+          <?lsmb END ?>
+          <?lsmb zipcode ?>
+          <?lsmb IF country ?>
+          <br><?lsmb country ?>
+          <?lsmb END ?>
 
-	  <br>
-	  <?lsmb IF contact ?>
-	  <br><?lsmb text('Attn: [_1]', contact) ?>
-	  <?lsmb END ?>
+          <br>
+          <?lsmb IF contact ?>
+          <br><?lsmb text('Attn: [_1]', contact) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF customerphone ?>
-	  <br><?lsmb text('Tel: [_1]', customerphone) ?>
-	  <?lsmb END ?>
+          <?lsmb IF customerphone ?>
+          <br><?lsmb text('Tel: [_1]', customerphone) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF customerfax ?>
-	  <br><?lsmb text('Fax: [_1]', customerfax) ?>
-	  <?lsmb END ?>
+          <?lsmb IF customerfax ?>
+          <br><?lsmb text('Fax: [_1]', customerfax) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF email ?>
-	  <br><?lsmb email ?>
-	  <?lsmb END ?>
-	  </td>
+          <?lsmb IF email ?>
+          <br><?lsmb email ?>
+          <?lsmb END ?>
+          </td>
 
-	</tr>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% border=1>
-	<tr>
-	  <th width=17% align=left nowrap><?lsmb text('Number') ?></th>
-	  <th width=17% align=left><?lsmb text('Date') ?></th>
-	  <th width=17% align=left><?lsmb text('Valid until') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Contact') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Shipping Point') ?></th>
-	  <th width=15% align=left nowrap><?lsmb text('Ship via') ?></th>
-	</tr>
+        <tr>
+          <th width=17% align=left nowrap><?lsmb text('Number') ?></th>
+          <th width=17% align=left><?lsmb text('Date') ?></th>
+          <th width=17% align=left><?lsmb text('Valid until') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Contact') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Shipping Point') ?></th>
+          <th width=15% align=left nowrap><?lsmb text('Ship via') ?></th>
+        </tr>
 
-	<tr>
-	  <td><?lsmb quonumber ?></td>
-	  <td><?lsmb quodate ?></td>
-	  <td><?lsmb reqdate ?></td>
-	  <td><?lsmb employee ?></td>
-	  <td><?lsmb shippingpoint ?>&nbsp;</td>
-	  <td><?lsmb shipvia ?>&nbsp;</td>
-	</tr>
+        <tr>
+          <td><?lsmb quonumber ?></td>
+          <td><?lsmb quodate ?></td>
+          <td><?lsmb reqdate ?></td>
+          <td><?lsmb employee ?></td>
+          <td><?lsmb shippingpoint ?>&nbsp;</td>
+          <td><?lsmb shipvia ?>&nbsp;</td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr bgcolor=000000>
-	  <th align=right><font color=ffffff><?lsmb text('Item') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
-	  <th><font color=ffffff><?lsmb text('Qty') ?></th>
-	  <th>&nbsp;</th>
-	  <th><font color=ffffff><?lsmb text('Price') ?></th>
-	  <th><font color=ffffff><?lsmb text('Disc %') ?></th>
-	  <th><font color=ffffff><?lsmb text('Amount') ?></th>
-	</tr>
+        <tr bgcolor=000000>
+          <th align=right><font color=ffffff><?lsmb text('Item') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
+          <th><font color=ffffff><?lsmb text('Qty') ?></th>
+          <th>&nbsp;</th>
+          <th><font color=ffffff><?lsmb text('Price') ?></th>
+          <th><font color=ffffff><?lsmb text('Disc %') ?></th>
+          <th><font color=ffffff><?lsmb text('Amount') ?></th>
+        </tr>
 
         <?lsmb FOREACH number ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr valign=top>
-	  <td align=right><?lsmb runningnumber.${loop_count} ?></td>
-	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td align=right><?lsmb qty.${loop_count} ?></td>
-	  <td><?lsmb unit.${loop_count} ?></td>
-	  <td align=right><?lsmb sellprice.${loop_count} ?></td>
-	  <td align=right><?lsmb discountrate.${loop_count} ?></td>
-	  <td align=right><?lsmb linetotal.${loop_count} ?></td>
-	</tr>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr valign=top>
+          <td align=right><?lsmb runningnumber.${loop_count} ?></td>
+          <td><?lsmb number.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
+          <td align=right><?lsmb qty.${loop_count} ?></td>
+          <td><?lsmb unit.${loop_count} ?></td>
+          <td align=right><?lsmb sellprice.${loop_count} ?></td>
+          <td align=right><?lsmb discountrate.${loop_count} ?></td>
+          <td align=right><?lsmb linetotal.${loop_count} ?></td>
+        </tr>
         <?lsmb END ?>
 
-	<tr>
-	  <td colspan=8><hr noshade></td>
-	</tr>
+        <tr>
+          <td colspan=8><hr noshade></td>
+        </tr>
 
-	<tr>
-	  <?lsmb IF taxincluded ?>
-	  <th colspan=6 align=right><?lsmb text('Total') ?></th>
-	  <td colspan=2 align=right><?lsmb invtotal ?></td>
-	  <?lsmb ELSE ?>
-	  <th colspan=6 align=right><?lsmb text('Subtotal') ?></th>
-	  <td colspan=2 align=right><?lsmb subtotal ?></td>
-	  <?lsmb END ?>
-	</tr>
+        <tr>
+          <?lsmb IF taxincluded ?>
+          <th colspan=6 align=right><?lsmb text('Total') ?></th>
+          <td colspan=2 align=right><?lsmb invtotal ?></td>
+          <?lsmb ELSE ?>
+          <th colspan=6 align=right><?lsmb text('Subtotal') ?></th>
+          <td colspan=2 align=right><?lsmb subtotal ?></td>
+          <?lsmb END ?>
+        </tr>
 
-	<?lsmb FOREACH tax ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr>
-	  <th colspan=6 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
-	  <td colspan=2 align=right><?lsmb tax.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+        <?lsmb FOREACH tax ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr>
+          <th colspan=6 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+          <td colspan=2 align=right><?lsmb tax.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
-	<tr>
-	  <td colspan=4>&nbsp;</td>
-	  <td colspan=4><hr noshade></td>
-	</tr>
+        <tr>
+          <td colspan=4>&nbsp;</td>
+          <td colspan=4><hr noshade></td>
+        </tr>
 
-	<tr>
-	  <td colspan=4>&nbsp;
-	  <?lsmb IF terms ?>
-	  <?lsmb text('Terms Net [_1] days', terms) ?>
-	  <?lsmb END ?>
-	  </td>
-	  <th colspan=2 align=right><?lsmb text('Total') ?></th>
-	  <th colspan=2 align=right><?lsmb quototal ?></th>
-	</tr>
+        <tr>
+          <td colspan=4>&nbsp;
+          <?lsmb IF terms ?>
+          <?lsmb text('Terms Net [_1] days', terms) ?>
+          <?lsmb END ?>
+          </td>
+          <th colspan=2 align=right><?lsmb text('Total') ?></th>
+          <th colspan=2 align=right><?lsmb quototal ?></th>
+        </tr>
 
-	<tr>
-	  <td>&nbsp;</td>
-	</tr>
+        <tr>
+          <td>&nbsp;</td>
+        </tr>
 
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr valign=top>
+        <tr valign=top>
           <?lsmb IF notes ?>
-	  <td><?lsmb text('Notes') ?></td>
+          <td><?lsmb text('Notes') ?></td>
           <td><?lsmb  FOREACH P IN notes.split('\n\n') ?>
                     <p><?lsmb P ?></p>
                <?lsmb END ?></td>
           <?lsmb END ?>
-	  <td align=right>
-	  <?lsmb text('All prices in [_1] Funds', currency) ?>
-	  </td>
-	</tr>
+          <td align=right>
+          <?lsmb text('All prices in [_1] Funds', currency) ?>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr valign=top>
-	  <td width="60%"><font size=-3>
-	  <?lsmb
+        <tr valign=top>
+          <td width="60%"><font size=-3>
+          <?lsmb
              text('Special order items are subject to a 10% cancellation fee.')
            ?>
-	  </font>
-	  </td>
-	  <td width="40%">
-	  X <hr noshade>
-	  </td>
-	</tr>
+          </font>
+          </td>
+          <td width="40%">
+          X <hr noshade>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>

--- a/templates/demo_with_images/statement.html
+++ b/templates/demo_with_images/statement.html
@@ -13,7 +13,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3><h4 style="text-transform:uppercase">
          <?lsmb text('Statement') ?></h4></th>
@@ -21,30 +20,28 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td colspan=3 align=right><?lsmb statementdate ?></td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr valign=top>
-	  <td><?lsmb statement.entity.name ?>
-	  <br><?lsmb statement.address.line_one ?>
-	  <?lsmb IF statement.address.line_two ?>
-	  <br><?lsmb statement.address.line_two ?>
-	  <?lsmb END ?>
-	  <br><?lsmb statement.address.city ?>
-	  <?lsmb IF statement.address.state ?>
-	  , <?lsmb statement.address.state ?>
-	  <?lsmb END ?>
-	  <?lsmb statement.address.mail_code ?>
-	  <br>
-	  </td>
-	</tr>
+        <tr valign=top>
+          <td><?lsmb statement.entity.name ?>
+          <br><?lsmb statement.address.line_one ?>
+          <?lsmb IF statement.address.line_two ?>
+          <br><?lsmb statement.address.line_two ?>
+          <?lsmb END ?>
+          <br><?lsmb statement.address.city ?>
+          <?lsmb IF statement.address.state ?>
+          , <?lsmb statement.address.state ?>
+          <?lsmb END ?>
+          <?lsmb statement.address.mail_code ?>
+          <br>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -52,48 +49,47 @@
   <tr height=10></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
         <tr>
-	  <th align=left><?lsmb text('Invoice #') ?></th>
+          <th align=left><?lsmb text('Invoice #') ?></th>
           <th align=left><?lsmb text('Order #') ?></th>
-	  <th width="10%"><?lsmb text('Date') ?></th>
-	  <th width="10%"><?lsmb text('Due') ?></th>
-	  <th width="10%"><?lsmb text('Current') ?></th>
-	  <th width="10%"><?lsmb text('30') ?></th>
-	  <th width="10%"><?lsmb text('60') ?></th>
-	  <th width="10%"><?lsmb text('90') ?></th>
-	</tr>
+          <th width="10%"><?lsmb text('Date') ?></th>
+          <th width="10%"><?lsmb text('Due') ?></th>
+          <th width="10%"><?lsmb text('Current') ?></th>
+          <th width="10%"><?lsmb text('30') ?></th>
+          <th width="10%"><?lsmb text('60') ?></th>
+          <th width="10%"><?lsmb text('90') ?></th>
+        </tr>
 
-	<?lsmb- FOREACH invoice IN statement.aging.rows ?>
-	<tr>
-	  <td><?lsmb invoice.invnumber ?></td>
+        <?lsmb- FOREACH invoice IN statement.aging.rows ?>
+        <tr>
+          <td><?lsmb invoice.invnumber ?></td>
           <td><?lsmb invoice.ordnumber ?></td>
-	  <td><?lsmb invoice.transdate ?></td>
-	  <td><?lsmb invoice.duedate ?></td>
-	  <td align=right><?lsmb invoice.c0 ?></td>
-	  <td align=right><?lsmb invoice.c30 ?></td>
-	  <td align=right><?lsmb invoice.c60 ?></td>
-	  <td align=right><?lsmb invoice.c90 ?></td>
-	</tr>
+          <td><?lsmb invoice.transdate ?></td>
+          <td><?lsmb invoice.duedate ?></td>
+          <td align=right><?lsmb invoice.c0 ?></td>
+          <td align=right><?lsmb invoice.c30 ?></td>
+          <td align=right><?lsmb invoice.c60 ?></td>
+          <td align=right><?lsmb invoice.c90 ?></td>
+        </tr>
         <?lsmb END -?>
 
         <tr>
-	  <td colspan=8><hr size=1></td>
-	</tr>
+          <td colspan=8><hr size=1></td>
+        </tr>
 
-	<tr>
-	  <td>&nbsp;</td>
-	  <td>&nbsp;</td>
+        <tr>
           <td>&nbsp;</td>
           <td>&nbsp;</td>
-	  <th align=right><?lsmb statement.aging.c0total ?></td>
-	  <th align=right><?lsmb statement.aging.c30total ?></td>
-	  <th align=right><?lsmb statement.aging.c60total ?></td>
-	  <th align=right><?lsmb statement.aging.c90total ?></td>
-	</tr>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+          <th align=right><?lsmb statement.aging.c0total ?></td>
+          <th align=right><?lsmb statement.aging.c30total ?></td>
+          <th align=right><?lsmb statement.aging.c60total ?></td>
+          <th align=right><?lsmb statement.aging.c90total ?></td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -101,20 +97,18 @@
   <tr height=10></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td align=right>
       <table width="50%">
         <tr>
-	  <th><?lsmb text('Total Outstanding') ?></th>
+          <th><?lsmb text('Total Outstanding') ?></th>
           <th align=right><?lsmb statement.aging.total ?></th>
-	</tr>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td><hr noshade></td>
   </tr>

--- a/templates/demo_with_images/timecard.html
+++ b/templates/demo_with_images/timecard.html
@@ -9,9 +9,8 @@
 <table width="100%">
 
   <?lsmb INCLUDE letterhead ?>
-  
+
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -20,103 +19,100 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
         <tr valign=top>
-	  <td>
-	    <table>
-	      <tr>
-		<th align=left><?lsmb text('Employee') ?></th>
-		<td><?lsmb employee ?></td>
-	      </tr>
-	      <tr>
-		<th align=left><?lsmb text('ID') ?></th>
-		<td><?lsmb employee_id ?></td>
-	      </tr>
-	    </table>
-	  </td>
-   
-	  <td align=right>
-	    <table>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Card ID') ?></th>
-		<td><?lsmb id ?></td>
-	      </tr>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Date') ?></th>
-		<td><?lsmb transdate ?></td>
-	      </tr>
-	      <tr>
-		<th align=left nowrap><?lsmb text('In') ?></th>
-		<td><?lsmb checkedin ?></td>
-	      </tr>
+          <td>
+            <table>
+              <tr>
+                <th align=left><?lsmb text('Employee') ?></th>
+                <td><?lsmb employee ?></td>
+              </tr>
+              <tr>
+                <th align=left><?lsmb text('ID') ?></th>
+                <td><?lsmb employee_id ?></td>
+              </tr>
+            </table>
+          </td>
+
+          <td align=right>
+            <table>
+              <tr>
+                <th align=left nowrap><?lsmb text('Card ID') ?></th>
+                <td><?lsmb id ?></td>
+              </tr>
+              <tr>
+                <th align=left nowrap><?lsmb text('Date') ?></th>
+                <td><?lsmb transdate ?></td>
+              </tr>
+              <tr>
+                <th align=left nowrap><?lsmb text('In') ?></th>
+                <td><?lsmb checkedin ?></td>
+              </tr>
               <tr>
                 <th align=left><?lsmb text('Out') ?></th>
-		<td><?lsmb checkedout ?></td>
-	      </tr>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Hours') ?></th>
-		<td><?lsmb qty ?></td>
-	      </tr>
-	    </table>
-	  </td>
+                <td><?lsmb checkedout ?></td>
+              </tr>
+              <tr>
+                <th align=left nowrap><?lsmb text('Hours') ?></th>
+                <td><?lsmb qty ?></td>
+              </tr>
+            </table>
+          </td>
         </tr>
       </table>
     </td>
   </tr>
 
   <tr height=5></tr>
-  
+
   <tr>
-    <td>&nbsp;</td>
-  
+
     <td>
       <table width="100%">
         <tr valign=bottom>
-	  <td>
-	    <table>
-	      <tr valign=top>
-	        <th align=left><?lsmb text('Job/Project #') ?></th>
-		<td><?lsmb projectnumber ?></td>
-	      </tr>
-	      <tr>
-	        <th align=left><?lsmb text('Description') ?></th>
-		<td><?lsmb projectdescription ?></td>
-	      </tr>
-	      <tr valign=top>
-	        <th align=left><?lsmb text('Labor/Service Code') ?></th>
-		<td><?lsmb partnumber ?></td>
-	      </tr>
-	      <tr>
-	        <th align=left><?lsmb text('Description') ?></th>
-		<td><?lsmb description ?></td>
-	      </tr>
-	    </table>
-	  </td>
-	  <td align=right>
-	    <table>
-	      <tr>
-	        <th align=right><?lsmb text('Rate') ?></th>
-		<td><?lsmb sellprice ?></td>
-	      </tr>
-	      <tr>
-		<th align=right><?lsmb text('Total') ?></th>
-		<td><?lsmb total ?></td>
-	      </tr>
-	    </table>
-	  </td>
-	</tr>
+          <td>
+            <table>
+              <tr valign=top>
+                <th align=left><?lsmb text('Job/Project #') ?></th>
+                <td><?lsmb projectnumber ?></td>
+              </tr>
+              <tr>
+                <th align=left><?lsmb text('Description') ?></th>
+                <td><?lsmb projectdescription ?></td>
+              </tr>
+              <tr valign=top>
+                <th align=left><?lsmb text('Labor/Service Code') ?></th>
+                <td><?lsmb partnumber ?></td>
+              </tr>
+              <tr>
+                <th align=left><?lsmb text('Description') ?></th>
+                <td><?lsmb description ?></td>
+              </tr>
+            </table>
+          </td>
+          <td align=right>
+            <table>
+              <tr>
+                <th align=right><?lsmb text('Rate') ?></th>
+                <td><?lsmb sellprice ?></td>
+              </tr>
+              <tr>
+                <th align=right><?lsmb text('Total') ?></th>
+                <td><?lsmb total ?></td>
+              </tr>
+            </table>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <?lsmb IF notes ?>
   <tr height=5></tr>
-  
+
   <tr>
-    <td>&nbsp;</td>
 
           <td><?lsmb  FOREACH P IN notes.split('\n\n') ?>
                     <p><?lsmb P ?></p>

--- a/templates/demo_with_images/work_order.html
+++ b/templates/demo_with_images/work_order.html
@@ -11,82 +11,80 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
-	<?lsmb text('Work Order') ?></h4>
+        <?lsmb text('Work Order') ?></h4>
     </th>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
-	<tr bgcolor=000000>
-	  <th align=left width="50%"><font color=ffffff><?lsmb text('To') ?></th>
-	  <th align=left width="50%"><font color=ffffff><?lsmb text('Ship To') ?>
+        <tr bgcolor=000000>
+          <th align=left width="50%"><font color=ffffff><?lsmb text('To') ?></th>
+          <th align=left width="50%"><font color=ffffff><?lsmb text('Ship To') ?>
           </th>
-	</tr>
+        </tr>
 
-	<tr valign=top>
-	  <td><?lsmb name ?>
-	  <br><?lsmb address1 ?>
-	  <?lsmb IF address2 ?>
-	  <br><?lsmb address2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb city ?>
-	  <?lsmb IF state ?>
-	  , <?lsmb state ?>
-	  <?lsmb END ?>
+        <tr valign=top>
+          <td><?lsmb name ?>
+          <br><?lsmb address1 ?>
+          <?lsmb IF address2 ?>
+          <br><?lsmb address2 ?>
+          <?lsmb END ?>
+          <br><?lsmb city ?>
+          <?lsmb IF state ?>
+          , <?lsmb state ?>
+          <?lsmb END ?>
           <?lsmb zipcode ?>
-	  <?lsmb IF country ?>
-	  <br><?lsmb country ?>
-	  <?lsmb END ?>
+          <?lsmb IF country ?>
+          <br><?lsmb country ?>
+          <?lsmb END ?>
           <br>
-	  <?lsmb IF contact ?>
-	  <br><?lsmb text('Attn: [_1]', contact) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF customerphone ?>
-	  <br><?lsmb text('Tel: [_1]', customerphone) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF customerfax ?>
-	  <br><?lsmb text('Fax: [_1]', customerfax) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF email ?>
-	  <br><?lsmb email ?>
-	  <?lsmb END ?>
-	  </td>
+          <?lsmb IF contact ?>
+          <br><?lsmb text('Attn: [_1]', contact) ?>
+          <?lsmb END ?>
+          <?lsmb IF customerphone ?>
+          <br><?lsmb text('Tel: [_1]', customerphone) ?>
+          <?lsmb END ?>
+          <?lsmb IF customerfax ?>
+          <br><?lsmb text('Fax: [_1]', customerfax) ?>
+          <?lsmb END ?>
+          <?lsmb IF email ?>
+          <br><?lsmb email ?>
+          <?lsmb END ?>
+          </td>
 
-	  <td><?lsmb shiptoname ?>
-	  <br><?lsmb shiptoaddress1 ?>
-	  <?lsmb IF shiptoaddress2 ?>
-	  <br><?lsmb shiptoaddress2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb shiptocity ?>
-	  <?lsmb IF shiptostate ?>
-	  , <?lsmb shiptostate ?>
-	  <?lsmb END ?>
+          <td><?lsmb shiptoname ?>
+          <br><?lsmb shiptoaddress1 ?>
+          <?lsmb IF shiptoaddress2 ?>
+          <br><?lsmb shiptoaddress2 ?>
+          <?lsmb END ?>
+          <br><?lsmb shiptocity ?>
+          <?lsmb IF shiptostate ?>
+          , <?lsmb shiptostate ?>
+          <?lsmb END ?>
           <?lsmb shiptozipcode ?>
-	  <?lsmb IF shiptocountry ?>
-	  <br><?lsmb shiptocountry ?>
-	  <?lsmb END ?>
-	  <br>
+          <?lsmb IF shiptocountry ?>
+          <br><?lsmb shiptocountry ?>
+          <?lsmb END ?>
+          <br>
           <?lsmb IF shiptocontact ?>
           <br><?lsmb shiptocontact ?>
           <?lsmb END ?>
-	  <?lsmb IF shiptophone ?>
-	  <br><?lsmb text('Tel: [_1]', shiptophone) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF shiptofax ?>
-	  <br><?lsmb text('Fax: [_1]', shiptofax) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF shiptoemail ?>
-	  <br><?lsmb shiptoemail ?>
-	  <?lsmb END ?>
-	  </td>
-	</tr>
+          <?lsmb IF shiptophone ?>
+          <br><?lsmb text('Tel: [_1]', shiptophone) ?>
+          <?lsmb END ?>
+          <?lsmb IF shiptofax ?>
+          <br><?lsmb text('Fax: [_1]', shiptofax) ?>
+          <?lsmb END ?>
+          <?lsmb IF shiptoemail ?>
+          <br><?lsmb shiptoemail ?>
+          <?lsmb END ?>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -94,69 +92,66 @@
   <tr height=5></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% border=1>
-	<tr>
-	  <th width=17% align=left nowrap><?lsmb text('Order #') ?></th>
-	  <th width=17% align=left><?lsmb text('Order Date') ?></th>
-	  <th width=17% align=left><?lsmb text('Required by') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Salesperson') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Shipping Point') ?></th>
-	  <th width=15% align=left nowrap><?lsmb text('Ship Via') ?></th>
-	</tr>
+        <tr>
+          <th width=17% align=left nowrap><?lsmb text('Order #') ?></th>
+          <th width=17% align=left><?lsmb text('Order Date') ?></th>
+          <th width=17% align=left><?lsmb text('Required by') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Salesperson') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Shipping Point') ?></th>
+          <th width=15% align=left nowrap><?lsmb text('Ship Via') ?></th>
+        </tr>
 
-	<tr>
-	  <td><?lsmb ordnumber ?></td>
-	  <td><?lsmb orddate ?></td>
-	  <td><?lsmb reqdate ?></td>
-	  <td><?lsmb employee ?></td>
-	  <td><?lsmb shippingpoint ?>&nbsp;</td>
-	  <td><?lsmb shipvia ?>&nbsp;</td>
-	</tr>
+        <tr>
+          <td><?lsmb ordnumber ?></td>
+          <td><?lsmb orddate ?></td>
+          <td><?lsmb reqdate ?></td>
+          <td><?lsmb employee ?></td>
+          <td><?lsmb shippingpoint ?>&nbsp;</td>
+          <td><?lsmb shipvia ?>&nbsp;</td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr bgcolor=000000>
-	  <th align=right><font color=ffffff><?lsmb text('Item') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
-	  <th><font color=ffffff><?lsmb text('Qty') ?></th>
-	  <th>&nbsp;</th>
+        <tr bgcolor=000000>
+          <th align=right><font color=ffffff><?lsmb text('Item') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
+          <th><font color=ffffff><?lsmb text('Qty') ?></th>
+          <th>&nbsp;</th>
            <th><font color=ffffff><?lsmb text('Bin') ?></th>
-	  <th><font color=ffffff><?lsmb text('Serial #') ?></th>
-	</tr>
+          <th><font color=ffffff><?lsmb text('Serial #') ?></th>
+        </tr>
 
-	<?lsmb FOREACH number ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr valign=top>
+        <?lsmb FOREACH number ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr valign=top>
           <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
-	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td align=right><?lsmb qty.${loop_count} ?></td>
-	  <td><?lsmb unit.${loop_count} ?></td>
+          <td><?lsmb number.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
+          <td align=right><?lsmb qty.${loop_count} ?></td>
+          <td><?lsmb unit.${loop_count} ?></td>
            <td><?lsmb bin.${loop_count} ?></td>
-	  <td><?lsmb serialnumber.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+          <td><?lsmb serialnumber.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
-	<tr>
-	  <td colspan=7><hr noshade></td>
-	</tr>
+        <tr>
+          <td colspan=7><hr noshade></td>
+        </tr>
 
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <?lsmb IF notes ?>
           <td><?lsmb  FOREACH P IN notes.split('\n\n') ?>

--- a/templates/xedemo/ap_transaction.html
+++ b/templates/xedemo/ap_transaction.html
@@ -9,9 +9,8 @@
 <table width="100%">
 
   <?lsmb INCLUDE letterhead ?>
-  
+
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -21,24 +20,23 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
         <tr valign=top>
           <td><?lsmb name ?>
           <br><?lsmb address1 ?>
-	  <?lsmb IF address2 ?>
+          <?lsmb IF address2 ?>
           <br><?lsmb address2 ?>
-	  <?lsmb END ?>
+          <?lsmb END ?>
           <br><?lsmb city ?>
-	  <?lsmb IF state ?>
-	  , <?lsmb state ?>
-	  <?lsmb END ?>
-	  <?lsmb zipcode ?>
-	  <?lsmb IF country ?>
-	  <br><?lsmb country ?>
-	  <?lsmb END ?>
+          <?lsmb IF state ?>
+          , <?lsmb state ?>
+          <?lsmb END ?>
+          <?lsmb zipcode ?>
+          <?lsmb IF country ?>
+          <br><?lsmb country ?>
+          <?lsmb END ?>
           <br>
 
           <?lsmb IF contact ?>
@@ -62,107 +60,104 @@
           <p><?lsmb text('Taxnumber: [_1]', vendortaxnumber) ?>
           <?lsmb END ?>
           </td>
-   
-	  <td align=right>
-	    <table>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Invoice #') ?></th>
-		<td><?lsmb invnumber ?></td>
-	      </tr>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Date') ?></th>
-		<td><?lsmb invdate ?></td>
-	      </tr>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Due') ?></th>
-		<td><?lsmb duedate ?></td>
-	      </tr>
-	      <?lsmb IF ponumber ?>
+
+          <td align=right>
+            <table>
+              <tr>
+                <th align=left nowrap><?lsmb text('Invoice #') ?></th>
+                <td><?lsmb invnumber ?></td>
+              </tr>
+              <tr>
+                <th align=left nowrap><?lsmb text('Date') ?></th>
+                <td><?lsmb invdate ?></td>
+              </tr>
+              <tr>
+                <th align=left nowrap><?lsmb text('Due') ?></th>
+                <td><?lsmb duedate ?></td>
+              </tr>
+              <?lsmb IF ponumber ?>
               <tr>
                 <th align=left><?lsmb text('PO #') ?></th>
-		<td><?lsmb ponumber ?>&nbsp;</td>
-	      </tr>
-	      <?lsmb END ?>
-	      <?lsmb IF ordnumber ?>
-	      <tr>
-		<th align=left><?lsmb text('Order #') ?></th>
-		<td><?lsmb ordnumber ?>&nbsp;</td>
-	      </tr>
-	      <?lsmb END ?>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Employee') ?></th>
-		<td><?lsmb employee ?>&nbsp;</td>
-	      </tr>
-	    </table>
-	  </td>
+                <td><?lsmb ponumber ?>&nbsp;</td>
+              </tr>
+              <?lsmb END ?>
+              <?lsmb IF ordnumber ?>
+              <tr>
+                <th align=left><?lsmb text('Order #') ?></th>
+                <td><?lsmb ordnumber ?>&nbsp;</td>
+              </tr>
+              <?lsmb END ?>
+              <tr>
+                <th align=left nowrap><?lsmb text('Employee') ?></th>
+                <td><?lsmb employee ?>&nbsp;</td>
+              </tr>
+            </table>
+          </td>
         </tr>
       </table>
     </td>
   </tr>
 
   <tr height=5></tr>
-  
+
   <tr>
-    <td>&nbsp;</td>
-  
+
     <td>
       <table>
-	<?lsmb FOREACH account ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr valign=top>
-	  <td><?lsmb accno.${loop_count} ?></td>
-	  <td><?lsmb account.${loop_count} ?></td>
-	  <td width=10> </td>
-	  <td align=right><?lsmb amount.${loop_count} ?></td>
-	  <td width=10> </td>
-	  <td><?lsmb description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td width=10> </td>
-	  <td><?lsmb projectnumber.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+        <?lsmb FOREACH account ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr valign=top>
+          <td><?lsmb accno.${loop_count} ?></td>
+          <td><?lsmb account.${loop_count} ?></td>
+          <td width=10> </td>
+          <td align=right><?lsmb amount.${loop_count} ?></td>
+          <td width=10> </td>
+          <td><?lsmb description.${loop_count}.replace("\n","<br />") ?></td>
+          <td width=10> </td>
+          <td><?lsmb projectnumber.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
-	<tr>
-	  <?lsmb IF taxincluded ?>
-	  <th colspan=2 align=right><?lsmb text('Total') ?></th>
-	  <td width=10> </td>
-	  <td align=right><?lsmb invtotal ?></td>
-	  <?lsmb ELSE ?>
-	  <th colspan=2 align=right><?lsmb text('Subtotal') ?></th>
-	  <td width=10> </td>
-	  <td align=right><?lsmb subtotal ?></td>
-	  <?lsmb END ?>
-	</tr>
+        <tr>
+          <?lsmb IF taxincluded ?>
+          <th colspan=2 align=right><?lsmb text('Total') ?></th>
+          <td width=10> </td>
+          <td align=right><?lsmb invtotal ?></td>
+          <?lsmb ELSE ?>
+          <th colspan=2 align=right><?lsmb text('Subtotal') ?></th>
+          <td width=10> </td>
+          <td align=right><?lsmb subtotal ?></td>
+          <?lsmb END ?>
+        </tr>
 
-	<?lsmb FOREACH tax ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr>
-	  <th colspan=2 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
-	  <td width=10> </td>
-	  <td align=right><?lsmb tax.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
-	
-	<?lsmb IF NOT taxincluded ?>
-	<tr>
-	  <th colspan=2 align=right><?lsmb text('Total') ?></th>
-	  <td width=10> </td>
-	  <td align=right><?lsmb invtotal ?></td>
-	</tr>
-	<?lsmb END ?>
+        <?lsmb FOREACH tax ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr>
+          <th colspan=2 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+          <td width=10> </td>
+          <td align=right><?lsmb tax.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
+
+        <?lsmb IF NOT taxincluded ?>
+        <tr>
+          <th colspan=2 align=right><?lsmb text('Total') ?></th>
+          <td width=10> </td>
+          <td align=right><?lsmb invtotal ?></td>
+        </tr>
+        <?lsmb END ?>
       </table>
     </td>
   </tr>
-  
+
   <tr>
-    <td>&nbsp;</td>
-    
+
     <td>
       <?lsmb text_amount ?> ***** <?lsmb decimal ?>/100 <?lsmb currency ?>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
           <td><?lsmb  FOREACH P IN notes.split('\n\n') ?>
                     <p><?lsmb P ?></p>
@@ -171,7 +166,6 @@
 
   <?lsmb IF paid_1 ?>
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table>
@@ -185,32 +179,32 @@
           </td>
         </tr>
 
-	<tr>
-	  <td>
-	    <table>
-	      <tr>
-		<th><?lsmb text('Date') ?></th>
-		<th>&nbsp;</th>
-		<th><?lsmb text('Source') ?></th>
-		<th><?lsmb text('Memo') ?></th>
-		<th><?lsmb text('Amount') ?></th>
-	      </tr>
+        <tr>
+          <td>
+            <table>
+              <tr>
+                <th><?lsmb text('Date') ?></th>
+                <th>&nbsp;</th>
+                <th><?lsmb text('Source') ?></th>
+                <th><?lsmb text('Memo') ?></th>
+                <th><?lsmb text('Amount') ?></th>
+              </tr>
   <?lsmb END ?>
 
         <?lsmb FOREACH payment ?>
         <?lsmb loop_count = loop.count - 1 ?>
-	      <tr>
-		<td><?lsmb paymentdate.${loop_count} ?></td>
-		<td><?lsmb paymentaccount.${loop_count} ?></td>
-		<td><?lsmb paymentsource.${loop_count} ?></td>
-		<td><?lsmb paymentmemo.${loop_count} ?></td>
-		<td align=right><?lsmb payment.${loop_count} ?></td>
-	      </tr>
+              <tr>
+                <td><?lsmb paymentdate.${loop_count} ?></td>
+                <td><?lsmb paymentaccount.${loop_count} ?></td>
+                <td><?lsmb paymentsource.${loop_count} ?></td>
+                <td><?lsmb paymentmemo.${loop_count} ?></td>
+                <td align=right><?lsmb payment.${loop_count} ?></td>
+              </tr>
         <?lsmb END ?>
 
   <?lsmb IF paid_1 ?>
-	    </table>
-	  </td>
+            </table>
+          </td>
         </tr>
       </table>
     </td>
@@ -221,7 +215,6 @@
 
   <?lsmb IF taxincluded ?>
   <tr>
-    <td>&nbsp;</td>
   </tr>
 
   <tr>

--- a/templates/xedemo/ar_transaction.html
+++ b/templates/xedemo/ar_transaction.html
@@ -11,7 +11,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -20,24 +19,23 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
         <tr valign=top>
           <td><?lsmb name ?>
           <br><?lsmb address1 ?>
-	  <?lsmb IF address2 ?>
+          <?lsmb IF address2 ?>
           <br><?lsmb address2 ?>
-	  <?lsmb END ?>
+          <?lsmb END ?>
           <br><?lsmb city ?>
-	  <?lsmb IF state ?>
-	  , <?lsmb state ?>
-	  <?lsmb END ?>
-	  <?lsmb zipcode ?>
-	  <?lsmb IF country ?>
-	  <br><?lsmb country ?>
-	  <?lsmb END ?>
+          <?lsmb IF state ?>
+          , <?lsmb state ?>
+          <?lsmb END ?>
+          <?lsmb zipcode ?>
+          <?lsmb IF country ?>
+          <br><?lsmb country ?>
+          <?lsmb END ?>
           <br>
 
           <?lsmb IF contact ?>
@@ -61,99 +59,97 @@
           <br><?lsmb text('Taxnumber:') _ ' ' _ customertaxnumber ?>
           <?lsmb END ?>
           </td>
-   
-	  <td align=right>
-	    <table>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Invoice #') ?></th>
-		<td><?lsmb invnumber ?></td>
-	      </tr>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Date') ?></th>
-		<td><?lsmb invdate ?></td>
-	      </tr>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Due') ?></th>
-		<td><?lsmb duedate ?></td>
-	      </tr>
-	      <?lsmb IF ponumber ?>
+
+          <td align=right>
+            <table>
+              <tr>
+                <th align=left nowrap><?lsmb text('Invoice #') ?></th>
+                <td><?lsmb invnumber ?></td>
+              </tr>
+              <tr>
+                <th align=left nowrap><?lsmb text('Date') ?></th>
+                <td><?lsmb invdate ?></td>
+              </tr>
+              <tr>
+                <th align=left nowrap><?lsmb text('Due') ?></th>
+                <td><?lsmb duedate ?></td>
+              </tr>
+              <?lsmb IF ponumber ?>
               <tr>
                 <th align=left><?lsmb text('PO #') ?></th>
-		<td><?lsmb ponumber ?>&nbsp;</td>
-	      </tr>
-	      <?lsmb END ?>
-	      <?lsmb IF ordnumber ?>
-	      <tr>
-		<th align=left><?lsmb text('Order #') ?></th>
-		<td><?lsmb ordnumber ?>&nbsp;</td>
-	      </tr>
-	      <?lsmb END ?>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Salesperson') ?></th>
-		<td><?lsmb employee ?>&nbsp;</td>
-	      </tr>
-	    </table>
-	  </td>
+                <td><?lsmb ponumber ?>&nbsp;</td>
+              </tr>
+              <?lsmb END ?>
+              <?lsmb IF ordnumber ?>
+              <tr>
+                <th align=left><?lsmb text('Order #') ?></th>
+                <td><?lsmb ordnumber ?>&nbsp;</td>
+              </tr>
+              <?lsmb END ?>
+              <tr>
+                <th align=left nowrap><?lsmb text('Salesperson') ?></th>
+                <td><?lsmb employee ?>&nbsp;</td>
+              </tr>
+            </table>
+          </td>
         </tr>
       </table>
     </td>
   </tr>
 
   <tr height=5></tr>
-  
+
   <tr>
-    <td>&nbsp;</td>
-  
+
     <td>
       <table>
-	<?lsmb FOREACH account ?>
+        <?lsmb FOREACH account ?>
         <?lsmb loop_count = loop.count - 1 ?>
-	<tr valign=top>
-	  <td><?lsmb accno.${loop_count} ?></td>
-	  <td><?lsmb account.${loop_count} ?></td>
-	  <td width=10>&nbsp;</td>
-	  <td align=right><?lsmb amount.${loop_count} ?></td>
-	  <td width=10>&nbsp;</td>
-	  <td><?lsmb description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td width=10>&nbsp;</td>
-	  <td><?lsmb projectnumber.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+        <tr valign=top>
+          <td><?lsmb accno.${loop_count} ?></td>
+          <td><?lsmb account.${loop_count} ?></td>
+          <td width=10>&nbsp;</td>
+          <td align=right><?lsmb amount.${loop_count} ?></td>
+          <td width=10>&nbsp;</td>
+          <td><?lsmb description.${loop_count}.replace("\n","<br />") ?></td>
+          <td width=10>&nbsp;</td>
+          <td><?lsmb projectnumber.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
-	<tr>
-	  <?lsmb IF taxincluded ?>
-	  <th colspan=2 align=right><?lsmb text('Total') ?></th>
-	  <td width=10>&nbsp;</td>
-	  <td align=right><?lsmb invtotal ?></td>
-	  <?lsmb ELSE ?>
-	  <th colspan=2 align=right><?lsmb text('Subtotal') ?></th>
-	  <td width=10>&nbsp;</td>
-	  <td align=right><?lsmb subtotal ?></td>
-	  <?lsmb END ?>
-	</tr>
+        <tr>
+          <?lsmb IF taxincluded ?>
+          <th colspan=2 align=right><?lsmb text('Total') ?></th>
+          <td width=10>&nbsp;</td>
+          <td align=right><?lsmb invtotal ?></td>
+          <?lsmb ELSE ?>
+          <th colspan=2 align=right><?lsmb text('Subtotal') ?></th>
+          <td width=10>&nbsp;</td>
+          <td align=right><?lsmb subtotal ?></td>
+          <?lsmb END ?>
+        </tr>
 
-	<?lsmb FOREACH tax ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr>
-	  <th colspan=2 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
-	  <td width=10>&nbsp;</td>
-	  <td align=right><?lsmb tax.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
-	
-	<?lsmb IF NOT taxincluded ?>
-	<tr>
-	  <th colspan=2 align=right><?lsmb text('Total') ?></th>
-	  <td width=10>&nbsp;</td>
-	  <td align=right><?lsmb invtotal ?></td>
-	</tr>
-	<?lsmb END ?>
+        <?lsmb FOREACH tax ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr>
+          <th colspan=2 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+          <td width=10>&nbsp;</td>
+          <td align=right><?lsmb tax.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
+
+        <?lsmb IF NOT taxincluded ?>
+        <tr>
+          <th colspan=2 align=right><?lsmb text('Total') ?></th>
+          <td width=10>&nbsp;</td>
+          <td align=right><?lsmb invtotal ?></td>
+        </tr>
+        <?lsmb END ?>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <?lsmb text_amount ?> ***** <?lsmb decimal ?>/100 <?lsmb currency ?>
@@ -161,7 +157,6 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
           <td><?lsmb  FOREACH P IN notes.split('\n\n') ?>
                     <p><?lsmb P ?></p>
@@ -170,7 +165,6 @@
 
   <?lsmb IF paid_1 ?>
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table>
@@ -184,30 +178,30 @@
           </td>
         </tr>
 
-	<tr>
-	  <td>
-	    <table>
-	      <tr>
-		<th><?lsmb text('Date') ?></th>
-		<th>&nbsp;</th>
-		<th><?lsmb text('Source') ?></th>
-		<th><?lsmb text('Amount') ?></th>
-	      </tr>
+        <tr>
+          <td>
+            <table>
+              <tr>
+                <th><?lsmb text('Date') ?></th>
+                <th>&nbsp;</th>
+                <th><?lsmb text('Source') ?></th>
+                <th><?lsmb text('Amount') ?></th>
+              </tr>
   <?lsmb END ?>
 
         <?lsmb FOREACH payment ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	      <tr>
-		<td><?lsmb paymentdate.${loop_count} ?></td>
-		<td><?lsmb paymentaccount.${loop_count} ?></td>
-		<td><?lsmb paymentsource.${loop_count} ?></td>
-		<td align=right><?lsmb payment.${loop_count} ?></td>
-	      </tr>
+        <?lsmb loop_count = loop.count - 1 ?>
+              <tr>
+                <td><?lsmb paymentdate.${loop_count} ?></td>
+                <td><?lsmb paymentaccount.${loop_count} ?></td>
+                <td><?lsmb paymentsource.${loop_count} ?></td>
+                <td align=right><?lsmb payment.${loop_count} ?></td>
+              </tr>
         <?lsmb END ?>
 
   <?lsmb IF paid_1 ?>
-	    </table>
-	  </td>
+            </table>
+          </td>
         </tr>
       </table>
     </td>
@@ -219,7 +213,6 @@
   <?lsmb FOREACH tax ?>
   <?lsmb loop_count = loop.count - 1 ?>
   <tr>
-    <td>&nbsp;</td>
 
     <th colspan=9 align=left><font size=-2><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> <?lsmb text('Registration') _ ' ' _  taxnumber.${loop_count} ?></th>
   </tr>
@@ -227,7 +220,6 @@
 
   <?lsmb IF taxincluded ?>
   <tr>
-    <td>&nbsp;</td>
   </tr>
 
   <tr>

--- a/templates/xedemo/bin_list.html
+++ b/templates/xedemo/bin_list.html
@@ -11,7 +11,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -20,79 +19,78 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
-	<tr bgcolor=000000>
-	  <th align=left width="50%"><font color=ffffff><?lsmb text('From') ?>
+        <tr bgcolor=000000>
+          <th align=left width="50%"><font color=ffffff><?lsmb text('From') ?>
           </th>
-	  <th align=left width="50%"><font color=ffffff><?lsmb text('Ship To') ?>
+          <th align=left width="50%"><font color=ffffff><?lsmb text('Ship To') ?>
           </th>
-	</tr>
+        </tr>
 
-	<tr valign=top>
-	  <td><?lsmb name ?>
-	  <br><?lsmb address1 ?>
-	  <?lsmb IF address2 ?>
+        <tr valign=top>
+          <td><?lsmb name ?>
+          <br><?lsmb address1 ?>
+          <?lsmb IF address2 ?>
           <br><?lsmb address2 ?>
           <?lsmb END ?>
-	  <br><?lsmb city ?>
-	  <?lsmb IF state ?>
-	  , <?lsmb state ?>
-	  <?lsmb END ?>
-	  <?lsmb zipcode ?>
-	  <?lsmb IF country ?>
+          <br><?lsmb city ?>
+          <?lsmb IF state ?>
+          , <?lsmb state ?>
+          <?lsmb END ?>
+          <?lsmb zipcode ?>
+          <?lsmb IF country ?>
           <?lsmb country ?>
           <?lsmb END ?>
-	  <br>
+          <br>
 
-	  <?lsmb IF contact ?>
-	  <br><?lsmb text('Attn: [_1]', contact) ?>
-	  <?lsmb END ?>
+          <?lsmb IF contact ?>
+          <br><?lsmb text('Attn: [_1]', contact) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF vendorphone ?>
-	  <br><?lsmb text('Tel: [_1]', vendorphone) ?>
-	  <?lsmb END ?>
+          <?lsmb IF vendorphone ?>
+          <br><?lsmb text('Tel: [_1]', vendorphone) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF vendorfax ?>
-	  <br><?lsmb text('Fax: [_1]', vendorfax) ?>
-	  <?lsmb END ?>
+          <?lsmb IF vendorfax ?>
+          <br><?lsmb text('Fax: [_1]', vendorfax) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF email ?>
-	  <br><?lsmb email ?>
-	  <?lsmb END ?>
+          <?lsmb IF email ?>
+          <br><?lsmb email ?>
+          <?lsmb END ?>
 
-	  </td>
+          </td>
 
-	  <td><?lsmb shiptoname ?>
-	  <br><?lsmb shiptoaddress1 ?>
-	  <?lsmb IF shiptoaddress2 ?>
+          <td><?lsmb shiptoname ?>
+          <br><?lsmb shiptoaddress1 ?>
+          <?lsmb IF shiptoaddress2 ?>
           <br><?lsmb shiptoaddress2 ?>
           <?lsmb END ?>
-	  <br><?lsmb shiptocity ?>
-	  <?lsmb IF shiptostate ?>
-	  , <?lsmb shiptostate ?>
-	  <?lsmb END ?>
-	  <?lsmb shiptozipcode ?>
-	  <?lsmb IF shiptocountry ?>
+          <br><?lsmb shiptocity ?>
+          <?lsmb IF shiptostate ?>
+          , <?lsmb shiptostate ?>
+          <?lsmb END ?>
+          <?lsmb shiptozipcode ?>
+          <?lsmb IF shiptocountry ?>
           <?lsmb shiptocountry ?>
           <?lsmb END ?>
 
-	  <br>
-	  <?lsmb IF shiptocontact ?>
-	  <br><?lsmb text('Attn: [_1]', shiptocontact) ?>
-	  <?lsmb END ?>
+          <br>
+          <?lsmb IF shiptocontact ?>
+          <br><?lsmb text('Attn: [_1]', shiptocontact) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF shiptophone ?>
-	  <br><?lsmb text('Tel: [_1]', shiptophone) ?>
-	  <?lsmb END ?>
+          <?lsmb IF shiptophone ?>
+          <br><?lsmb text('Tel: [_1]', shiptophone) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF shiptofax ?>
-	  <br><?lsmb text('Fax: [_1]', shiptofax) ?>
-	  <?lsmb END ?>
-	  </td>
-	</tr>
+          <?lsmb IF shiptofax ?>
+          <br><?lsmb text('Fax: [_1]', shiptofax) ?>
+          <?lsmb END ?>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -100,81 +98,78 @@
   <tr height=5></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% border=1>
-	<tr>
-	  <th width=17% align=left nowrap><?lsmb text('Order #') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Date') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Contact') ?></th>
-	  <?lsmb IF warehouse ?>
-	  <th width=17% align=left nowrap><?lsmb text('Warehouse') ?></th>
-	  <?lsmb END ?>
-	  <th width=17% align=left><?lsmb text('Shipping Point') ?></th>
-	  <th width=15% align=left><?lsmb text('Ship via') ?></th>
-	</tr>
+        <tr>
+          <th width=17% align=left nowrap><?lsmb text('Order #') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Date') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Contact') ?></th>
+          <?lsmb IF warehouse ?>
+          <th width=17% align=left nowrap><?lsmb text('Warehouse') ?></th>
+          <?lsmb END ?>
+          <th width=17% align=left><?lsmb text('Shipping Point') ?></th>
+          <th width=15% align=left><?lsmb text('Ship via') ?></th>
+        </tr>
 
-	<tr>
-	  <td><?lsmb ordnumber ?>&nbsp;</td>
+        <tr>
+          <td><?lsmb ordnumber ?>&nbsp;</td>
 
-	  <?lsmb IF shippingdate ?>
-	  <td><?lsmb shippingdate ?></td>
-	  <?lsmb ELSE ?>
-	  <td><?lsmb orddate ?></td>
-	  <?lsmb END ?>
+          <?lsmb IF shippingdate ?>
+          <td><?lsmb shippingdate ?></td>
+          <?lsmb ELSE ?>
+          <td><?lsmb orddate ?></td>
+          <?lsmb END ?>
 
-	  <td><?lsmb employee ?>&nbsp;</td>
+          <td><?lsmb employee ?>&nbsp;</td>
 
-	  <?lsmb IF warehouse ?>
-	  <td><?lsmb warehouse ?></td>
-	  <?lsmb END ?>
+          <?lsmb IF warehouse ?>
+          <td><?lsmb warehouse ?></td>
+          <?lsmb END ?>
 
-	  <td><?lsmb shippingpoint ?>&nbsp;</td>
-	  <td><?lsmb shipvia ?>&nbsp;</td>
-	</tr>
+          <td><?lsmb shippingpoint ?>&nbsp;</td>
+          <td><?lsmb shipvia ?>&nbsp;</td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr bgcolor=000000>
-	  <th align=left><font color=ffffff><?lsmb text('Item') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
-	  <th><font color=ffffff><?lsmb text('Serialnumber') ?></th>
-	  <th>&nbsp;</th>
-	  <th><font color=ffffff><?lsmb text('Qty') ?></th>
-	  <th><font color=ffffff><?lsmb text('Recd') ?></th>
-	  <th>&nbsp;</th>
-	  <th><font color=ffffff><?lsmb text('Bin') ?></th>
-	</tr>
+        <tr bgcolor=000000>
+          <th align=left><font color=ffffff><?lsmb text('Item') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
+          <th><font color=ffffff><?lsmb text('Serialnumber') ?></th>
+          <th>&nbsp;</th>
+          <th><font color=ffffff><?lsmb text('Qty') ?></th>
+          <th><font color=ffffff><?lsmb text('Recd') ?></th>
+          <th>&nbsp;</th>
+          <th><font color=ffffff><?lsmb text('Bin') ?></th>
+        </tr>
 
-	<?lsmb FOREACH number ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr valign=top>
-	  <td><?lsmb runningnumber.${loop_count} ?></td>
-	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td><?lsmb serialnumber.${loop_count} ?></td>
-	  <td><?lsmb deliverydate.${loop_count} ?></td>
-	  <td align=right><?lsmb qty.${loop_count} ?></td>
-	  <td align=right><?lsmb ship.${loop_count} ?></td>
-	  <td><?lsmb unit.${loop_count} ?></td>
-	  <td><?lsmb bin.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+        <?lsmb FOREACH number ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr valign=top>
+          <td><?lsmb runningnumber.${loop_count} ?></td>
+          <td><?lsmb number.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
+          <td><?lsmb serialnumber.${loop_count} ?></td>
+          <td><?lsmb deliverydate.${loop_count} ?></td>
+          <td align=right><?lsmb qty.${loop_count} ?></td>
+          <td align=right><?lsmb ship.${loop_count} ?></td>
+          <td><?lsmb unit.${loop_count} ?></td>
+          <td><?lsmb bin.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td><hr noshade></td>
   </tr>

--- a/templates/xedemo/invoice.html
+++ b/templates/xedemo/invoice.html
@@ -8,9 +8,8 @@
 <table width="100%">
 
   <?lsmb INCLUDE letterhead ?>
-  
+
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -20,7 +19,6 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
@@ -102,10 +100,9 @@
   </tr>
 
   <tr height=5></tr>
-  
+
   <tr>
-    <td>&nbsp;</td>
-  
+
     <td>
       <table width=100% border=1>
         <tr>
@@ -132,8 +129,7 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
-  
+
     <td>
       <table width="100%">
         <tr bgcolor=000000>
@@ -166,7 +162,7 @@
         <tr>
           <td colspan=9><hr noshade></td>
         </tr>
-    
+
           <?lsmb IF tax; ?>
         <tr>
           <th colspan=7 align=right><?lsmb text('Subtotal') ?></th>
@@ -211,7 +207,6 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
@@ -223,7 +218,7 @@
           <?lsmb END ?>
 
           <td><?lsmb text_amount ?> ***** <?lsmb decimal ?>/100</td>
-          
+
           <td align=right nowrap>
           <?lsmb text('All prices in [_1]', currency) ?>
           </td>
@@ -234,7 +229,6 @@
 
   <?lsmb IF paymentdate.0 ?>
   <tr>
-    <td>&nbsp;</td>
 
     <td colspan=9>
       <table width="60%">
@@ -274,7 +268,6 @@
   <tr height=10></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <th>
     <?lsmb text('Thank you for your valued business!') ?>
@@ -282,7 +275,6 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
@@ -304,7 +296,6 @@
   <?lsmb FOREACH tax ?>
   <?lsmb loop_count = loop.count - 1 ?>
   <tr>
-    <td>&nbsp;</td>
 
     <th colspan=9 align=left><font size=-2><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> <?lsmb text('Registration [_1]', taxnumber.${loop_count}) ?></th>
   </tr>
@@ -312,7 +303,6 @@
 
   <?lsmb IF taxincluded ?>
   <tr>
-    <td>&nbsp;</td>
   </tr>
 
   <tr>

--- a/templates/xedemo/letterhead.html
+++ b/templates/xedemo/letterhead.html
@@ -1,6 +1,4 @@
   <tr>
-    <td width=10>&nbsp;</td>
-
     <td>
       <table width="100%">
         <tr>
@@ -11,7 +9,7 @@
             </h4>
           </td>
           <!-- Commenting out the image tag for now.  In general, folks can
-               customize this to their servers, but if the server is behind a 
+               customize this to their servers, but if the server is behind a
                firewall, then this won't work.  Recommend that if people do this,
                they hardwire in a link to a publically accessible image. - CT -->
           <th><!-- <img src=<?lsmb images ?>/logo.png border=0 height=58> --></th>
@@ -26,7 +24,7 @@
 
         <tr>
           <td colspan=3>
-	    <hr noshade>
+            <hr noshade>
           </td>
         </tr>
       </table>

--- a/templates/xedemo/packing_list.html
+++ b/templates/xedemo/packing_list.html
@@ -11,7 +11,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -20,49 +19,48 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
-	<tr bgcolor=000000>
-	  <th width=50% align=left><font color=ffffff>
+        <tr bgcolor=000000>
+          <th width=50% align=left><font color=ffffff>
                <?lsmb text('Ship To:') ?>
           </th>
-	  <th width="50%">&nbsp;</th>
-	</tr>
+          <th width="50%">&nbsp;</th>
+        </tr>
 
-	<tr valign=top>
-	  <td><?lsmb shiptoname ?>
-	  <br><?lsmb shiptoaddress1 ?>
-	  <?lsmb IF shiptoaddress2 ?>
-	  <br><?lsmb shiptoaddress2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb shiptocity ?>
-	  <?lsmb IF shiptostate ?>
-	  , <?lsmb shiptostate ?>
-	  <?lsmb END ?>
-	  <?lsmb shiptozipcode ?>
-	  <?lsmb IF shiptocountry ?>
-	  <br><?lsmb shiptocountry ?>
-	  <?lsmb END ?>
-	  </td>
+        <tr valign=top>
+          <td><?lsmb shiptoname ?>
+          <br><?lsmb shiptoaddress1 ?>
+          <?lsmb IF shiptoaddress2 ?>
+          <br><?lsmb shiptoaddress2 ?>
+          <?lsmb END ?>
+          <br><?lsmb shiptocity ?>
+          <?lsmb IF shiptostate ?>
+          , <?lsmb shiptostate ?>
+          <?lsmb END ?>
+          <?lsmb shiptozipcode ?>
+          <?lsmb IF shiptocountry ?>
+          <br><?lsmb shiptocountry ?>
+          <?lsmb END ?>
+          </td>
 
-	  <td>
-	  <?lsmb IF shiptocontact ?>
-	  <br><?lsmb text('Attn: [_1]', shiptocontact) ?>
-	  <?lsmb END ?>
+          <td>
+          <?lsmb IF shiptocontact ?>
+          <br><?lsmb text('Attn: [_1]', shiptocontact) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF shiptophone ?>
-	  <br><?lsmb text('Tel: [_1]', shiptophone) ?>
-	  <?lsmb END ?>
+          <?lsmb IF shiptophone ?>
+          <br><?lsmb text('Tel: [_1]', shiptophone) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF shiptofax ?>
-	  <br><?lsmb text('Fax: [_1]', shiptofax) ?>
-	  <?lsmb END ?>
+          <?lsmb IF shiptofax ?>
+          <br><?lsmb text('Fax: [_1]', shiptofax) ?>
+          <?lsmb END ?>
 
-	  <?lsmb shiptoemail ?>
-	  </td>
-	</tr>
+          <?lsmb shiptoemail ?>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -70,116 +68,111 @@
   <tr height=5></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% border=1>
-	<tr>
-	  <th width=17% align=left><?lsmb text('Invoice #') ?></th>
-	  <th width=17% align=left><?lsmb text('Order #') ?></th>
-	  <th width=17% align=left><?lsmb text('Date') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Contact') ?></th>
-	  <?lsmb IF warehouse ?>
-	  <th width=17% align=left><?lsmb text('Warehouse') ?></th>
-	  <?lsmb END ?>
-	  <th width=17% align=left><?lsmb text('Shipping Point') ?></th>
-	  <th width=15% align=left><?lsmb text('Ship via') ?></th>
-	</tr>
+        <tr>
+          <th width=17% align=left><?lsmb text('Invoice #') ?></th>
+          <th width=17% align=left><?lsmb text('Order #') ?></th>
+          <th width=17% align=left><?lsmb text('Date') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Contact') ?></th>
+          <?lsmb IF warehouse ?>
+          <th width=17% align=left><?lsmb text('Warehouse') ?></th>
+          <?lsmb END ?>
+          <th width=17% align=left><?lsmb text('Shipping Point') ?></th>
+          <th width=15% align=left><?lsmb text('Ship via') ?></th>
+        </tr>
 
         <tr>
-	  <td><?lsmb invnumber ?>&nbsp;</td>
-	  <td><?lsmb ordnumber ?>&nbsp;</td>
+          <td><?lsmb invnumber ?>&nbsp;</td>
+          <td><?lsmb ordnumber ?>&nbsp;</td>
 
-	  <?lsmb IF shippingdate ?>
-	  <td><?lsmb shippingdate ?></td>
-	  <?lsmb ELSE ?>
-	  <td><?lsmb transdate ?></td>
-	  <?lsmb END ?>
+          <?lsmb IF shippingdate ?>
+          <td><?lsmb shippingdate ?></td>
+          <?lsmb ELSE ?>
+          <td><?lsmb transdate ?></td>
+          <?lsmb END ?>
 
           <td><?lsmb employee ?>&nbsp;</td>
 
-	  <?lsmb IF warehouse ?>
-	  <td><?lsmb warehouse ?>&nbsp;</td>
-	  <?lsmb END ?>
+          <?lsmb IF warehouse ?>
+          <td><?lsmb warehouse ?>&nbsp;</td>
+          <?lsmb END ?>
 
-	  <td><?lsmb shippingpoint ?>&nbsp;</td>
-	  <td><?lsmb shipvia ?>&nbsp;</td>
-	</tr>
+          <td><?lsmb shippingpoint ?>&nbsp;</td>
+          <td><?lsmb shipvia ?>&nbsp;</td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr bgcolor=000000>
-	  <th align=left><font color=ffffff><?lsmb text('Item') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Serial #') ?></th>
-	  <th>&nbsp;</th>
-	  <th><font color=ffffff><?lsmb text('Qty') ?></th>
-	  <th><font color=ffffff><?lsmb text('Ship') ?></th>
-	  <th>&nbsp;</th>
-	</tr>
+        <tr bgcolor=000000>
+          <th align=left><font color=ffffff><?lsmb text('Item') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Serial #') ?></th>
+          <th>&nbsp;</th>
+          <th><font color=ffffff><?lsmb text('Qty') ?></th>
+          <th><font color=ffffff><?lsmb text('Ship') ?></th>
+          <th>&nbsp;</th>
+        </tr>
 
-	<?lsmb FOREACH number ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr valign=top>
-	  <td><?lsmb runningnumber.${loop_count} ?></td>
-	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td><?lsmb serialnumber.${loop_count} ?></td>
-	  <td><?lsmb deliverydate.${loop_count} ?></td>
-	  <td align=right><?lsmb qty.${loop_count} ?></td>
-	  <td align=right><?lsmb ship.${loop_count} ?></td>
-	  <td><?lsmb unit.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+        <?lsmb FOREACH number ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr valign=top>
+          <td><?lsmb runningnumber.${loop_count} ?></td>
+          <td><?lsmb number.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
+          <td><?lsmb serialnumber.${loop_count} ?></td>
+          <td><?lsmb deliverydate.${loop_count} ?></td>
+          <td align=right><?lsmb qty.${loop_count} ?></td>
+          <td align=right><?lsmb ship.${loop_count} ?></td>
+          <td><?lsmb unit.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td><hr noshade></td>
   </tr>
 
   <?lsmb IF notes ?>
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr valign=top>
-	  <td>Notes</td>
+        <tr valign=top>
+          <td>Notes</td>
           <td><?lsmb  FOREACH P IN notes.split('\n\n') ?>
                     <p><?lsmb P ?></p>
                <?lsmb END ?></td>
-	</tr>
+        </tr>
       </table>
     </td>
   </tr>
   <?lsmb END ?>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr valign=top>
-	  <td width="70%"><font size=-3>
-	  <?lsmb text('Items returned are subject to a 10% restocking charge. A return authorization must be obtained from [_1] before goods are returned. Returns must be shipped prepaid and properly insured. [_1] will not be responsible for damages during transit.', company) ?>
-	  </font>
-	  </td>
-	  <td width="30%">
-	  X <hr noshade>
-	  </td>
-	</tr>
+        <tr valign=top>
+          <td width="70%"><font size=-3>
+          <?lsmb text('Items returned are subject to a 10% restocking charge. A return authorization must be obtained from [_1] before goods are returned. Returns must be shipped prepaid and properly insured. [_1] will not be responsible for damages during transit.', company) ?>
+          </font>
+          </td>
+          <td width="30%">
+          X <hr noshade>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>

--- a/templates/xedemo/pick_list.html
+++ b/templates/xedemo/pick_list.html
@@ -11,7 +11,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -20,48 +19,47 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
         <tr bgcolor=000000>
-	  <th width=50% align=left><font color=ffffff><?lsmb text('Ship To:')
+          <th width=50% align=left><font color=ffffff><?lsmb text('Ship To:')
           ?></th>
-	  <th width="50%">&nbsp;</th>
-	</tr>
+          <th width="50%">&nbsp;</th>
+        </tr>
 
-	<tr valign=top>
-	  <td><?lsmb shiptoname ?>
-	  <br><?lsmb shiptoaddress1 ?>
-	  <?lsmb IF shiptoaddress2 ?>
-	  <br><?lsmb shiptoaddress2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb shiptocity ?>
-	  <?lsmb IF shiptostate ?>
-	  , <?lsmb shiptostate ?>
-	  <?lsmb END ?>
-	  <?lsmb shiptozipcode ?>
-	  <?lsmb IF shiptocountry ?>
-	  <br><?lsmb shiptocountry ?>
-	  <?lsmb END ?>
-	  </td>
+        <tr valign=top>
+          <td><?lsmb shiptoname ?>
+          <br><?lsmb shiptoaddress1 ?>
+          <?lsmb IF shiptoaddress2 ?>
+          <br><?lsmb shiptoaddress2 ?>
+          <?lsmb END ?>
+          <br><?lsmb shiptocity ?>
+          <?lsmb IF shiptostate ?>
+          , <?lsmb shiptostate ?>
+          <?lsmb END ?>
+          <?lsmb shiptozipcode ?>
+          <?lsmb IF shiptocountry ?>
+          <br><?lsmb shiptocountry ?>
+          <?lsmb END ?>
+          </td>
 
-	  <td>
-	  <?lsmb IF shiptocontact ?>
-	  <br><?lsmb text('Attn: [_1]', shiptocontact) ?>
-	  <?lsmb END ?>
+          <td>
+          <?lsmb IF shiptocontact ?>
+          <br><?lsmb text('Attn: [_1]', shiptocontact) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF shiptophone ?>
-	  <br><?lsmb text('Tel: [_1]', shiptophone) ?>
-	  <?lsmb END ?>
+          <?lsmb IF shiptophone ?>
+          <br><?lsmb text('Tel: [_1]', shiptophone) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF shiptofax ?>
-	  <br><?lsmb text('Fax: [_1]', shiptofax) ?>
-	  <?lsmb END ?>
+          <?lsmb IF shiptofax ?>
+          <br><?lsmb text('Fax: [_1]', shiptofax) ?>
+          <?lsmb END ?>
 
-	  <?lsmb shiptoemail ?>
-	  </td>
-	</tr>
+          <?lsmb shiptoemail ?>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -69,71 +67,68 @@
   <tr height=5></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% border=1>
         <tr>
-	  <th width=15% align=left><?lsmb text('Invoice #') ?></th>
-	  <th width=15% align=left><?lsmb text('Order #') ?></th>
-	  <th width=10% align=left><?lsmb text('Date') ?></th>
-	  <th width=15% align=left nowrap><?lsmb text('Contact') ?></th>
-	  <th width=15% align=left><?lsmb text('Warehouse') ?></th>
-	  <th width=10% align=left><?lsmb text('Shipping Point') ?></th>
-	  <th width=10% align=left><?lsmb text('Ship via') ?></th>
-	</tr>
+          <th width=15% align=left><?lsmb text('Invoice #') ?></th>
+          <th width=15% align=left><?lsmb text('Order #') ?></th>
+          <th width=10% align=left><?lsmb text('Date') ?></th>
+          <th width=15% align=left nowrap><?lsmb text('Contact') ?></th>
+          <th width=15% align=left><?lsmb text('Warehouse') ?></th>
+          <th width=10% align=left><?lsmb text('Shipping Point') ?></th>
+          <th width=10% align=left><?lsmb text('Ship via') ?></th>
+        </tr>
 
         <tr>
-	  <td><?lsmb invnumber ?>&nbsp;</td>
-	  <td><?lsmb ordnumber ?>&nbsp;</td>
+          <td><?lsmb invnumber ?>&nbsp;</td>
+          <td><?lsmb ordnumber ?>&nbsp;</td>
           <?lsmb IF shippingdate ?>
-	  <td><?lsmb shippingdate ?></td>
+          <td><?lsmb shippingdate ?></td>
           <?lsmb ELSE ?>
-	  <td><?lsmb transdate ?></td>
-	  <?lsmb END ?>
+          <td><?lsmb transdate ?></td>
+          <?lsmb END ?>
 
-	  <td><?lsmb employee ?>&nbsp;</td>
-	  <td><?lsmb warehouse ?>&nbsp;</td>
-	  <td><?lsmb shippingpoint ?>&nbsp;</td>
-	  <td><?lsmb shipvia ?>&nbsp;</td>
-	</tr>
+          <td><?lsmb employee ?>&nbsp;</td>
+          <td><?lsmb warehouse ?>&nbsp;</td>
+          <td><?lsmb shippingpoint ?>&nbsp;</td>
+          <td><?lsmb shipvia ?>&nbsp;</td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr bgcolor=000000>
-	  <th align=left><font color=ffffff><?lsmb text('Item') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
-	  <th><font color=ffffff><?lsmb text('Qty') ?></th>
-	  <th><font color=ffffff><?lsmb text('Ship') ?></th>
-	  <th>&nbsp;</th>
-	  <th><font color=ffffff><?lsmb text('Bin') ?></th>
-	</tr>
+        <tr bgcolor=000000>
+          <th align=left><font color=ffffff><?lsmb text('Item') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
+          <th><font color=ffffff><?lsmb text('Qty') ?></th>
+          <th><font color=ffffff><?lsmb text('Ship') ?></th>
+          <th>&nbsp;</th>
+          <th><font color=ffffff><?lsmb text('Bin') ?></th>
+        </tr>
 
         <?lsmb FOREACH number ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr valign=top>
-	  <td><?lsmb runningnumber.${loop_count} ?></td>
-	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td align=right><?lsmb qty.${loop_count} ?></td>
-	  <td align=right>[&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]</td>
-	  <td><?lsmb unit.${loop_count} ?></td>
-	  <td align=right><?lsmb bin.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr valign=top>
+          <td><?lsmb runningnumber.${loop_count} ?></td>
+          <td><?lsmb number.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
+          <td align=right><?lsmb qty.${loop_count} ?></td>
+          <td align=right>[&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]</td>
+          <td><?lsmb unit.${loop_count} ?></td>
+          <td align=right><?lsmb bin.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td><hr noshade></td>
   </tr>

--- a/templates/xedemo/product_receipt.html
+++ b/templates/xedemo/product_receipt.html
@@ -11,7 +11,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -21,7 +20,6 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
@@ -94,7 +92,6 @@
   <tr height=5></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% border=1>
@@ -120,7 +117,6 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
@@ -213,7 +209,6 @@
 
   <?lsmb IF notes ?>
   <tr>
-    <td>&nbsp;</td>
 
     <td>
     <table width="100%">
@@ -230,7 +225,6 @@
   <?lsmb END ?>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">

--- a/templates/xedemo/request_quotation.html
+++ b/templates/xedemo/request_quotation.html
@@ -11,7 +11,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -20,74 +19,73 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr bgcolor=000000>
-	  <th align=left width="50%"><font color=ffffff><?lsmb text('To:') ?>
+        <tr bgcolor=000000>
+          <th align=left width="50%"><font color=ffffff><?lsmb text('To:') ?>
          </th>
-	  <th align=left width="50%"><font color=ffffff><?lsmb text('Ship To:') ?>
+          <th align=left width="50%"><font color=ffffff><?lsmb text('Ship To:') ?>
          </th>
-	</tr>
+        </tr>
 
-	<tr valign=top>
-	  <td><?lsmb name ?>
-	  <br><?lsmb address1 ?>
-	  <?lsmb IF address2 ?>
-	  <br><?lsmb address2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb city ?>
-	  <?lsmb IF state ?>
-	  , <?lsmb state ?>
-	  <?lsmb END ?>
-	  <?lsmb zipcode ?>
-	  <?lsmb IF country ?>
-	  <br><?lsmb country ?>
-	  <?lsmb END ?>
+        <tr valign=top>
+          <td><?lsmb name ?>
+          <br><?lsmb address1 ?>
+          <?lsmb IF address2 ?>
+          <br><?lsmb address2 ?>
+          <?lsmb END ?>
+          <br><?lsmb city ?>
+          <?lsmb IF state ?>
+          , <?lsmb state ?>
+          <?lsmb END ?>
+          <?lsmb zipcode ?>
+          <?lsmb IF country ?>
+          <br><?lsmb country ?>
+          <?lsmb END ?>
           <br>
 
-	  <?lsmb IF contact ?>
-	  <br><?lsmb text('Attn: [_1]', contact) ?>
-	  <?lsmb END ?>
+          <?lsmb IF contact ?>
+          <br><?lsmb text('Attn: [_1]', contact) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF vendorphone ?>
-	  <br><?lsmb text('Tel: [_1]', vendorphone) ?>
-	  <?lsmb END ?>
+          <?lsmb IF vendorphone ?>
+          <br><?lsmb text('Tel: [_1]', vendorphone) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF vendorfax ?>
-	  <br><?lsmb text('Fax: [_1]', vendorfax) ?>
-	  <?lsmb END ?>
-	  </td>
+          <?lsmb IF vendorfax ?>
+          <br><?lsmb text('Fax: [_1]', vendorfax) ?>
+          <?lsmb END ?>
+          </td>
 
-	  <td><?lsmb shiptoname ?>
-	  <br><?lsmb shiptoaddress1 ?>
-	  <?lsmb IF shiptoaddress2 ?>
-	  <br><?lsmb shiptoaddr2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb shiptocity ?>
-	  <?lsmb IF shiptostate ?>
-	  , <?lsmb shiptostate ?>
-	  <?lsmb END ?>
-	  <?lsmb shiptozipcode ?>
-	  <?lsmb IF shiptocountry ?>
-	  <br><?lsmb shiptocountry ?>
-	  <?lsmb END ?>
+          <td><?lsmb shiptoname ?>
+          <br><?lsmb shiptoaddress1 ?>
+          <?lsmb IF shiptoaddress2 ?>
+          <br><?lsmb shiptoaddr2 ?>
+          <?lsmb END ?>
+          <br><?lsmb shiptocity ?>
+          <?lsmb IF shiptostate ?>
+          , <?lsmb shiptostate ?>
+          <?lsmb END ?>
+          <?lsmb shiptozipcode ?>
+          <?lsmb IF shiptocountry ?>
+          <br><?lsmb shiptocountry ?>
+          <?lsmb END ?>
           <br>
 
-	  <?lsmb IF shiptocontact ?>
-	  <br><?lsmb text('Attn: [_1]', shiptocontact) ?>
-	  <?lsmb END ?>
+          <?lsmb IF shiptocontact ?>
+          <br><?lsmb text('Attn: [_1]', shiptocontact) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF shiptophone ?>
-	  <br><?lsmb text('Tel: [_1]', shiptophone) ?>
-	  <?lsmb END ?>
+          <?lsmb IF shiptophone ?>
+          <br><?lsmb text('Tel: [_1]', shiptophone) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF shiptofax ?>
-	  <br><?lsmb text('Fax: [_1]', shiptofax) ?>
-	  <?lsmb END ?>
-	  </td>
-	</tr>
+          <?lsmb IF shiptofax ?>
+          <br><?lsmb text('Fax: [_1]', shiptofax) ?>
+          <?lsmb END ?>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -95,27 +93,26 @@
   <tr height=5></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% border=1>
-	<tr>
-	  <th width=17% align=left><?lsmb text('RFQ #') ?></th>
-	  <th width=17% align=left><?lsmb text('Date') ?></th>
-	  <th width=17% align=left><?lsmb text('Required by') ?></th>
-	  <th width=17% align=left><?lsmb text('Contact') ?></th>
-	  <th width=17% align=left><?lsmb text('Shipping Point') ?></th>
-	  <th width=15% align=left><?lsmb text('Ship via') ?></th>
-	</tr>
+        <tr>
+          <th width=17% align=left><?lsmb text('RFQ #') ?></th>
+          <th width=17% align=left><?lsmb text('Date') ?></th>
+          <th width=17% align=left><?lsmb text('Required by') ?></th>
+          <th width=17% align=left><?lsmb text('Contact') ?></th>
+          <th width=17% align=left><?lsmb text('Shipping Point') ?></th>
+          <th width=15% align=left><?lsmb text('Ship via') ?></th>
+        </tr>
 
-	<tr>
-	  <td><?lsmb quonumber ?></td>
-	  <td><?lsmb quodate ?></td>
-	  <td><?lsmb reqdate ?>&nbsp;</td>
-	  <td><?lsmb employee ?></td>
-	  <td><?lsmb shippingpoint ?>&nbsp;</td>
-	  <td><?lsmb shipvia ?>&nbsp;</td>
-	</tr>
+        <tr>
+          <td><?lsmb quonumber ?></td>
+          <td><?lsmb quodate ?></td>
+          <td><?lsmb reqdate ?>&nbsp;</td>
+          <td><?lsmb employee ?></td>
+          <td><?lsmb shippingpoint ?>&nbsp;</td>
+          <td><?lsmb shipvia ?>&nbsp;</td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -123,7 +120,6 @@
   <tr height="10"></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td><?lsmb text('Please provide price and delivery time for the following items:') ?></td>
   </tr>
@@ -131,35 +127,34 @@
   <tr height="10"></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr>
-	  <th align=right><?lsmb text('Item') ?></th>
-	  <th align=left><?lsmb text('Number') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
-	  <th><?lsmb text('Qty') ?></th>
-	  <th>&nbsp;</th>
-	  <th><?lsmb text('Delivery') ?></th>
-	  <th<?lsmb text('Unit Price') ?></th>
-	  <th<?lsmb text('Extended') ?></th>
-	</tr>
+        <tr>
+          <th align=right><?lsmb text('Item') ?></th>
+          <th align=left><?lsmb text('Number') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
+          <th><?lsmb text('Qty') ?></th>
+          <th>&nbsp;</th>
+          <th><?lsmb text('Delivery') ?></th>
+          <th<?lsmb text('Unit Price') ?></th>
+          <th<?lsmb text('Extended') ?></th>
+        </tr>
 
         <?lsmb FOREACH number ?>
-	<?lsmb loop_count = loop.count - 1 ?>
+        <?lsmb loop_count = loop.count - 1 ?>
         <tr valign=top>
           <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
-	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td align=right><?lsmb qty.${loop_count} ?></td>
-	  <td><?lsmb unit.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+          <td><?lsmb number.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
+          <td align=right><?lsmb qty.${loop_count} ?></td>
+          <td><?lsmb unit.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
-	<tr>
-	  <td colspan=8><hr noshade></td>
-	</tr>
+        <tr>
+          <td colspan=8><hr noshade></td>
+        </tr>
 
       </table>
     </td>
@@ -167,16 +162,15 @@
 
   <?lsmb IF notes ?>
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr valign=top>
-	  <td<?lsmb text('Notes') ?></td>
+        <tr valign=top>
+          <td<?lsmb text('Notes') ?></td>
           <td><?lsmb  FOREACH P IN notes.split('\n\n') ?>
                     <p><?lsmb P ?></p>
                <?lsmb END ?></td>
-	</tr>
+        </tr>
 
       </table>
     </td>

--- a/templates/xedemo/sales_order.html
+++ b/templates/xedemo/sales_order.html
@@ -11,7 +11,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -20,73 +19,72 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
-	<tr bgcolor=000000>
-	  <th align=left width="50%"><font color=ffffff><?lsmb text('To') ?></th>
-	  <th align=left width="50%"><font color=ffffff><?lsmb text('Ship To') ?>
+        <tr bgcolor=000000>
+          <th align=left width="50%"><font color=ffffff><?lsmb text('To') ?></th>
+          <th align=left width="50%"><font color=ffffff><?lsmb text('Ship To') ?>
           </th>
-	</tr>
+        </tr>
 
-	<tr valign=top>
-	  <td><?lsmb name ?>
-	  <br><?lsmb address1 ?>
-	  <?lsmb IF address2 ?>
-	  <br><?lsmb address2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb city ?>
-	  <?lsmb IF state ?>
-	  , <?lsmb state ?>
-	  <?lsmb END ?>
+        <tr valign=top>
+          <td><?lsmb name ?>
+          <br><?lsmb address1 ?>
+          <?lsmb IF address2 ?>
+          <br><?lsmb address2 ?>
+          <?lsmb END ?>
+          <br><?lsmb city ?>
+          <?lsmb IF state ?>
+          , <?lsmb state ?>
+          <?lsmb END ?>
           <?lsmb zipcode ?>
-	  <?lsmb IF country ?>
-	  <br><?lsmb country ?>
-	  <?lsmb END ?>
+          <?lsmb IF country ?>
+          <br><?lsmb country ?>
+          <?lsmb END ?>
           <br>
-	  <?lsmb IF contact ?>
-	  <br><?lsmb text('Attn: [_1]', contact) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF customerphone ?>
-	  <br><?lsmb text('Tel: [_1]', customerphone) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF customerfax ?>
-	  <br><?lsmb text('Fax: [_1]', customerfax) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF email ?>
-	  <br><?lsmb email ?>
-	  <?lsmb END ?>
-	  </td>
+          <?lsmb IF contact ?>
+          <br><?lsmb text('Attn: [_1]', contact) ?>
+          <?lsmb END ?>
+          <?lsmb IF customerphone ?>
+          <br><?lsmb text('Tel: [_1]', customerphone) ?>
+          <?lsmb END ?>
+          <?lsmb IF customerfax ?>
+          <br><?lsmb text('Fax: [_1]', customerfax) ?>
+          <?lsmb END ?>
+          <?lsmb IF email ?>
+          <br><?lsmb email ?>
+          <?lsmb END ?>
+          </td>
 
-	  <td><?lsmb shiptoname ?>
-	  <br><?lsmb shiptoaddress1 ?>
-	  <?lsmb IF shiptoaddress2 ?>
-	  <br><?lsmb shiptoaddress2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb shiptocity ?>
-	  <?lsmb IF shiptostate ?>
-	  , <?lsmb shiptostate ?>
-	  <?lsmb END ?>
+          <td><?lsmb shiptoname ?>
+          <br><?lsmb shiptoaddress1 ?>
+          <?lsmb IF shiptoaddress2 ?>
+          <br><?lsmb shiptoaddress2 ?>
+          <?lsmb END ?>
+          <br><?lsmb shiptocity ?>
+          <?lsmb IF shiptostate ?>
+          , <?lsmb shiptostate ?>
+          <?lsmb END ?>
           <?lsmb shiptozipcode ?>
-	  <?lsmb IF shiptocountry ?>
-	  <br><?lsmb shiptocountry ?>
-	  <?lsmb END ?>
-	  <br>
+          <?lsmb IF shiptocountry ?>
+          <br><?lsmb shiptocountry ?>
+          <?lsmb END ?>
+          <br>
           <?lsmb IF shiptocontact ?>
           <br><?lsmb shiptocontact ?>
           <?lsmb END ?>
-	  <?lsmb IF shiptophone ?>
-	  <br><?lsmb text('Tel: [_1]', shiptophone) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF shiptofax ?>
-	  <br><?lsmb text('Fax: [_1]', shiptofax) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF shiptoemail ?>
-	  <br><?lsmb shiptoemail ?>
-	  <?lsmb END ?>
-	  </td>
-	</tr>
+          <?lsmb IF shiptophone ?>
+          <br><?lsmb text('Tel: [_1]', shiptophone) ?>
+          <?lsmb END ?>
+          <?lsmb IF shiptofax ?>
+          <br><?lsmb text('Fax: [_1]', shiptofax) ?>
+          <?lsmb END ?>
+          <?lsmb IF shiptoemail ?>
+          <br><?lsmb shiptoemail ?>
+          <?lsmb END ?>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -94,141 +92,137 @@
   <tr height=5></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% border=1>
-	<tr>
-	  <th width=17% align=left nowrap><?lsmb text('Order #') ?></th>
-	  <th width=17% align=left><?lsmb text('Order Date') ?></th>
-	  <th width=17% align=left><?lsmb text('Required by') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Salesperson') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Shipping Point') ?></th>
-	  <th width=15% align=left nowrap><?lsmb text('Ship Via') ?></th>
-	</tr>
+        <tr>
+          <th width=17% align=left nowrap><?lsmb text('Order #') ?></th>
+          <th width=17% align=left><?lsmb text('Order Date') ?></th>
+          <th width=17% align=left><?lsmb text('Required by') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Salesperson') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Shipping Point') ?></th>
+          <th width=15% align=left nowrap><?lsmb text('Ship Via') ?></th>
+        </tr>
 
-	<tr>
-	  <td><?lsmb ordnumber ?></td>
-	  <td><?lsmb orddate ?></td>
-	  <td><?lsmb reqdate ?></td>
-	  <td><?lsmb employee ?></td>
-	  <td><?lsmb shippingpoint ?>&nbsp;</td>
-	  <td><?lsmb shipvia ?>&nbsp;</td>
-	</tr>
+        <tr>
+          <td><?lsmb ordnumber ?></td>
+          <td><?lsmb orddate ?></td>
+          <td><?lsmb reqdate ?></td>
+          <td><?lsmb employee ?></td>
+          <td><?lsmb shippingpoint ?>&nbsp;</td>
+          <td><?lsmb shipvia ?>&nbsp;</td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr bgcolor=000000>
-	  <th align=right><font color=ffffff><?lsmb text('Item') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
-	  <th><font color=ffffff><?lsmb text('Qty') ?></th>
-	  <th>&nbsp;</th>
-	  <th><font color=ffffff><?lsmb text('Price') ?></th>
-	  <th><font color=ffffff><?lsmb text('Disc %') ?></th>
-	  <th><font color=ffffff><?lsmb text('Amount') ?></th>
-	</tr>
+        <tr bgcolor=000000>
+          <th align=right><font color=ffffff><?lsmb text('Item') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
+          <th><font color=ffffff><?lsmb text('Qty') ?></th>
+          <th>&nbsp;</th>
+          <th><font color=ffffff><?lsmb text('Price') ?></th>
+          <th><font color=ffffff><?lsmb text('Disc %') ?></th>
+          <th><font color=ffffff><?lsmb text('Amount') ?></th>
+        </tr>
 
-	<?lsmb FOREACH number ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr valign=top>
+        <?lsmb FOREACH number ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr valign=top>
           <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
-	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td align=right><?lsmb qty.${loop_count} ?></td>
-	  <td><?lsmb unit.${loop_count} ?></td>
-	  <td align=right><?lsmb sellprice.${loop_count} ?></td>
-	  <td align=right><?lsmb discountrate.${loop_count} ?></td>
-	  <td align=right><?lsmb linetotal.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+          <td><?lsmb number.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
+          <td align=right><?lsmb qty.${loop_count} ?></td>
+          <td><?lsmb unit.${loop_count} ?></td>
+          <td align=right><?lsmb sellprice.${loop_count} ?></td>
+          <td align=right><?lsmb discountrate.${loop_count} ?></td>
+          <td align=right><?lsmb linetotal.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
-	<tr>
-	  <td colspan=8><hr noshade></td>
-	</tr>
+        <tr>
+          <td colspan=8><hr noshade></td>
+        </tr>
 
-	<tr>
-	  <?lsmb IF taxincluded ?>
-	  <th colspan=6 align=right><?lsmb text('Total') ?></th>
-	  <td colspan=2 align=right><?lsmb invtotal ?></td>
-	  <?lsmb ELSE ?>
-	  <th colspan=6 align=right><?lsmb text('Subtotal') ?></th>
-	  <td colspan=2 align=right><?lsmb subtotal ?></td>
-	  <?lsmb END ?>
-	</tr>
+        <tr>
+          <?lsmb IF taxincluded ?>
+          <th colspan=6 align=right><?lsmb text('Total') ?></th>
+          <td colspan=2 align=right><?lsmb invtotal ?></td>
+          <?lsmb ELSE ?>
+          <th colspan=6 align=right><?lsmb text('Subtotal') ?></th>
+          <td colspan=2 align=right><?lsmb subtotal ?></td>
+          <?lsmb END ?>
+        </tr>
 
-	<?lsmb FOREACH tax ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr>
-	  <th colspan=6 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
-	  <td colspan=2 align=right><?lsmb tax.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+        <?lsmb FOREACH tax ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr>
+          <th colspan=6 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+          <td colspan=2 align=right><?lsmb tax.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
-	<tr>
-	  <td colspan=4>&nbsp;</td>
-	  <td colspan=4><hr noshade></td>
-	</tr>
+        <tr>
+          <td colspan=4>&nbsp;</td>
+          <td colspan=4><hr noshade></td>
+        </tr>
 
-	<tr>
-	  <td colspan=4>
+        <tr>
+          <td colspan=4>
           <?lsmb text_amount ?> ***** <?lsmb decimal ?>/100
-	  <?lsmb IF terms ?>
-	  <br><?lsmb text('Terms Net [_1] days', terms) ?>
-	  <?lsmb END ?>
-	  </td>
-	  <th colspan=2 align=right><?lsmb text('Total') ?></th>
-	  <th colspan=2 align=right><?lsmb ordtotal ?></th>
-	</tr>
+          <?lsmb IF terms ?>
+          <br><?lsmb text('Terms Net [_1] days', terms) ?>
+          <?lsmb END ?>
+          </td>
+          <th colspan=2 align=right><?lsmb text('Total') ?></th>
+          <th colspan=2 align=right><?lsmb ordtotal ?></th>
+        </tr>
 
-	<tr>
-	  <td>&nbsp;</td>
-	</tr>
+        <tr>
+          <td>&nbsp;</td>
+        </tr>
 
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr valign=top>
-	  <?lsmb IF notes ?>
-	  <td><?lsmb text('Notes') ?></td>
+        <tr valign=top>
+          <?lsmb IF notes ?>
+          <td><?lsmb text('Notes') ?></td>
           <td><?lsmb  FOREACH P IN notes.split('\n\n') ?>
                     <p><?lsmb P ?></p>
                <?lsmb END ?></td>
-	  <?lsmb END ?>
-	  <td align=right nowrap>
-	  <?lsmb text('All prices in [_1] Funds', currency) ?>
-	  </td>
-	</tr>
+          <?lsmb END ?>
+          <td align=right nowrap>
+          <?lsmb text('All prices in [_1] Funds', currency) ?>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr valign=top>
-	  <td width="60%"><font size=-3>
-	  <?lsmb text('Special order items are subject to a 10% order cancellation fee.') ?>
-	  </font>
-	  </td>
-	  <td width="40%">
-	  X <hr noshade>
-	  </td>
-	</tr>
+        <tr valign=top>
+          <td width="60%"><font size=-3>
+          <?lsmb text('Special order items are subject to a 10% order cancellation fee.') ?>
+          </font>
+          </td>
+          <td width="40%">
+          X <hr noshade>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>

--- a/templates/xedemo/sales_quotation.html
+++ b/templates/xedemo/sales_quotation.html
@@ -11,7 +11,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3 style="text-transform:uppercase">
       <h4><?lsmb text('Quotation') ?></h4>
@@ -19,186 +18,181 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
 
-	<tr valign=top>
-	  <td><?lsmb name ?>
-	  <br><?lsmb address1 ?>
-	  <?lsmb IF address2 ?>
-	  <br><?lsmb address2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb city ?>
-	  <?lsmb IF state ?>
-	  , <?lsmb state ?>
-	  <?lsmb END ?>
-	  <?lsmb zipcode ?>
-	  <?lsmb IF country ?>
-	  <br><?lsmb country ?>
-	  <?lsmb END ?>
+        <tr valign=top>
+          <td><?lsmb name ?>
+          <br><?lsmb address1 ?>
+          <?lsmb IF address2 ?>
+          <br><?lsmb address2 ?>
+          <?lsmb END ?>
+          <br><?lsmb city ?>
+          <?lsmb IF state ?>
+          , <?lsmb state ?>
+          <?lsmb END ?>
+          <?lsmb zipcode ?>
+          <?lsmb IF country ?>
+          <br><?lsmb country ?>
+          <?lsmb END ?>
 
-	  <br>
-	  <?lsmb IF contact ?>
-	  <br><?lsmb text('Attn: [_1]', contact) ?>
-	  <?lsmb END ?>
+          <br>
+          <?lsmb IF contact ?>
+          <br><?lsmb text('Attn: [_1]', contact) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF customerphone ?>
-	  <br><?lsmb text('Tel: [_1]', customerphone) ?>
-	  <?lsmb END ?>
+          <?lsmb IF customerphone ?>
+          <br><?lsmb text('Tel: [_1]', customerphone) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF customerfax ?>
-	  <br><?lsmb text('Fax: [_1]', customerfax) ?>
-	  <?lsmb END ?>
+          <?lsmb IF customerfax ?>
+          <br><?lsmb text('Fax: [_1]', customerfax) ?>
+          <?lsmb END ?>
 
-	  <?lsmb IF email ?>
-	  <br><?lsmb email ?>
-	  <?lsmb END ?>
-	  </td>
+          <?lsmb IF email ?>
+          <br><?lsmb email ?>
+          <?lsmb END ?>
+          </td>
 
-	</tr>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% border=1>
-	<tr>
-	  <th width=17% align=left nowrap><?lsmb text('Number') ?></th>
-	  <th width=17% align=left><?lsmb text('Date') ?></th>
-	  <th width=17% align=left><?lsmb text('Valid until') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Contact') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Shipping Point') ?></th>
-	  <th width=15% align=left nowrap><?lsmb text('Ship via') ?></th>
-	</tr>
+        <tr>
+          <th width=17% align=left nowrap><?lsmb text('Number') ?></th>
+          <th width=17% align=left><?lsmb text('Date') ?></th>
+          <th width=17% align=left><?lsmb text('Valid until') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Contact') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Shipping Point') ?></th>
+          <th width=15% align=left nowrap><?lsmb text('Ship via') ?></th>
+        </tr>
 
-	<tr>
-	  <td><?lsmb quonumber ?></td>
-	  <td><?lsmb quodate ?></td>
-	  <td><?lsmb reqdate ?></td>
-	  <td><?lsmb employee ?></td>
-	  <td><?lsmb shippingpoint ?>&nbsp;</td>
-	  <td><?lsmb shipvia ?>&nbsp;</td>
-	</tr>
+        <tr>
+          <td><?lsmb quonumber ?></td>
+          <td><?lsmb quodate ?></td>
+          <td><?lsmb reqdate ?></td>
+          <td><?lsmb employee ?></td>
+          <td><?lsmb shippingpoint ?>&nbsp;</td>
+          <td><?lsmb shipvia ?>&nbsp;</td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr bgcolor=000000>
-	  <th align=right><font color=ffffff><?lsmb text('Item') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
-	  <th><font color=ffffff><?lsmb text('Qty') ?></th>
-	  <th>&nbsp;</th>
-	  <th><font color=ffffff><?lsmb text('Price') ?></th>
-	  <th><font color=ffffff><?lsmb text('Disc %') ?></th>
-	  <th><font color=ffffff><?lsmb text('Amount') ?></th>
-	</tr>
+        <tr bgcolor=000000>
+          <th align=right><font color=ffffff><?lsmb text('Item') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
+          <th><font color=ffffff><?lsmb text('Qty') ?></th>
+          <th>&nbsp;</th>
+          <th><font color=ffffff><?lsmb text('Price') ?></th>
+          <th><font color=ffffff><?lsmb text('Disc %') ?></th>
+          <th><font color=ffffff><?lsmb text('Amount') ?></th>
+        </tr>
 
         <?lsmb FOREACH number ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr valign=top>
-	  <td align=right><?lsmb runningnumber.${loop_count} ?></td>
-	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td align=right><?lsmb qty.${loop_count} ?></td>
-	  <td><?lsmb unit.${loop_count} ?></td>
-	  <td align=right><?lsmb sellprice.${loop_count} ?></td>
-	  <td align=right><?lsmb discountrate.${loop_count} ?></td>
-	  <td align=right><?lsmb linetotal.${loop_count} ?></td>
-	</tr>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr valign=top>
+          <td align=right><?lsmb runningnumber.${loop_count} ?></td>
+          <td><?lsmb number.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
+          <td align=right><?lsmb qty.${loop_count} ?></td>
+          <td><?lsmb unit.${loop_count} ?></td>
+          <td align=right><?lsmb sellprice.${loop_count} ?></td>
+          <td align=right><?lsmb discountrate.${loop_count} ?></td>
+          <td align=right><?lsmb linetotal.${loop_count} ?></td>
+        </tr>
         <?lsmb END ?>
 
-	<tr>
-	  <td colspan=8><hr noshade></td>
-	</tr>
+        <tr>
+          <td colspan=8><hr noshade></td>
+        </tr>
 
-	<tr>
-	  <?lsmb IF taxincluded ?>
-	  <th colspan=6 align=right><?lsmb text('Total') ?></th>
-	  <td colspan=2 align=right><?lsmb invtotal ?></td>
-	  <?lsmb ELSE ?>
-	  <th colspan=6 align=right><?lsmb text('Subtotal') ?></th>
-	  <td colspan=2 align=right><?lsmb subtotal ?></td>
-	  <?lsmb END ?>
-	</tr>
+        <tr>
+          <?lsmb IF taxincluded ?>
+          <th colspan=6 align=right><?lsmb text('Total') ?></th>
+          <td colspan=2 align=right><?lsmb invtotal ?></td>
+          <?lsmb ELSE ?>
+          <th colspan=6 align=right><?lsmb text('Subtotal') ?></th>
+          <td colspan=2 align=right><?lsmb subtotal ?></td>
+          <?lsmb END ?>
+        </tr>
 
-	<?lsmb FOREACH tax ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr>
-	  <th colspan=6 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
-	  <td colspan=2 align=right><?lsmb tax.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+        <?lsmb FOREACH tax ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr>
+          <th colspan=6 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+          <td colspan=2 align=right><?lsmb tax.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
-	<tr>
-	  <td colspan=4>&nbsp;</td>
-	  <td colspan=4><hr noshade></td>
-	</tr>
+        <tr>
+          <td colspan=4>&nbsp;</td>
+          <td colspan=4><hr noshade></td>
+        </tr>
 
-	<tr>
-	  <td colspan=4>&nbsp;
-	  <?lsmb IF terms ?>
-	  <?lsmb text('Terms Net [_1] days', terms) ?>
-	  <?lsmb END ?>
-	  </td>
-	  <th colspan=2 align=right><?lsmb text('Total') ?></th>
-	  <th colspan=2 align=right><?lsmb quototal ?></th>
-	</tr>
+        <tr>
+          <td colspan=4>&nbsp;
+          <?lsmb IF terms ?>
+          <?lsmb text('Terms Net [_1] days', terms) ?>
+          <?lsmb END ?>
+          </td>
+          <th colspan=2 align=right><?lsmb text('Total') ?></th>
+          <th colspan=2 align=right><?lsmb quototal ?></th>
+        </tr>
 
-	<tr>
-	  <td>&nbsp;</td>
-	</tr>
+        <tr>
+          <td>&nbsp;</td>
+        </tr>
 
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr valign=top>
+        <tr valign=top>
           <?lsmb IF notes ?>
-	  <td><?lsmb text('Notes') ?></td>
+          <td><?lsmb text('Notes') ?></td>
           <td><?lsmb  FOREACH P IN notes.split('\n\n') ?>
                     <p><?lsmb P ?></p>
                <?lsmb END ?></td>
           <?lsmb END ?>
-	  <td align=right>
-	  <?lsmb text('All prices in [_1] Funds', currency) ?>
-	  </td>
-	</tr>
+          <td align=right>
+          <?lsmb text('All prices in [_1] Funds', currency) ?>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr valign=top>
-	  <td width="60%"><font size=-3>
-	  <?lsmb
+        <tr valign=top>
+          <td width="60%"><font size=-3>
+          <?lsmb
              text('Special order items are subject to a 10% cancellation fee.')
            ?>
-	  </font>
-	  </td>
-	  <td width="40%">
-	  X <hr noshade>
-	  </td>
-	</tr>
+          </font>
+          </td>
+          <td width="40%">
+          X <hr noshade>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>

--- a/templates/xedemo/statement.html
+++ b/templates/xedemo/statement.html
@@ -13,7 +13,6 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3><h4 style="text-transform:uppercase">
          <?lsmb text('Statement') ?></h4></th>
@@ -21,30 +20,28 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td colspan=3 align=right><?lsmb statementdate ?></td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr valign=top>
-	  <td><?lsmb statement.entity.name ?>
-	  <br><?lsmb statement.address.line_one ?>
-	  <?lsmb IF statement.address.line_two ?>
-	  <br><?lsmb statement.address.line_two ?>
-	  <?lsmb END ?>
-	  <br><?lsmb statement.address.city ?>
-	  <?lsmb IF statement.address.state ?>
-	  , <?lsmb statement.address.state ?>
-	  <?lsmb END ?>
-	  <?lsmb statement.address.mail_code ?>
-	  <br>
-	  </td>
-	</tr>
+        <tr valign=top>
+          <td><?lsmb statement.entity.name ?>
+          <br><?lsmb statement.address.line_one ?>
+          <?lsmb IF statement.address.line_two ?>
+          <br><?lsmb statement.address.line_two ?>
+          <?lsmb END ?>
+          <br><?lsmb statement.address.city ?>
+          <?lsmb IF statement.address.state ?>
+          , <?lsmb statement.address.state ?>
+          <?lsmb END ?>
+          <?lsmb statement.address.mail_code ?>
+          <br>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -52,48 +49,47 @@
   <tr height=10></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
         <tr>
-	  <th align=left><?lsmb text('Invoice #') ?></th>
+          <th align=left><?lsmb text('Invoice #') ?></th>
           <th align=left><?lsmb text('Order #') ?></th>
-	  <th width="10%"><?lsmb text('Date') ?></th>
-	  <th width="10%"><?lsmb text('Due') ?></th>
-	  <th width="10%"><?lsmb text('Current') ?></th>
-	  <th width="10%"><?lsmb text('30') ?></th>
-	  <th width="10%"><?lsmb text('60') ?></th>
-	  <th width="10%"><?lsmb text('90') ?></th>
-	</tr>
+          <th width="10%"><?lsmb text('Date') ?></th>
+          <th width="10%"><?lsmb text('Due') ?></th>
+          <th width="10%"><?lsmb text('Current') ?></th>
+          <th width="10%"><?lsmb text('30') ?></th>
+          <th width="10%"><?lsmb text('60') ?></th>
+          <th width="10%"><?lsmb text('90') ?></th>
+        </tr>
 
-	<?lsmb- FOREACH invoice IN statement.aging.rows ?>
-	<tr>
-	  <td><?lsmb invoice.invnumber ?></td>
+        <?lsmb- FOREACH invoice IN statement.aging.rows ?>
+        <tr>
+          <td><?lsmb invoice.invnumber ?></td>
           <td><?lsmb invoice.ordnumber ?></td>
-	  <td><?lsmb invoice.transdate ?></td>
-	  <td><?lsmb invoice.duedate ?></td>
-	  <td align=right><?lsmb invoice.c0 ?></td>
-	  <td align=right><?lsmb invoice.c30 ?></td>
-	  <td align=right><?lsmb invoice.c60 ?></td>
-	  <td align=right><?lsmb invoice.c90 ?></td>
-	</tr>
+          <td><?lsmb invoice.transdate ?></td>
+          <td><?lsmb invoice.duedate ?></td>
+          <td align=right><?lsmb invoice.c0 ?></td>
+          <td align=right><?lsmb invoice.c30 ?></td>
+          <td align=right><?lsmb invoice.c60 ?></td>
+          <td align=right><?lsmb invoice.c90 ?></td>
+        </tr>
         <?lsmb END -?>
 
         <tr>
-	  <td colspan=8><hr size=1></td>
-	</tr>
+          <td colspan=8><hr size=1></td>
+        </tr>
 
-	<tr>
-	  <td>&nbsp;</td>
-	  <td>&nbsp;</td>
+        <tr>
           <td>&nbsp;</td>
           <td>&nbsp;</td>
-	  <th align=right><?lsmb statement.aging.c0total ?></td>
-	  <th align=right><?lsmb statement.aging.c30total ?></td>
-	  <th align=right><?lsmb statement.aging.c60total ?></td>
-	  <th align=right><?lsmb statement.aging.c90total ?></td>
-	</tr>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+          <th align=right><?lsmb statement.aging.c0total ?></td>
+          <th align=right><?lsmb statement.aging.c30total ?></td>
+          <th align=right><?lsmb statement.aging.c60total ?></td>
+          <th align=right><?lsmb statement.aging.c90total ?></td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -101,20 +97,18 @@
   <tr height=10></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td align=right>
       <table width="50%">
         <tr>
-	  <th><?lsmb text('Total Outstanding') ?></th>
+          <th><?lsmb text('Total Outstanding') ?></th>
           <th align=right><?lsmb statement.aging.total ?></th>
-	</tr>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td><hr noshade></td>
   </tr>

--- a/templates/xedemo/timecard.html
+++ b/templates/xedemo/timecard.html
@@ -9,9 +9,8 @@
 <table width="100%">
 
   <?lsmb INCLUDE letterhead ?>
-  
+
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
@@ -20,103 +19,100 @@
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
         <tr valign=top>
-	  <td>
-	    <table>
-	      <tr>
-		<th align=left><?lsmb text('Employee') ?></th>
-		<td><?lsmb employee ?></td>
-	      </tr>
-	      <tr>
-		<th align=left><?lsmb text('ID') ?></th>
-		<td><?lsmb employee_id ?></td>
-	      </tr>
-	    </table>
-	  </td>
-   
-	  <td align=right>
-	    <table>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Card ID') ?></th>
-		<td><?lsmb id ?></td>
-	      </tr>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Date') ?></th>
-		<td><?lsmb transdate ?></td>
-	      </tr>
-	      <tr>
-		<th align=left nowrap><?lsmb text('In') ?></th>
-		<td><?lsmb checkedin ?></td>
-	      </tr>
+          <td>
+            <table>
+              <tr>
+                <th align=left><?lsmb text('Employee') ?></th>
+                <td><?lsmb employee ?></td>
+              </tr>
+              <tr>
+                <th align=left><?lsmb text('ID') ?></th>
+                <td><?lsmb employee_id ?></td>
+              </tr>
+            </table>
+          </td>
+
+          <td align=right>
+            <table>
+              <tr>
+                <th align=left nowrap><?lsmb text('Card ID') ?></th>
+                <td><?lsmb id ?></td>
+              </tr>
+              <tr>
+                <th align=left nowrap><?lsmb text('Date') ?></th>
+                <td><?lsmb transdate ?></td>
+              </tr>
+              <tr>
+                <th align=left nowrap><?lsmb text('In') ?></th>
+                <td><?lsmb checkedin ?></td>
+              </tr>
               <tr>
                 <th align=left><?lsmb text('Out') ?></th>
-		<td><?lsmb checkedout ?></td>
-	      </tr>
-	      <tr>
-		<th align=left nowrap><?lsmb text('Hours') ?></th>
-		<td><?lsmb qty ?></td>
-	      </tr>
-	    </table>
-	  </td>
+                <td><?lsmb checkedout ?></td>
+              </tr>
+              <tr>
+                <th align=left nowrap><?lsmb text('Hours') ?></th>
+                <td><?lsmb qty ?></td>
+              </tr>
+            </table>
+          </td>
         </tr>
       </table>
     </td>
   </tr>
 
   <tr height=5></tr>
-  
+
   <tr>
-    <td>&nbsp;</td>
-  
+
     <td>
       <table width="100%">
         <tr valign=bottom>
-	  <td>
-	    <table>
-	      <tr valign=top>
-	        <th align=left><?lsmb text('Job/Project #') ?></th>
-		<td><?lsmb projectnumber ?></td>
-	      </tr>
-	      <tr>
-	        <th align=left><?lsmb text('Description') ?></th>
-		<td><?lsmb projectdescription ?></td>
-	      </tr>
-	      <tr valign=top>
-	        <th align=left><?lsmb text('Labor/Service Code') ?></th>
-		<td><?lsmb partnumber ?></td>
-	      </tr>
-	      <tr>
-	        <th align=left><?lsmb text('Description') ?></th>
-		<td><?lsmb description ?></td>
-	      </tr>
-	    </table>
-	  </td>
-	  <td align=right>
-	    <table>
-	      <tr>
-	        <th align=right><?lsmb text('Rate') ?></th>
-		<td><?lsmb sellprice ?></td>
-	      </tr>
-	      <tr>
-		<th align=right><?lsmb text('Total') ?></th>
-		<td><?lsmb total ?></td>
-	      </tr>
-	    </table>
-	  </td>
-	</tr>
+          <td>
+            <table>
+              <tr valign=top>
+                <th align=left><?lsmb text('Job/Project #') ?></th>
+                <td><?lsmb projectnumber ?></td>
+              </tr>
+              <tr>
+                <th align=left><?lsmb text('Description') ?></th>
+                <td><?lsmb projectdescription ?></td>
+              </tr>
+              <tr valign=top>
+                <th align=left><?lsmb text('Labor/Service Code') ?></th>
+                <td><?lsmb partnumber ?></td>
+              </tr>
+              <tr>
+                <th align=left><?lsmb text('Description') ?></th>
+                <td><?lsmb description ?></td>
+              </tr>
+            </table>
+          </td>
+          <td align=right>
+            <table>
+              <tr>
+                <th align=right><?lsmb text('Rate') ?></th>
+                <td><?lsmb sellprice ?></td>
+              </tr>
+              <tr>
+                <th align=right><?lsmb text('Total') ?></th>
+                <td><?lsmb total ?></td>
+              </tr>
+            </table>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <?lsmb IF notes ?>
   <tr height=5></tr>
-  
+
   <tr>
-    <td>&nbsp;</td>
 
           <td><?lsmb  FOREACH P IN notes.split('\n\n') ?>
                     <p><?lsmb P ?></p>

--- a/templates/xedemo/work_order.html
+++ b/templates/xedemo/work_order.html
@@ -11,82 +11,80 @@
   <?lsmb INCLUDE letterhead ?>
 
   <tr>
-    <td width=10>&nbsp;</td>
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
-	<?lsmb text('Work Order') ?></h4>
+        <?lsmb text('Work Order') ?></h4>
     </th>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% cellspacing=0 cellpadding=0>
-	<tr bgcolor=000000>
-	  <th align=left width="50%"><font color=ffffff><?lsmb text('To') ?></th>
-	  <th align=left width="50%"><font color=ffffff><?lsmb text('Ship To') ?>
+        <tr bgcolor=000000>
+          <th align=left width="50%"><font color=ffffff><?lsmb text('To') ?></th>
+          <th align=left width="50%"><font color=ffffff><?lsmb text('Ship To') ?>
           </th>
-	</tr>
+        </tr>
 
-	<tr valign=top>
-	  <td><?lsmb name ?>
-	  <br><?lsmb address1 ?>
-	  <?lsmb IF address2 ?>
-	  <br><?lsmb address2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb city ?>
-	  <?lsmb IF state ?>
-	  , <?lsmb state ?>
-	  <?lsmb END ?>
+        <tr valign=top>
+          <td><?lsmb name ?>
+          <br><?lsmb address1 ?>
+          <?lsmb IF address2 ?>
+          <br><?lsmb address2 ?>
+          <?lsmb END ?>
+          <br><?lsmb city ?>
+          <?lsmb IF state ?>
+          , <?lsmb state ?>
+          <?lsmb END ?>
           <?lsmb zipcode ?>
-	  <?lsmb IF country ?>
-	  <br><?lsmb country ?>
-	  <?lsmb END ?>
+          <?lsmb IF country ?>
+          <br><?lsmb country ?>
+          <?lsmb END ?>
           <br>
-	  <?lsmb IF contact ?>
-	  <br><?lsmb text('Attn: [_1]', contact) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF customerphone ?>
-	  <br><?lsmb text('Tel: [_1]', customerphone) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF customerfax ?>
-	  <br><?lsmb text('Fax: [_1]', customerfax) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF email ?>
-	  <br><?lsmb email ?>
-	  <?lsmb END ?>
-	  </td>
+          <?lsmb IF contact ?>
+          <br><?lsmb text('Attn: [_1]', contact) ?>
+          <?lsmb END ?>
+          <?lsmb IF customerphone ?>
+          <br><?lsmb text('Tel: [_1]', customerphone) ?>
+          <?lsmb END ?>
+          <?lsmb IF customerfax ?>
+          <br><?lsmb text('Fax: [_1]', customerfax) ?>
+          <?lsmb END ?>
+          <?lsmb IF email ?>
+          <br><?lsmb email ?>
+          <?lsmb END ?>
+          </td>
 
-	  <td><?lsmb shiptoname ?>
-	  <br><?lsmb shiptoaddress1 ?>
-	  <?lsmb IF shiptoaddress2 ?>
-	  <br><?lsmb shiptoaddress2 ?>
-	  <?lsmb END ?>
-	  <br><?lsmb shiptocity ?>
-	  <?lsmb IF shiptostate ?>
-	  , <?lsmb shiptostate ?>
-	  <?lsmb END ?>
+          <td><?lsmb shiptoname ?>
+          <br><?lsmb shiptoaddress1 ?>
+          <?lsmb IF shiptoaddress2 ?>
+          <br><?lsmb shiptoaddress2 ?>
+          <?lsmb END ?>
+          <br><?lsmb shiptocity ?>
+          <?lsmb IF shiptostate ?>
+          , <?lsmb shiptostate ?>
+          <?lsmb END ?>
           <?lsmb shiptozipcode ?>
-	  <?lsmb IF shiptocountry ?>
-	  <br><?lsmb shiptocountry ?>
-	  <?lsmb END ?>
-	  <br>
+          <?lsmb IF shiptocountry ?>
+          <br><?lsmb shiptocountry ?>
+          <?lsmb END ?>
+          <br>
           <?lsmb IF shiptocontact ?>
           <br><?lsmb shiptocontact ?>
           <?lsmb END ?>
-	  <?lsmb IF shiptophone ?>
-	  <br><?lsmb text('Tel: [_1]', shiptophone) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF shiptofax ?>
-	  <br><?lsmb text('Fax: [_1]', shiptofax) ?>
-	  <?lsmb END ?>
-	  <?lsmb IF shiptoemail ?>
-	  <br><?lsmb shiptoemail ?>
-	  <?lsmb END ?>
-	  </td>
-	</tr>
+          <?lsmb IF shiptophone ?>
+          <br><?lsmb text('Tel: [_1]', shiptophone) ?>
+          <?lsmb END ?>
+          <?lsmb IF shiptofax ?>
+          <br><?lsmb text('Fax: [_1]', shiptofax) ?>
+          <?lsmb END ?>
+          <?lsmb IF shiptoemail ?>
+          <br><?lsmb shiptoemail ?>
+          <?lsmb END ?>
+          </td>
+        </tr>
       </table>
     </td>
   </tr>
@@ -94,69 +92,66 @@
   <tr height=5></tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width=100% border=1>
-	<tr>
-	  <th width=17% align=left nowrap><?lsmb text('Order #') ?></th>
-	  <th width=17% align=left><?lsmb text('Order Date') ?></th>
-	  <th width=17% align=left><?lsmb text('Required by') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Salesperson') ?></th>
-	  <th width=17% align=left nowrap><?lsmb text('Shipping Point') ?></th>
-	  <th width=15% align=left nowrap><?lsmb text('Ship Via') ?></th>
-	</tr>
+        <tr>
+          <th width=17% align=left nowrap><?lsmb text('Order #') ?></th>
+          <th width=17% align=left><?lsmb text('Order Date') ?></th>
+          <th width=17% align=left><?lsmb text('Required by') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Salesperson') ?></th>
+          <th width=17% align=left nowrap><?lsmb text('Shipping Point') ?></th>
+          <th width=15% align=left nowrap><?lsmb text('Ship Via') ?></th>
+        </tr>
 
-	<tr>
-	  <td><?lsmb ordnumber ?></td>
-	  <td><?lsmb orddate ?></td>
-	  <td><?lsmb reqdate ?></td>
-	  <td><?lsmb employee ?></td>
-	  <td><?lsmb shippingpoint ?>&nbsp;</td>
-	  <td><?lsmb shipvia ?>&nbsp;</td>
-	</tr>
+        <tr>
+          <td><?lsmb ordnumber ?></td>
+          <td><?lsmb orddate ?></td>
+          <td><?lsmb reqdate ?></td>
+          <td><?lsmb employee ?></td>
+          <td><?lsmb shippingpoint ?>&nbsp;</td>
+          <td><?lsmb shipvia ?>&nbsp;</td>
+        </tr>
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <td>
       <table width="100%">
-	<tr bgcolor=000000>
-	  <th align=right><font color=ffffff><?lsmb text('Item') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
-	  <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
-	  <th><font color=ffffff><?lsmb text('Qty') ?></th>
-	  <th>&nbsp;</th>
+        <tr bgcolor=000000>
+          <th align=right><font color=ffffff><?lsmb text('Item') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Number') ?></th>
+          <th align=left><font color=ffffff><?lsmb text('Description') ?></th>
+          <th><font color=ffffff><?lsmb text('Qty') ?></th>
+          <th>&nbsp;</th>
            <th><font color=ffffff><?lsmb text('Bin') ?></th>
-	  <th><font color=ffffff><?lsmb text('Serial #') ?></th>
-	</tr>
+          <th><font color=ffffff><?lsmb text('Serial #') ?></th>
+        </tr>
 
-	<?lsmb FOREACH number ?>
-	<?lsmb loop_count = loop.count - 1 ?>
-	<tr valign=top>
+        <?lsmb FOREACH number ?>
+        <?lsmb loop_count = loop.count - 1 ?>
+        <tr valign=top>
           <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
-	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
-	  <td align=right><?lsmb qty.${loop_count} ?></td>
-	  <td><?lsmb unit.${loop_count} ?></td>
+          <td><?lsmb number.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
+          <td align=right><?lsmb qty.${loop_count} ?></td>
+          <td><?lsmb unit.${loop_count} ?></td>
            <td><?lsmb bin.${loop_count} ?></td>
-	  <td><?lsmb serialnumber.${loop_count} ?></td>
-	</tr>
-	<?lsmb END ?>
+          <td><?lsmb serialnumber.${loop_count} ?></td>
+        </tr>
+        <?lsmb END ?>
 
-	<tr>
-	  <td colspan=7><hr noshade></td>
-	</tr>
+        <tr>
+          <td colspan=7><hr noshade></td>
+        </tr>
 
       </table>
     </td>
   </tr>
 
   <tr>
-    <td>&nbsp;</td>
 
     <?lsmb IF notes ?>
           <td><?lsmb  FOREACH P IN notes.split('\n\n') ?>


### PR DESCRIPTION
Due to cleaning of the HTML in the documents to which that commit
was applied, backport was impossible. This manual backport fixes that.

Note that the cherry-pick caused space changes to be included in this PR; use "ignore-space-change" to compare the true nature of the PR.