### PR TITLE
Track history in workflows

### DIFF
--- a/UI/css/ledgersmb-common.css
+++ b/UI/css/ledgersmb-common.css
@@ -555,3 +555,8 @@ span.indicator {
     display: inline-block;
     width: 60ex;
 }
+
+#invoice caption {
+    font-size: var(--listtop-font-size);
+    font-weight: bold;
+}

--- a/UI/css/ledgersmb.css
+++ b/UI/css/ledgersmb.css
@@ -153,7 +153,7 @@
     --listrow0-font-size: initial;
     --listrow1-font-size: 10pt;
     --listsubtotal-font-size: 10pt;
-    --listtop-font-size: 1.2;
+    --listtop-font-size: 120%;
     --listtotal-font-size: 10pt;
     --menuOut-font-size: initial;
     --menuOut-a-font-size: initial;

--- a/lib/LedgerSMB/Scripts/email.pm
+++ b/lib/LedgerSMB/Scripts/email.pm
@@ -72,7 +72,8 @@ sub render {
         $wf->execute_action( $request->{wf_action} )
             if grep { $_ eq $request->{wf_action} } $wf->get_current_actions;
 
-        if ($wf->state eq 'SUCCESS') {
+        if ($wf->state eq 'SUCCESS'
+            or $request->{wf_action} eq 'Cancel') {
             return [ HTTP_SEE_OTHER,
                      [ Location => $request->{callback} ],
                      [ '' ]];

--- a/lib/LedgerSMB/Workflow/Action/Null.pm
+++ b/lib/LedgerSMB/Workflow/Action/Null.pm
@@ -1,0 +1,84 @@
+package LedgerSMB::Workflow::Action::Null;
+
+=head1 NAME
+
+LedgerSMB::Workflow::Action::Null - Workflow 'empty' Action
+
+=head1 SYNOPSIS
+
+  # action configuration
+  <actions>
+    <action name="Send" class="LedgerSMB::Workflow::Action::Null"
+            description="Some description for the workflow history" />
+  </actions>
+
+
+=head1 DESCRIPTION
+
+This module implements an action which does nothing more than logging
+a description provided in the action configuration to the history table.
+
+=head1 METHODS
+
+=cut
+
+
+use strict;
+use warnings;
+use parent qw( Workflow::Action );
+
+use DateTime;
+use Log::Any qw($log);
+use Workflow::Factory qw(FACTORY);
+
+use LedgerSMB::File::Email;
+use LedgerSMB::Magic qw(FC_EMAIL);
+
+
+my @PROPS = qw( description );
+__PACKAGE__->mk_accessors(@PROPS);
+
+=head2 init($wf, $params)
+
+Implements the C<Workflow::Action> protocol.
+
+=cut
+
+sub init {
+    my ($self, $wf, $params) = @_;
+    $self->SUPER::init($wf, $params);
+
+    $self->description( $params->{description} );
+}
+
+=head2 execute($wf)
+
+Implements the C<Workflow::Action> protocol.
+
+
+=cut
+
+sub execute {
+    my ($self, $wf) = @_;
+
+    if ($self->description) {
+        $wf->add_history(
+            {
+                action      => $self->name,
+                description => $self->description,
+                date        => DateTime->now(),
+                state       => $wf->state,
+            });
+    }
+}
+
+1;
+
+=head1 LICENSE AND COPYRIGHT
+
+Copyright (C) 2020 The LedgerSMB Core Team
+
+This file is licensed under the GNU General Public License version 2, or at your
+option any later version.  A copy of the license should have been included with
+your software.
+

--- a/old/bin/arap.pl
+++ b/old/bin/arap.pl
@@ -320,14 +320,16 @@ sub add_transaction {
 
 sub post_as_new {
 
-    for (qw(id printed emailed queued)) { delete $form->{$_} }
+    $form->{old_workflow_id} = $form->{workflow_id};
+    for (qw(id printed emailed queued workflow_id)) { delete $form->{$_} }
     &post;
 
 }
 
 sub print_and_post_as_new {
 
-    for (qw(id printed emailed queued)) { delete $form->{$_} }
+    $form->{old_workflow_id} = $form->{workflow_id};
+    for (qw(id printed emailed queued workflow_id)) { delete $form->{$_} }
     &print_and_post;
 
 }

--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -237,6 +237,7 @@ sub invoice_links {
     $form->{paidaccounts} = 1 unless ( exists $form->{paidaccounts} );
 
     $form->{AP} = $form->{AP_1} unless $form->{id};
+    $form->{AP} //= $form->{AP_links}->{AP}->[0]->{accno} unless $form->{id};
 
     $form->{locked} =
       ( $form->{revtrans} )

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -222,11 +222,12 @@ sub invoice_links {
 
     }
 
+    $form->{AR} //= $form->{AR_1} unless $form->{id};
+    $form->{AR} //= $form->{AR_links}->{AR}->[0]->{accno} unless $form->{id};
     for (qw(AR_links acc_trans)) { delete $form->{$_} }
 
     $form->{paidaccounts} = 1 unless ( exists $form->{paidaccounts} );
 
-    $form->{AR} = $form->{AR_1} unless $form->{id};
     $form->{locked} =
       ( $form->{revtrans} )
       ? '1'

--- a/sql/changes/1.9/relaxed-transdate-nullity.sql
+++ b/sql/changes/1.9/relaxed-transdate-nullity.sql
@@ -1,0 +1,16 @@
+
+ALTER TABLE transactions ALTER COLUMN transdate DROP NOT NULL;
+ALTER TABLE ar ALTER COLUMN transdate DROP NOT NULL;
+ALTER TABLE ap ALTER COLUMN transdate DROP NOT NULL;
+ALTER TABLE acc_trans ALTER COLUMN transdate DROP NOT NULL;
+
+
+ALTER TABLE transactions ADD CONSTRAINT transdate_nullity
+      CHECK (not approved or transdate is not null);
+ALTER TABLE ar ADD CONSTRAINT transdate_nullity
+      CHECK (not approved or transdate is not null);
+ALTER TABLE ap ADD CONSTRAINT transdate_nullity
+      CHECK (not approved or transdate is not null);
+ALTER TABLE acc_trans ADD CONSTRAINT transdate_nullity
+      CHECK (not approved or transdate is not null);
+

--- a/sql/changes/1.9/workflow-extend-tables.sql
+++ b/sql/changes/1.9/workflow-extend-tables.sql
@@ -5,3 +5,54 @@ ALTER TABLE transactions
 ALTER TABLE oe
    ADD COLUMN workflow_id int REFERENCES workflow (workflow_id);
 
+-- create transaction workflows
+
+UPDATE transactions t
+   SET workflow_id = nextval('workflow_seq')
+ WHERE EXISTS (select 1 from ar where t.id = ar.id and ar.invoice)
+       OR EXISTS (select 1 from ap where t.id = ap.id and ap.invoice);
+
+WITH new_workflow AS (
+   INSERT INTO workflow
+   SELECT workflow_id, 'AR/AP' as type,
+          CASE WHEN approved THEN 'POSTED' ELSE 'SAVED' END as state,
+          now() as last_update
+     FROM transactions
+    WHERE workflow_id is not null
+   RETURNING workflow_id, state, last_update
+)
+INSERT INTO workflow_history
+SELECT nextval('workflow_history_seq') as workflow_hist_id,
+       workflow_id,
+       '<upgrade>' as action,
+       'History item created for existing transaction during schema upgrade'
+                as description,
+       state,
+       '<upgrade>' as workflow_user,
+       last_update as history_date
+  FROM new_workflow;
+
+-- create order/quote workflows
+
+UPDATE oe
+   SET workflow_id = nextval('workflow_seq');
+
+WITH new_workflow AS (
+   INSERT INTO workflow
+   SELECT workflow_id, 'Order/Quote' as type,
+          'SAVED' as action, now() as last_update
+     FROM oe
+   RETURNING workflow_id, state, last_update
+)
+INSERT INTO workflow_history
+            (workflow_hist_id, workflow_id, action, description,
+             state, workflow_user, history_date)
+SELECT nextval('workflow_history_seq') as workflow_hist_id,
+       workflow_id,
+       '<upgrade>' as action,
+       'History item created for existing order/quote during schema upgrade'
+                as description,
+       state,
+       '<upgrade>' as workflow_user,
+       last_update as history_date
+  FROM new_workflow;

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -143,3 +143,4 @@ mc/delete-migration-validation-data.sql
 1.9/workflow-schema.sql
 1.9/workflow-email-table.sql
 1.9/workflow-extend-tables.sql
+1.9/relaxed-transdate-nullity.sql

--- a/t/01-load.t
+++ b/t/01-load.t
@@ -233,6 +233,8 @@ my @modules =
           'LedgerSMB::Database::Loadorder', 'LedgerSMB::Database::Change',
      'LedgerSMB::Magic',
      'LedgerSMB::Workflow::Action::Email',
+     'LedgerSMB::Workflow::Action::Null',
+     'LedgerSMB::Workflow::Action::RecordSpawnedWorkflow',
      'LedgerSMB::Workflow::Action::SpawnWorkflow',
      'LedgerSMB::Workflow::Persister',
      'LedgerSMB::Workflow::Persister::Email',

--- a/workflows/arap.actions.xml
+++ b/workflows/arap.actions.xml
@@ -1,7 +1,44 @@
 <actions type="AR/AP">
-  <action name="Save" class="Workflow::Action::Null" />
-  <action name="Post" class="Workflow::Action::Null" />
+  <!--
+
+Notes on actions for AR/AP:
+
+* 'post' really is 'save' because 'approve' models the 'Post' button
+* 'copy_to_new' does the same thing as 'save_as_new' now that updating
+  saved invoices no longer clobbers the updated data
+
+
+TODO! Check workflow when 'separate duties' is false!
+(Do we get the correct state transitions?)
+
+  -->
+  <action name="print"
+          description="Printed"
+          class="LedgerSMB::Workflow::Action::Null" />
+  <action name="save" class="Workflow::Action::Null" />
+  <action name="post" class="Workflow::Action::Null" />
+  <action name="ship_to"
+          description="Added shipping information"
+          class="LedgerSMB::Workflow::Action::Null" />
   <action name="E-mail"
           class="LedgerSMB::Workflow::Action::SpawnWorkflow"
           spawn_type="Email" />
+  <action name="print_and_save"
+          description="Printed and saved"
+          class="LedgerSMB::Workflow::Action::Null" />
+  <action name="print_and_save_as_new"
+          description="Printed and created new"
+          class="LedgerSMB::Workflow::Action::Null" />
+  <action name="save_as_new"
+          description="Created new"
+          class="LedgerSMB::Workflow::Action::RecordSpawnedWorkflow" />
+  <action name="sales_order"
+          description="Created sales order"
+          class="LedgerSMB::Workflow::Action::RecordSpawnedWorkflow" />
+  <action name="purchase_order"
+          description="Created purchase order"
+          class="LedgerSMB::Workflow::Action::RecordSpawnedWorkflow" />
+  <action name="void"
+          description="Voided"
+          class="LedgerSMB::Workflow::Action::Null" />
 </actions>

--- a/workflows/arap.conditions.xml
+++ b/workflows/arap.conditions.xml
@@ -1,0 +1,6 @@
+<conditions>
+  <type>AR/AP</type>
+  <condition name="is_sales"
+             test="($context->{table_name} eq 'ar')"
+             class="Workflow::Condition::Evaluate"/>
+</conditions>

--- a/workflows/arap.workflow.xml
+++ b/workflows/arap.workflow.xml
@@ -1,16 +1,39 @@
 <workflow>
   <type>AR/AP</type>
+<!--
+
+TODO! Check workflow when 'separate duties' is false!
+(Do we get the correct state transitions?)
+
+-->
   <persister>JournalEntry</persister>
+  <initial_state>SAVED</initial_state>
   <description>Manage the life cycle of an AR/AP document</description>
-  <state name="INITIAL">
-    <action name="Save" resulting_state="SAVED" />
-  </state>
   <state name="SAVED">
-    <action name="Post" resulting_state="POSTED" />
+    <action name="save" resulting_state="NOCHANGE" />
+    <action name="save_as_new" resulting_state="NOCHANGE" />
+    <action name="post" resulting_state="POSTED" />
+    <action name="sales_order" resulting_state="NOCHANGE">
+      <condition name="is_sales" />
+    </action>
+    <action name="purchase_order" resulting_state="NOCHANGE">
+      <condition name="!is_sales" />
+    </action>
   </state>
   <state name="POSTED">
+    <action name="save_as_new" resulting_state="NOCHANGE" />
+    <action name="void" resulting_state="VOIDED" />
     <action name="E-mail" resulting_state="NOCHANGE">
       <!-- condition name="configuredEmailFrom" / -->
     </action>
+    <action name="sales_order" resulting_state="NOCHANGE">
+      <condition name="is_sales" />
+    </action>
+    <action name="purchase_order" resulting_state="NOCHANGE">
+      <condition name="!is_sales" />
+    </action>
+  </state>
+  <state name="VOIDED">
+    <action name="save_as_new" resulting_state="NOCHANGE" />
   </state>
 </workflow>

--- a/workflows/order.actions.xml
+++ b/workflows/order.actions.xml
@@ -1,7 +1,44 @@
 <actions type="Order/Quote">
-  <action name="Save" class="Workflow::Action::Null" />
-  <action name="Post" class="Workflow::Action::Null" />
-  <action name="E-mail"
+  <action name="print"
+          description="Printed"
+          class="LedgerSMB::Workflow::Action::Null" />
+  <action name="save"
+          description="Saved (overwritten)"
+          class="LedgerSMB::Workflow::Action::Null" />
+  <action name="ship_to"
+          description="Added shipping information"
+          class="LedgerSMB::Workflow::Action::Null" />
+  <action name="e_mail"
           class="LedgerSMB::Workflow::Action::SpawnWorkflow"
           spawn_type="Email" />
+  <action name="print_and_save"
+          description="Printed and saved"
+          class="LedgerSMB::Workflow::Action::Null" />
+  <action name="print_and_save_as_new"
+          description="Printed and created new"
+          class="LedgerSMB::Workflow::Action::Null" />
+  <action name="save_as_new"
+          description="Created new"
+          class="LedgerSMB::Workflow::Action::RecordSpawnedWorkflow" />
+  <action name="sales_invoice"
+          description="Created sales invoice"
+          class="LedgerSMB::Workflow::Action::RecordSpawnedWorkflow" />
+  <action name="sales_order"
+          description="Created sales order"
+          class="LedgerSMB::Workflow::Action::RecordSpawnedWorkflow" />
+  <action name="quotation"
+          description="Created quotation"
+          class="LedgerSMB::Workflow::Action::RecordSpawnedWorkflow" />
+  <action name="vendor_invoice"
+          description="Created vendor invoice"
+          class="LedgerSMB::Workflow::Action::RecordSpawnedWorkflow" />
+  <action name="purchase_order"
+          description="Created purchase order"
+          class="LedgerSMB::Workflow::Action::RecordSpawnedWorkflow" />
+  <action name="rfq"
+          description="Created request-for-quote"
+          class="LedgerSMB::Workflow::Action::RecordSpawnedWorkflow" />
+  <action name="delete"
+          description="Deleted"
+          class="LedgerSMB::Workflow::Action::Null" />
 </actions>

--- a/workflows/order.conditions.xml
+++ b/workflows/order.conditions.xml
@@ -1,0 +1,9 @@
+<conditions>
+  <type>Order/Quote</type>
+  <condition name="is_sales"
+             test="($context->{_extra}->{oe_class_id} &amp; 1) == 1"
+             class="Workflow::Condition::Evaluate"/>
+  <condition name="is_order"
+             test="$context->{_extra}->{oe_class_id} &lt;= 2"
+             class="Workflow::Condition::Evaluate"/>
+</conditions>

--- a/workflows/order.workflow.xml
+++ b/workflows/order.workflow.xml
@@ -1,13 +1,42 @@
 <workflow>
   <type>Order/Quote</type>
+  <initial_state>SAVED</initial_state>
   <persister>Order</persister>
   <description>Manage the life cycle of an AR/AP document</description>
-  <state name="INITIAL">
-    <action name="Save" resulting_state="SAVED" />
-  </state>
   <state name="SAVED">
-    <action name="E-mail" resulting_state="NOCHANGE">
+    <action name="e_mail" resulting_state="NOCHANGE">
       <!-- condition name="configuredEmailFrom" / -->
     </action>
+    <action name="print" resulting_state="NOCHANGE" />
+    <action name="print_and_save" resulting_state="NOCHANGE" />
+    <action name="print_and_save_as_new" resulting_state="NOCHANGE" />
+    <action name="save" resulting_state="NOCHANGE" />
+    <action name="save_as_new" resulting_state="NOCHANGE" />
+    <!-- action name="ship_to" resulting_state="NOCHANGE" / -->
+    <action name="sales_invoice" resulting_state="NOCHANGE">
+      <condition name="is_sales" />
+    </action>
+    <action name="sales_order" resulting_state="NOCHANGE">
+      <condition name="is_sales" />
+      <condition name="!is_order" />
+    </action>
+    <action name="quotation" resulting_state="NOCHANGE">
+      <condition name="is_sales" />
+      <condition name="is_order" />
+    </action>
+    <action name="vendor_invoice" resulting_state="NOCHANGE">
+      <condition name="!is_sales" />
+    </action>
+    <action name="purchase_order" resulting_state="NOCHANGE">
+      <condition name="!is_sales" />
+      <condition name="!is_order" />
+    </action>
+    <action name="rfq" resulting_state="NOCHANGE">
+      <condition name="!is_sales" />
+      <condition name="is_order" />
+    </action>
+    <action name="delete" resulting_state="DELETED" />
+  </state>
+  <state name="DELETED">
   </state>
 </workflow>

--- a/xt/lib/Pherkin/Extension/LedgerSMB.pm
+++ b/xt/lib/Pherkin/Extension/LedgerSMB.pm
@@ -19,6 +19,7 @@ use LedgerSMB::Database;
 use LedgerSMB::PGDate;
 use LedgerSMB::Entity::Person::Employee;
 use LedgerSMB::Entity::User;
+use LedgerSMB::Sysconfig;
 use Test::BDD::Cucumber::Extension;
 use List::Util qw(any);
 use Log::Log4perl qw(:easy);
@@ -27,7 +28,7 @@ use Moose;
 use namespace::autoclean;
 extends 'Test::BDD::Cucumber::Extension';
 
-
+LedgerSMB::Sysconfig->initialize;
 
 has db_name => (is => 'rw', default => $ENV{PGDATABASE});
 has username => (is => 'rw', default => $ENV{PGUSER});


### PR DESCRIPTION
This change adds action-logging to quotes, orders and invoices: state changes and spawned actions (such as e-mails created) are now visible from the document page. Also, this change saves invoices created from orders before closing the originating order.
