### PR TITLE
New invoice content in AP/AR tests

### DIFF
--- a/xt/lib/PageObject/App/AP/Invoice.pm
+++ b/xt/lib/PageObject/App/AP/Invoice.pm
@@ -40,7 +40,7 @@ sub select_vendor {
     $elem->clear;
     $elem->send_keys($vendor);
 
-    $self->update($elem);
+    $self->update;
 }
 
 

--- a/xt/lib/PageObject/App/AP/Invoice.pm
+++ b/xt/lib/PageObject/App/AP/Invoice.pm
@@ -41,6 +41,7 @@ sub select_vendor {
     $elem->send_keys($vendor);
 
     $self->update;
+    $self->session->page->body->maindiv->wait_for_content(replaces => $elem);
 }
 
 

--- a/xt/lib/PageObject/App/AP/Invoice.pm
+++ b/xt/lib/PageObject/App/AP/Invoice.pm
@@ -40,8 +40,7 @@ sub select_vendor {
     $elem->clear;
     $elem->send_keys($vendor);
 
-    $self->update;
-    $self->session->page->body->maindiv->wait_for_content(replaces => $elem);
+    $self->update($elem);
 }
 
 

--- a/xt/lib/PageObject/App/AR/Invoice.pm
+++ b/xt/lib/PageObject/App/AR/Invoice.pm
@@ -40,7 +40,7 @@ sub select_customer {
     $elem->clear;
     $elem->send_keys($customer);
 
-    $self->update($elem);
+    $self->update;
 }
 
 

--- a/xt/lib/PageObject/App/AR/Invoice.pm
+++ b/xt/lib/PageObject/App/AR/Invoice.pm
@@ -40,8 +40,7 @@ sub select_customer {
     $elem->clear;
     $elem->send_keys($customer);
 
-    $self->update;
-    $self->session->page->body->maindiv->wait_for_content(replaces => $elem);
+    $self->update($elem);
 }
 
 

--- a/xt/lib/PageObject/App/AR/Invoice.pm
+++ b/xt/lib/PageObject/App/AR/Invoice.pm
@@ -21,8 +21,6 @@ __PACKAGE__->self_register(
                   id => 'AR-invoice',
               });
 
-
-
 sub _verify {
     my ($self) = @_;
 
@@ -43,6 +41,7 @@ sub select_customer {
     $elem->send_keys($customer);
 
     $self->update;
+    $self->session->page->body->maindiv->wait_for_content(replaces => $elem);
 }
 
 

--- a/xt/lib/PageObject/App/Invoice.pm
+++ b/xt/lib/PageObject/App/Invoice.pm
@@ -21,10 +21,11 @@ sub _verify {
 }
 
 sub update {
-    my ($self,$elem) = @_;
+    my ($self) = @_;
 
-    $self->find("*button", text => "Update")->click;
-    $self->session->page->body->maindiv->wait_for_content(replaces => $elem);
+    my $btn = $self->find("*button", text => "Update");
+    $btn->click;
+    $self->session->page->body->maindiv->wait_for_content(replaces => $btn);
 }
 
 sub _post_btn {

--- a/xt/lib/PageObject/App/Invoice.pm
+++ b/xt/lib/PageObject/App/Invoice.pm
@@ -21,10 +21,10 @@ sub _verify {
 }
 
 sub update {
-    my ($self) = @_;
+    my ($self,$elem) = @_;
 
     $self->find("*button", text => "Update")->click;
-    $self->session->page->body->maindiv->wait_for_content;
+    $self->session->page->body->maindiv->wait_for_content(replaces => $elem);
 }
 
 sub _post_btn {


### PR DESCRIPTION
Make sure we get the desired customer or vendor before declaring the page loaded to remove some test brittleness.