### PR TITLE
Close #4971: Workaround for the batch approval list

### DIFF
--- a/lib/LedgerSMB/Scripts/vouchers.pm
+++ b/lib/LedgerSMB/Scripts/vouchers.pm
@@ -264,7 +264,7 @@ sub list_batches {
     my ($request) = @_;
     $request->open_form;
     return $request->render_report(
-        LedgerSMB::Report::Unapproved::Batch_Overview->new(%$request)
+        LedgerSMB::Report::Unapproved::Batch_Overview->new(approved => 0, %$request)
         );
 }
 


### PR DESCRIPTION
This is a workaround because it hard-codes the unapproved status
and does not restrict on the other parameters (class_id? and amount
boundaries).
There is currently insufficient infrastructure to pass these
query arguments around.
