### PR TITLE
Fix #4208: acc_trans lines have approved status but transaction does not

### DIFF
--- a/old/lib/LedgerSMB/AA.pm
+++ b/old/lib/LedgerSMB/AA.pm
@@ -410,16 +410,16 @@ sub post_transaction {
             $query = qq|
                 INSERT INTO acc_trans
                         (trans_id, chart_id, amount_bc, curr, amount_tc,
-                        transdate, memo, cleared)
+                        transdate, approved, memo, cleared)
                 VALUES  (?, (SELECT id FROM account
                                   WHERE accno = ?),
-                         ?, ?, ?, ?, ?, ?)|;
+                         ?, ?, ?, ?, ?, ?, ?)|;
 
             @queryargs = (
                 $form->{id},            $ref->{accno},
                 $ref->{amount_bc} * $ml, $ref->{curr},
                 $ref->{amount_tc} * $ml,
-                $form->{transdate},
+                $form->{transdate}, $form->{approved},
                 $ref->{description},
                 $ref->{cleared}
             );
@@ -456,15 +456,15 @@ sub post_transaction {
             $query = qq|
                 INSERT INTO acc_trans
                         (trans_id, chart_id, amount_bc, curr, amount_tc,
-                            transdate)
+                            transdate, approved)
                      VALUES (?, (SELECT id FROM account
                               WHERE accno = ?),
-                        ?, ?, ?, ?)|;
+                        ?, ?, ?, ?, ?)|;
 
             @queryargs = (
                 $form->{id}, $ref->{accno}, $ref->{amount_bc} * $ml,
                 $form->{currency}, $ref->{amount_tc} * $ml,
-                $form->{transdate}
+                $form->{transdate}, $form->{approved}
             );
             $dbh->prepare($query)->execute(@queryargs)
               || $form->dberror($query);
@@ -478,15 +478,16 @@ sub post_transaction {
         ($accno) = split /--/, $form->{$ARAP};
         $query = qq|
             INSERT INTO acc_trans
-                     (trans_id, chart_id, amount_bc, curr, amount_tc, transdate)
+                     (trans_id, chart_id, amount_bc, curr, amount_tc,
+                      transdate, approved)
               VALUES (?, (SELECT id FROM account
                               WHERE accno = ?),
-                           ?, ?, ?, ?)|;
+                           ?, ?, ?, ?, ?)|;
         @queryargs =
             ( $form->{id}, $accno,
               $invamount * -1 * $ml, $form->{currency},
               $invamount * -1 * $ml / $form->{exchangerate},
-            $form->{transdate} );
+            $form->{transdate}, $form->{approved} );
 
         $dbh->prepare($query)->execute(@queryargs)
           || $form->dberror($query);


### PR DESCRIPTION
Because the default approved status is 'true', not setting the approved
status when inserting new lines, the status always ends up as 'true'
while the status field in the form indicates it isn't (and saves the
transaction record with that status correctly).
