### PR TITLE
Close #776: Move from row-based to column based preference storage

### DIFF
--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -1232,8 +1232,8 @@ sub db_init {
 
 sub _set_datestyle {
     my $dbh = shift;
-    my $datequery = 'select dateformat from user_preference join users using(id)
-                      where username = CURRENT_USER';
+    my $datequery = q{select "value" from user_preference join users using(id)
+                      where "name" = 'dateformat' and username = CURRENT_USER};
     my $date_sth = $dbh->prepare($datequery);
     $date_sth->execute;
     my ($datestyle) = $date_sth->fetchrow_array;

--- a/sql/changes/1.9/transpose_user_prefs.sql
+++ b/sql/changes/1.9/transpose_user_prefs.sql
@@ -1,0 +1,59 @@
+
+alter table user_preference rename to old_user_preference;
+alter table old_user_preference drop constraint user_preference_pkey;
+
+
+create table user_preference (
+   id      serial primary key,
+   user_id int check (user_id is null or user_id > 0)
+                references users(id) on delete cascade,
+   "name"  text not null,
+   "value" text not null
+);
+
+create unique index user_preference_unique_setting
+       on user_preference (coalesce(user_id, 0), "name");
+
+comment on index user_preference_unique_setting is
+$$This index replaces the uniqueness check of a primary key and
+maps NULL `user_id` values to zero to support uniqueness checks.$$;
+
+comment on table user_preference is
+$$This table lists user and global preferences, one preference per row.
+
+Global preferences are stored using a NULL `user_id` value, requiring
+a workaround to check uniqueness of the preference `name` column.
+$$;
+
+comment on column user_preference.id is
+$$This column is a surrogate primary key.
+
+It compensates for the fact that we cannot require `user_id` to be not-null
+because global settings will be stored with a NULL `user_id`. It exists to
+allow interactive software (e.g. PgAdmin4) to edit rows in the table.$$;
+
+insert into user_preference (id, "name", "value")
+select id, 'language', language
+from old_user_preference where language is not null
+union all
+select id, 'stylesheet', stylesheet
+from old_user_preference where stylesheet is not null
+union all
+select id, 'printer', printer
+from old_user_preference where printer is not null
+union all
+select id, 'dateformat', dateformat
+from old_user_preference where dateformat is not null
+union all
+select id, 'numberformat', numberformat
+from old_user_preference where numberformat is not null;
+
+
+drop table old_user_preference;
+
+-- insert global defaults as they used to be set
+-- on the columns of the user preference table
+insert into user_preference ("name", "value")
+values ('stylesheet', 'ledgersmb.css'),
+       ('dateformat', 'yyyy-mm-dd'),
+       ('numberformat', '1000.00');

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -144,3 +144,4 @@ mc/delete-migration-validation-data.sql
 1.9/workflow-email-table.sql
 1.9/workflow-extend-tables.sql
 1.9/relaxed-transdate-nullity.sql
+1.9/transpose_user_prefs.sql

--- a/sql/modules/BLACKLIST
+++ b/sql/modules/BLACKLIST
@@ -374,6 +374,8 @@ pnl__income_statement_accrual
 pnl__income_statement_cash
 pnl__invoice
 pnl__product
+preference__get
+preference__set
 prevent_closed_transactions
 pricegroup__list
 pricegroup__search

--- a/sql/modules/FinStatements.sql
+++ b/sql/modules/FinStatements.sql
@@ -47,11 +47,7 @@ WITH acc_meta AS (
      LEFT JOIN (SELECT trans_id, description
                   FROM account_translation
                  WHERE language_code =
-                        coalesce($5,
-                          (SELECT up.language
-                             FROM user_preference up
-                       INNER JOIN users ON up.id = users.id
-                            WHERE users.username = SESSION_USER))) at
+                        coalesce($5, preference__get('language'))) at
                ON a.id = at.trans_id
    WHERE array_splice_from((SELECT value::int FROM defaults
                              WHERE setting_key = 'earn_id'),aht.path)
@@ -76,11 +72,7 @@ hdr_meta AS (
     LEFT JOIN (SELECT trans_id, description
                  FROM account_translation
                 WHERE language_code =
-                       coalesce($5,
-                         (SELECT up.language
-                            FROM user_preference up
-                      INNER JOIN users ON up.id = users.id
-                           WHERE users.username = SESSION_USER))) at
+                       coalesce($5, preference__get('language'))) at
               ON aht.id = at.trans_id
     WHERE ((SELECT value::int FROM defaults
                               WHERE setting_key = 'earn_id') IS NOT NULL
@@ -177,11 +169,7 @@ WITH acc_meta AS (
      LEFT JOIN (SELECT trans_id, description
                   FROM account_translation
                  WHERE language_code =
-                        coalesce($5,
-                          (SELECT up.language
-                             FROM user_preference up
-                       INNER JOIN users ON up.id = users.id
-                            WHERE users.username = SESSION_USER))) at
+                        coalesce($5, preference__get('language'))) at
                ON a.id = at.trans_id
    WHERE array_splice_from((SELECT value::int FROM defaults
                              WHERE setting_key = 'earn_id'),aht.path)
@@ -206,11 +194,7 @@ hdr_meta AS (
     LEFT JOIN (SELECT trans_id, description
                  FROM account_translation
                 WHERE language_code =
-                       coalesce($5,
-                         (SELECT up.language
-                            FROM user_preference up
-                      INNER JOIN users ON up.id = users.id
-                           WHERE users.username = SESSION_USER))) at
+                       coalesce($5, preference__get('language'))) at
               ON aht.id = at.trans_id
     WHERE ((SELECT value::int FROM defaults
                               WHERE setting_key = 'earn_id') IS NOT NULL
@@ -298,11 +282,7 @@ WITH acc_meta AS (
      LEFT JOIN (SELECT trans_id, description
                   FROM account_translation
                  WHERE language_code =
-                        coalesce($5,
-                          (SELECT up.language
-                             FROM user_preference up
-                       INNER JOIN users ON up.id = users.id
-                            WHERE users.username = SESSION_USER))) at
+                        coalesce($5, preference__get('language'))) at
                ON a.id = at.trans_id
    WHERE array_splice_from((SELECT value::int FROM defaults
                              WHERE setting_key = 'earn_id'),aht.path)
@@ -327,11 +307,7 @@ hdr_meta AS (
     LEFT JOIN (SELECT trans_id, description
                  FROM account_translation
                 WHERE language_code =
-                       coalesce($5,
-                         (SELECT up.language
-                            FROM user_preference up
-                      INNER JOIN users ON up.id = users.id
-                           WHERE users.username = SESSION_USER))) at
+                       coalesce($5, preference__get('language'))) at
               ON aht.id = at.trans_id
     WHERE ((SELECT value::int FROM defaults
                               WHERE setting_key = 'earn_id') IS NOT NULL
@@ -421,11 +397,7 @@ WITH acc_meta AS (
      LEFT JOIN (SELECT trans_id, description
                   FROM account_translation
                  WHERE language_code =
-                        coalesce($2,
-                          (SELECT up.language
-                             FROM user_preference up
-                       INNER JOIN users ON up.id = users.id
-                            WHERE users.username = SESSION_USER))) at
+                        coalesce($2, preference__get('language'))) at
                ON a.id = at.trans_id
    WHERE array_splice_from((SELECT value::int FROM defaults
                              WHERE setting_key = 'earn_id'),aht.path)
@@ -450,11 +422,7 @@ hdr_meta AS (
     LEFT JOIN (SELECT trans_id, description
                  FROM account_translation
                 WHERE language_code =
-                       coalesce($2,
-                         (SELECT up.language
-                            FROM user_preference up
-                      INNER JOIN users ON up.id = users.id
-                           WHERE users.username = SESSION_USER))) at
+                       coalesce($2, preference__get('language'))) at
               ON aht.id = at.trans_id
     WHERE ((SELECT value::int FROM defaults
                               WHERE setting_key = 'earn_id') IS NOT NULL
@@ -513,11 +481,7 @@ WITH acc_meta AS (
      LEFT JOIN (SELECT trans_id, description
                   FROM account_translation
                  WHERE language_code =
-                        coalesce($4,
-                          (SELECT up.language
-                             FROM user_preference up
-                       INNER JOIN users ON up.id = users.id
-                            WHERE users.username = SESSION_USER))) at
+                        coalesce($4, preference__get('language'))) at
                ON a.id = at.trans_id
    WHERE array_splice_from((SELECT value::int FROM defaults
                              WHERE setting_key = 'earn_id'),aht.path)
@@ -542,11 +506,7 @@ hdr_meta AS (
     LEFT JOIN (SELECT trans_id, description
                  FROM account_translation
                 WHERE language_code =
-                       coalesce($4,
-                         (SELECT up.language
-                            FROM user_preference up
-                      INNER JOIN users ON up.id = users.id
-                           WHERE users.username = SESSION_USER))) at
+                       coalesce($4, preference__get('language'))) at
               ON aht.id = at.trans_id
     WHERE ((SELECT value::int FROM defaults
                               WHERE setting_key = 'earn_id') IS NOT NULL
@@ -626,11 +586,7 @@ hdr_meta AS (
     LEFT JOIN (SELECT trans_id, description
                  FROM account_translation
                 WHERE language_code =
-                       coalesce(in_language,
-                         (SELECT up.language
-                            FROM user_preference up
-                      INNER JOIN users ON up.id = users.id
-                           WHERE users.username = SESSION_USER))) at
+                       coalesce(in_language, preference__get('language'))) at
               ON aht.id = at.trans_id
      WHERE array_endswith((SELECT value::int FROM defaults
                             WHERE setting_key = 'earn_id'), aht.path)
@@ -648,11 +604,7 @@ acc_meta AS (
      LEFT JOIN (SELECT trans_id, description
                   FROM account_translation
                  WHERE language_code =
-                        coalesce(in_language,
-                          (SELECT up.language
-                             FROM user_preference up
-                       INNER JOIN users ON up.id = users.id
-                            WHERE users.username = SESSION_USER))) at
+                        coalesce(in_language, preference__get('language'))) at
                ON a.id = at.trans_id
      WHERE array_endswith((SELECT value::int FROM defaults
                             WHERE setting_key = 'earn_id'), aht.path)

--- a/sql/modules/LOADORDER
+++ b/sql/modules/LOADORDER
@@ -7,6 +7,7 @@
 triggers.sql
 old.sql
 Settings.sql
+Preferences.sql
 Util.sql
 App_Module.sql
 Menu.sql

--- a/sql/modules/Preferences.sql
+++ b/sql/modules/Preferences.sql
@@ -1,0 +1,70 @@
+
+set client_min_messages = 'warning';
+
+BEGIN;
+
+
+CREATE OR REPLACE FUNCTION preference__set (in_name text, in_value text, in_global boolean = false)
+RETURNS BOOL AS
+$$
+BEGIN
+  IF in_global THEN
+    IF in_value IS NULL THEN
+      DELETE FROM user_preference
+       WHERE "name" = in_name AND user_id IS NULL;
+
+      RETURN true;
+    END IF;
+
+    INSERT INTO user_preference (user_id, "name", "value")
+         VALUES (NULL, in_name, in_value)
+      ON CONFLICT (coalesce(user_id, 0), "name")
+    DO
+      UPDATE SET "value" = in_value;
+
+    RETURN true;
+  END IF;
+
+  IF in_value IS NULL THEN
+     DELETE FROM user_preference
+      WHERE user_id = (select id from users where username=SESSION_USER)
+            AND "name" = in_name;
+     RETURN true;
+  END IF;
+
+  INSERT INTO user_preference (user_id, "name", "value")
+       VALUES ((select id from users
+                 where username=SESSION_USER), in_name, in_value)
+    ON CONFLICT (coalesce(user_id, 0), "name")
+  DO
+    UPDATE SET "value" = in_value;
+
+  RETURN true;
+END;
+$$ language plpgsql;
+
+
+COMMENT ON FUNCTION preference__set (in_name text, in_value text, in_global boolean) IS
+$$ sets a value in the defaults thable and returns true if successful.$$;
+
+
+CREATE OR REPLACE FUNCTION preference__get (in_name text) RETURNS text AS
+$$
+  SELECT "value" FROM user_preference
+   WHERE "name" = in_name
+         AND (user_id is null
+              OR user_id = (select id from users
+                             where username = session_user)
+                             )
+  order by user_id
+  limit 1
+$$ LANGUAGE sql;
+
+COMMENT ON FUNCTION preference__get (in_key text) IS
+$$ Returns the value of the setting in the defaults table.$$;
+
+
+
+update defaults set value = 'yes' where setting_key = 'module_load_ok';
+
+COMMIT;

--- a/sql/modules/Roles.sql
+++ b/sql/modules/Roles.sql
@@ -1231,6 +1231,7 @@ SELECT lsmb__grant_perms('base_user', obj, 'SELECT')
 
 SELECT lsmb__grant_perms('base_user', obj, 'ALL')
   FROM unnest(array['session'::text, 'session_session_id_seq',
+                    'user_preference_id_seq',
                     'user_preference', 'status', 'recurring',
                     'recurringemail', 'recurringprint', 'transactions',
                     'ac_tax_form', 'invoice_tax_form', 'lsmb_sequence']) obj;

--- a/xt/66-cucumber/01-basic/step_definitions/ledgersmb_steps.pl
+++ b/xt/66-cucumber/01-basic/step_definitions/ledgersmb_steps.pl
@@ -24,10 +24,12 @@ Given qr/these preferences for the (admin|user)(?: "([^"]+)")?:/, sub {
     my $data = C->data;
 
     my $dbh = S->{ext_lsmb}->admin_dbh;
-    my $query = 'UPDATE user_preference SET ' . join(' ', map { "$_->{setting} = ?" } $data->@*)
-        . ' WHERE id = (select id from users where username = ?)';
-    $dbh->do($query, {}, (map { $_->{value} } $data->@*), $user_name )
-        or die $dbh->errstr;
+    my $query = 'SELECT preference__set(?, ?)';
+    my $sth = $dbh->prepare($query);
+    for my $setting ($data->@*) {
+        $sth->execute($setting->{setting}, $setting->{value})
+            or die $sth->errstr;
+    }
 };
 
 


### PR DESCRIPTION
By moving from a row to column based setup, there's (much) more flexibility
to define preferences, including allowing preferences to be defined by plugins.

Note too that this commit no longer stores the default values for the prefs in
the DDL (schema), but has moved the default values into the user_preference table,
thus allowing e.g. CoAs or other locale specific configurations to specify
default preferences with other values than the ones that were hard-coded in the
schema (as well as that they'll be able to specify more/different default
preferences).

Enables #815.