### PR TITLE
Optimize roles transactions

### DIFF
--- a/bin/delete-company-database
+++ b/bin/delete-company-database
@@ -10,7 +10,7 @@ then
   exit 1
 fi
 
-cmd="select rolname FROM pg_roles WHERE rolname LIKE 'lsmb_${1}__%';"
+cmd="SELECT rolname FROM pg_roles WHERE rolname LIKE 'lsmb_${1}__%';"
 company_roles=`su -c "psql -U postgres -t -c \"$cmd\"" postgres`
 
 su -c "dropdb -U postgres $1" postgres

--- a/sql/modules/Roles.sql
+++ b/sql/modules/Roles.sql
@@ -103,6 +103,8 @@ $$
 DECLARE
   t_in_role text;
 BEGIN
+  -- Make sure to evaluate the role once because the optimizer
+  -- uses it as a filter on every row otherwise
    SELECT lsmb__role(in_role) INTO t_in_role;
    PERFORM rolname FROM pg_roles WHERE rolname = t_in_role;
    IF NOT FOUND THEN

--- a/sql/modules/Settings.sql
+++ b/sql/modules/Settings.sql
@@ -18,7 +18,7 @@ $$
            SELECT substr(value,1,3)
            FROM defaults
            WHERE setting_key = 'curr';
-$$ language sql;
+$$ language sql STABLE;
 
 COMMENT ON FUNCTION defaults_get_defaultcurrency() IS
 $$ This function return the default currency asigned by the program. $$;
@@ -105,7 +105,7 @@ ALTER TABLE entity ALTER control_code SET default setting_increment('entity_cont
 
 
 CREATE OR REPLACE FUNCTION lsmb__role_prefix() RETURNS text
-LANGUAGE SQL AS
+LANGUAGE SQL STABLE AS
 $$ select coalesce((setting_get('role_prefix')).value,
                    'lsmb_' || current_database() || '__'); $$;
 
@@ -114,7 +114,7 @@ $$ Returns the prefix text to be used for roles. E.g.  'lsmb__mycompany_' $$;
 
 
 CREATE OR REPLACE FUNCTION lsmb__role(global_role text) RETURNS text
-LANGUAGE SQL AS
+LANGUAGE SQL STABLE AS
 $$ select lsmb__role_prefix() || $1; $$;
 
 COMMENT ON FUNCTION lsmb__role(global_role text) IS

--- a/sql/modules/admin.sql
+++ b/sql/modules/admin.sql
@@ -30,6 +30,8 @@ CREATE OR REPLACE FUNCTION admin__add_user_to_role(in_username TEXT, in_role TEX
     BEGIN
 
         -- Issue the grant
+        -- Make sure to evaluate the role once because the optimizer
+        -- uses it as a filter on every row otherwise
         SELECT lsmb__role(in_role) INTO t_in_role;
         select rolname into a_role from pg_roles
           where rolname = t_in_role;
@@ -71,6 +73,8 @@ CREATE OR REPLACE FUNCTION admin__remove_user_from_role(in_username TEXT, in_rol
     BEGIN
 
         -- Issue the grant
+        -- Make sure to evaluate the role once because the optimizer
+        -- uses it as a filter on every row otherwise
         SELECT lsmb__role(in_role) INTO t_in_role;
         select rolname into a_role from pg_roles
          where rolname = t_in_role;
@@ -144,6 +148,8 @@ CREATE OR REPLACE FUNCTION admin__get_roles_for_user(in_user_id INT) returns set
             END IF;
         END IF;
 
+        -- Make sure to evaluate the role prefix once because the optimizer
+        -- uses it as a filter on every row otherwise
         SELECT lsmb__role_prefix() INTO t_role_prefix;
         FOR u_role IN
         select r.rolname
@@ -210,6 +216,8 @@ CREATE OR REPLACE FUNCTION admin__get_roles_for_user_by_entity(in_entity_id INT)
             END IF;
         END IF;
 
+        -- Make sure to evaluate the role prefix once because the optimizer
+        -- uses it as a filter on every row otherwise
         SELECT lsmb__role_prefix() INTO t_role_prefix;
         FOR u_role IN
         select r.rolname
@@ -473,6 +481,8 @@ DECLARE
    u_role pg_roles;
    t_role_prefix TEXT;
 begin
+    -- Make sure to evaluate the role prefix once because the optimizer
+    -- uses it as a filter on every row otherwise
      SELECT lsmb__role_prefix() INTO t_role_prefix;
      FOR u_role IN
         SELECT *


### PR DESCRIPTION
The PG optimizer has trouble with functions in WHERE clauses because they are considered out of scope for each query.
This PR makes sure that roles functions are called once to compensate.