### PR TITLE
Fix shipping screen showing 'incorrect response' error

### DIFF
--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -523,6 +523,8 @@ sub redirect {
     }
     else {
         $self->info($msg);
+        print '</body>';
+        $self->finalize_request;
     }
 }
 


### PR DESCRIPTION
When clicking "Done" on the shipping screen, the resulting screen shows
an 'incorrect server response: missing BODY tag' error, which this
commit resolves.
