### PR TITLE
Close #4971: Workaround for the batch approval list

### DIFF
--- a/lib/LedgerSMB/Scripts/vouchers.pm
+++ b/lib/LedgerSMB/Scripts/vouchers.pm
@@ -262,7 +262,7 @@ sub list_batches {
     my ($request) = @_;
     $request->open_form;
     return LedgerSMB::Report::Unapproved::Batch_Overview->new(
-                 %$request)->render($request);
+        approved => 0, %$request)->render($request);
 }
 
 =head2 get_batch


### PR DESCRIPTION
This is a workaround because it hard-codes the unapproved status
and does not restrict on the other parameters (class_id? and amount
boundaries).
There is currently insufficient infrastructure to pass these
query arguments around.
