### PR TITLE
Fix order and quote 'save as new' not updating the Number

### DIFF
--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -1634,14 +1634,22 @@ sub create_backorder {
 
 sub save_as_new {
 
-    for (qw(closed id printed emailed queued)) { delete $form->{$_} }
+    # orders don't have a quonumber
+    # quotes don't have an ordnumber
+    for (qw(closed id printed emailed queued ordnumber quonumber)) {
+        delete $form->{$_}
+    }
     &save;
 
 }
 
 sub print_and_save_as_new {
 
-    for (qw(closed id printed emailed queued)) { delete $form->{$_} }
+    # orders don't have a quonumber
+    # quotes don't have an ordnumber
+    for (qw(closed id printed emailed queued ordnumber quonumber)) {
+        delete $form->{$_}
+    }
     &print_and_save;
 
 }


### PR DESCRIPTION
Before this fix, the save-as-new button saved new orders and quotations
with the same document number (Quotation Number or Order Number) as the
one it was spawned off from.