### PR TITLE
Fix inability to open saved invoices from search when gapless enabled

### DIFF
--- a/UI/Reports/filters/invoice_search.html
+++ b/UI/Reports/filters/invoice_search.html
@@ -253,6 +253,7 @@
                     type = 'checkbox'
                    value = '1'
                    label = text('ID')
+                 checked = 'CHECKED'
         } %]</td>
         <td>[% PROCESS input element_data = {
                     name = 'col_invnumber'

--- a/lib/LedgerSMB/Report/Invoices/Transactions.pm
+++ b/lib/LedgerSMB/Report/Invoices/Transactions.pm
@@ -254,7 +254,7 @@ sub columns {
     return [
        { col_id => 'id',
            name => $self->Text('ID'),
-           type => 'text'},
+           type => 'href'},
        { col_id => 'transdate',
            name => $self->Text('Date'),
            type => 'text'},
@@ -355,6 +355,7 @@ sub run_report {
         $r->{entity_name_href_suffix} =
                "&entity_id=$r->{entity_id}&meta_number=$r->{meta_number}";
         $r->{invnumber_href_suffix} = "$script?action=edit&id=$r->{id}";
+        $r->{id_href_suffix} = "$script?action=edit&id=$r->{id}";
     }
     return $self->rows(\@rows);
 }


### PR DESCRIPTION
The problem is that the only thing that currently can reach the invoice
is the link that's being clicked which is the invoice number. However,
with gapless numbering, saved invoices don't get an invoice number, meaning
that no link gets rendered in their place...

Resolve the above mentioned issue by turning the ID column into a link to
the invoice as well -- and display the ID by default too.
