### PR TITLE
Fix #5289: Failure to save purchase shipping addresses (and contacts)

### DIFF
--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -40,6 +40,8 @@
 
 package lsmb_legacy;
 use Try::Tiny;
+
+use LedgerSMB::IIAA;
 use LedgerSMB::Tax;
 use LedgerSMB::Template;
 use LedgerSMB::Template::UI;
@@ -1888,7 +1890,7 @@ sub createlocations
 
          &validatelocation;
 
-         $form->{locationid} = IS->createlocation($form);
+         $form->{locationid} = IIAA->createlocation($form);
 
 
     }
@@ -1896,7 +1898,7 @@ sub createlocations
     if($form->{shiptoradiocontact}==1)
     {
          &validatecontact;
-            IS->createcontact($form);
+         IIAA->createcontact($form);
         }
 
     &ship_to unless $continue;

--- a/old/lib/LedgerSMB/IIAA.pm
+++ b/old/lib/LedgerSMB/IIAA.pm
@@ -154,5 +154,59 @@ sub post_form_manual_tax {
     return $invamount;
 }
 
+sub createlocation
+{
+
+
+  my ( $self,$form ) = @_;
+
+  my $dbh=$form->{dbh};
+
+  my $query="select * from eca__location_save(?,?,?,?,?,?,?,?,?,?, null);";
+
+  my $sth=$dbh->prepare("$query");
+
+   $sth->execute($form->{"customer_id"} // $form->{"vendor_id"},
+         undef,
+         3,  ## no critic (ProhibitMagicNumbers) sniff
+         $form->{"shiptoaddress1_new"},
+         $form->{"shiptoaddress2_new"},
+         $form->{"shiptoaddress3_new"},
+         $form->{"shiptocity_new"},
+         $form->{"shiptostate_new"},
+         $form->{"shiptozipcode_new"},
+         $form->{"shiptocountry_new"}
+            ) || $form->dberror($query);
+  my ($l_id) = $sth->fetchrow_array;
+  $sth->finish();
+  return $l_id;
+}
+
+
+
+sub createcontact
+{
+
+  my ( $self,$form ) = @_;
+
+  my $dbh=$form->{dbh};
+
+  my $query="select * from eca__save_contact(?,?,?,?,?,?);";
+
+  my $sth=$dbh->prepare("$query");
+
+  $sth->execute($form->{"customer_id"} // $form->{"vendor_id"},
+                $form->{"shiptotype_new"},
+                $form->{"shiptodescription_new"},
+                $form->{"shiptocontact_new"},
+                $form->{"shiptocontact_new"},
+                $form->{"shiptotype_new"})
+      || $form->dberror($query);
+
+  $sth->finish();
+
+}
+
+
 
 1;

--- a/old/lib/LedgerSMB/IS.pm
+++ b/old/lib/LedgerSMB/IS.pm
@@ -1744,53 +1744,6 @@ sub construct_types
 }
 
 
-sub createlocation
-{
-
-
-  my ( $self,$form ) = @_;
-
-  my $dbh=$form->{dbh};
-
-  my $query="select * from eca__location_save(?,?,?,?,?,?,?,?,?,?, null);";
-
-  my $sth=$dbh->prepare("$query");
-
-   $sth->execute($form->{"customer_id"},
-         undef,
-         3,  ## no critic (ProhibitMagicNumbers) sniff
-         $form->{"shiptoaddress1_new"},
-         $form->{"shiptoaddress2_new"},
-         $form->{"shiptoaddress3_new"},
-         $form->{"shiptocity_new"},
-         $form->{"shiptostate_new"},
-         $form->{"shiptozipcode_new"},
-         $form->{"shiptocountry_new"}
-            ) || $form->dberror($query);
-  my ($l_id) = $sth->fetchrow_array;
-  $sth->finish();
-  return $l_id;
-}
-
-
-
-sub createcontact
-{
-
-  my ( $self,$form ) = @_;
-
-  my $dbh=$form->{dbh};
-
-  my $query="select * from eca__save_contact(?,?,?,?,?,?);";
-
-  my $sth=$dbh->prepare("$query");
-
-  $sth->execute($form->{"customer_id"},$form->{"shiptotype_new"},$form->{"shiptodescription_new"},$form->{"shiptocontact_new"},$form->{"shiptocontact_new"},$form->{"shiptotype_new"}) || $form->dberror($query);
-
-  $sth->finish();
-
-}
-
 
 
 


### PR DESCRIPTION
The code to save shipping addresses and contacts had only been implemented
on the sales side of things. By moving the code from IS to IIAA and updating
it to take both customer_id and vendor_id into account, the same functionality
now applies to both sales and purchase documents.
