### PR TITLE
Yath duration tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ commands:
               JOB_COUNT=2
             fi
             yath start --job-count $JOB_COUNT --event-timeout 1800 # Timeout after 30 min
-            yath --qvf --color --no-progress \
+            yath --qvf --color --no-progress --retry=2 \
               --pgtap-dbname=$PGDB --pgtap-username=$PGUSER \
               --pgtap-psql=.circleci/psql-wrap \
               --Feature-tags=~@wip \

--- a/t/01-load.t
+++ b/t/01-load.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-LONG
 
 use strict;
 use warnings;

--- a/t/02-number-handling.t
+++ b/t/02-number-handling.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-SHORT
 
 use strict;
 use warnings;

--- a/t/02.1-number-to-text.t
+++ b/t/02.1-number-to-text.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-SHORT
 
 use Test2::V0;
 

--- a/t/03-date-handling.t
+++ b/t/03-date-handling.t
@@ -2,6 +2,7 @@
 #
 # Note: This file assumes good dates, SL behaviour with bad dates is undefined
 #
+# HARNESS-DURATION-SHORT
 
 use strict;
 use warnings;

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-SHORT
 
 use strict;
 use warnings;

--- a/t/06-blacklist.t
+++ b/t/06-blacklist.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-SHORT
 
 use LedgerSMB::Sysconfig;
 

--- a/t/07.1-extract-perl.t
+++ b/t/07.1-extract-perl.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-SHORT
 
 use strict;
 use warnings;

--- a/t/10-form.t
+++ b/t/10-form.t
@@ -4,6 +4,7 @@
 #
 # Tests various functions in LedgerSMB::Form that aren't tested elsewhere.
 #
+# HARNESS-DURATION-SHORT
 
 # format_amount in 02-number-handling.t
 # parse_amount  in 02-number-handling.t

--- a/t/11-ledgersmb.t
+++ b/t/11-ledgersmb.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-SHORT
 
 use strict;
 use warnings;

--- a/t/12-dbconfig.t
+++ b/t/12-dbconfig.t
@@ -1,4 +1,5 @@
 #!perl
+# HARNESS-DURATION-SHORT
 
 use File::Spec;
 use Test::More;

--- a/t/12-sysconfig.t
+++ b/t/12-sysconfig.t
@@ -1,4 +1,5 @@
 #!perl
+# HARNESS-DURATION-SHORT
 
 use Test2::V0;
 use Test2::Tools::Spec;

--- a/t/13-auth-parsing.t
+++ b/t/13-auth-parsing.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-SHORT
 
 use Test2::V0;
 use MIME::Base64;

--- a/t/14-report-axis.t
+++ b/t/14-report-axis.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-SHORT
 
 use Test2::V0;
 

--- a/t/14-report-dates.t
+++ b/t/14-report-dates.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-SHORT
 
 use Test2::V0;
 

--- a/t/14-report-hierarchical.t
+++ b/t/14-report-hierarchical.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-SHORT
 
 use Test2::V0;
 

--- a/t/15-loadorder.t
+++ b/t/15-loadorder.t
@@ -1,4 +1,5 @@
 #!perl
+# HARNESS-DURATION-SHORT
 
 =head1 UNIT TESTS FOR
 

--- a/t/16-dbchange.t
+++ b/t/16-dbchange.t
@@ -1,4 +1,5 @@
 #!perl
+# HARNESS-DURATION-SHORT
 
 =head1 UNIT TESTS FOR
 

--- a/t/16-dbupgrade.t
+++ b/t/16-dbupgrade.t
@@ -1,4 +1,5 @@
 #!perl
+# HARNESS-DURATION-SHORT
 
 =head1 UNIT TESTS FOR
 

--- a/t/16-prechecks.t
+++ b/t/16-prechecks.t
@@ -1,4 +1,5 @@
 #!perl
+# HARNESS-DURATION-SHORT
 
 
 =head1 Driver application for testing of schema change checks

--- a/t/16-schema-upgrade-html.t
+++ b/t/16-schema-upgrade-html.t
@@ -1,4 +1,5 @@
 # Database schema upgrade pre-checks
+# HARNESS-DURATION-SHORT
 
 use Test2::V0;
 use Text::Diff;

--- a/t/16-schema-upgrade-json.t
+++ b/t/16-schema-upgrade-json.t
@@ -1,4 +1,5 @@
 #!perl
+# HARNESS-DURATION-SHORT
 
 # Database schema upgrade pre-checks
 

--- a/t/16-schema-upgrade-precheck.t
+++ b/t/16-schema-upgrade-precheck.t
@@ -1,4 +1,5 @@
 # Database schema upgrade pre-checks
+# HARNESS-DURATION-SHORT
 
 
 use Test2::V0 qw(!check); # ChangeChecks imports 'check'

--- a/t/17-setting.t
+++ b/t/17-setting.t
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-SHORT
 
 use Test2::V0;
 use LedgerSMB::Setting;

--- a/t/18-input-map.t
+++ b/t/18-input-map.t
@@ -1,4 +1,5 @@
 #!perl
+# HARNESS-DURATION-SHORT
 
 use Test2::V0;
 

--- a/t/20-camt053.t
+++ b/t/20-camt053.t
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-SHORT
 
 use Test2::V0;
 

--- a/t/21-ofx-bank-statement.t
+++ b/t/21-ofx-bank-statement.t
@@ -1,6 +1,7 @@
 use Test2::V0;
 use warnings;
 use strict;
+# HARNESS-DURATION-SHORT
 
 use LedgerSMB::FileFormats::OFX::BankStatement;
 

--- a/t/22-company-configuration.t
+++ b/t/22-company-configuration.t
@@ -1,4 +1,5 @@
 #!perl
+# HARNESS-DURATION-SHORT
 
 use Test2::V0;
 use warnings;

--- a/xt/01-default-config-checks.t
+++ b/xt/01-default-config-checks.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-SHORT
 
 use Test2::V0;
 

--- a/xt/01-html-checks.t
+++ b/xt/01-html-checks.t
@@ -1,4 +1,5 @@
 #!perl
+# HARNESS-DURATION-SHORT
 
 
 use Test2::V0;

--- a/xt/01-js-checks.t
+++ b/xt/01-js-checks.t
@@ -1,4 +1,5 @@
 #!perl
+# HARNESS-DURATION-SHORT
 
 use Test2::V0;
 

--- a/xt/01-sql-checks.t
+++ b/xt/01-sql-checks.t
@@ -1,4 +1,5 @@
 #!perl
+# HARNESS-DURATION-SHORT
 
 use Test2::V0;
 

--- a/xt/01.1-critic.t
+++ b/xt/01.1-critic.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-LONG
 
 
 use Test2::V0;

--- a/xt/01.2-deps.t
+++ b/xt/01.2-deps.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-SHORT
 
 use Module::CPANfile;
 use File::Find;

--- a/xt/05-po-checks.t
+++ b/xt/05-po-checks.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-SHORT
 
 use Test2::V0;
 

--- a/xt/06.1-Perl-PO.t
+++ b/xt/06.1-Perl-PO.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-MEDIUM
 
 =pod
 

--- a/xt/07.1-pod.t
+++ b/xt/07.1-pod.t
@@ -4,6 +4,7 @@
 #
 # Checks POD syntax.
 #
+# HARNESS-DURATION-SHORT
 
 use strict;
 use warnings;

--- a/xt/07.2-pod-copyright.t
+++ b/xt/07.2-pod-copyright.t
@@ -4,6 +4,7 @@
 #
 # Checks that every pod file has a LICENSE AND COPYRIGHT section
 # matching a template in `xt/data/07.2-license-and-copyright.template`.
+# HARNESS-DURATION-SHORT
 
 use Test2::V0;
 use Test2::Require::Module 'Test::Pod' => '1.00';

--- a/xt/08-pod-coverage.t
+++ b/xt/08-pod-coverage.t
@@ -4,6 +4,7 @@
 #
 # Checks POD coverage.
 #
+# HARNESS-DURATION-SHORT
 
 use Test2::V0;
 use Test2::Tools::Spec;

--- a/xt/09-versioning.t
+++ b/xt/09-versioning.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-SHORT
 
 use Test2::V0;
 

--- a/xt/40-database.t
+++ b/xt/40-database.t
@@ -1,4 +1,5 @@
 #!perl
+# HARNESS-DURATION-SHORT
 
 use Test2::V0;
 

--- a/xt/40-ledgersmb.t
+++ b/xt/40-ledgersmb.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-SHORT
 
 use strict;
 use warnings;

--- a/xt/41-coaload.t
+++ b/xt/41-coaload.t
@@ -1,4 +1,5 @@
 #!/usr/bin/env perl
+# HARNESS-DURATION-MEDIUM
 
 use strict;
 use warnings;

--- a/xt/42-account.pg
+++ b/xt/42-account.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-admin.pg
+++ b/xt/42-admin.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-app-module.pg
+++ b/xt/42-app-module.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-arap.pg
+++ b/xt/42-arap.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-assets.pg
+++ b/xt/42-assets.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-backup.pg
+++ b/xt/42-backup.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-budget.pg
+++ b/xt/42-budget.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-business-dates.pg
+++ b/xt/42-business-dates.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-business-type.pg
+++ b/xt/42-business-type.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-business-unit.pg
+++ b/xt/42-business-unit.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-cogs-fifo.pg
+++ b/xt/42-cogs-fifo.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-company.pg
+++ b/xt/42-company.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-customer.pg
+++ b/xt/42-customer.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-date.pg
+++ b/xt/42-date.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-draft.pg
+++ b/xt/42-draft.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-employee.pg
+++ b/xt/42-employee.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-endofyear.pg
+++ b/xt/42-endofyear.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-entity.pg
+++ b/xt/42-entity.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-files.pg
+++ b/xt/42-files.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-finstatements.pg
+++ b/xt/42-finstatements.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 /* Designing tests here based on data in taxform.sql.  We may want to split
    this out into another data script. --CT
  */

--- a/xt/42-goods.pg
+++ b/xt/42-goods.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-inventory.pg
+++ b/xt/42-inventory.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-invoice.pg
+++ b/xt/42-invoice.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-journal.pg
+++ b/xt/42-journal.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-location.pg
+++ b/xt/42-location.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-menu.pg
+++ b/xt/42-menu.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-orderentry.pg
+++ b/xt/42-orderentry.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-parts.pg
+++ b/xt/42-parts.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 
 BEGIN;
     -- Load the TAP functions.

--- a/xt/42-payment-fx.pg
+++ b/xt/42-payment-fx.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-payment.pg
+++ b/xt/42-payment.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-payroll.pg
+++ b/xt/42-payroll.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-person.pg
+++ b/xt/42-person.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-pricematrix.pg
+++ b/xt/42-pricematrix.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-reconciliation.pg
+++ b/xt/42-reconciliation.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
 
     -- Load the TAP functions.

--- a/xt/42-report.pg
+++ b/xt/42-report.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-robot.pg
+++ b/xt/42-robot.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-roles.pg
+++ b/xt/42-roles.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-session.pg
+++ b/xt/42-session.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
 
     -- Load the TAP functions.

--- a/xt/42-system.pg
+++ b/xt/42-system.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-taxform.pg
+++ b/xt/42-taxform.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 /*
 
 *igning tests. Thinking:

--- a/xt/42-templates.pg
+++ b/xt/42-templates.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-timecards.pg
+++ b/xt/42-timecards.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-transaction_templates.pg
+++ b/xt/42-transaction_templates.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-trial_balance.pg
+++ b/xt/42-trial_balance.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-util.pg
+++ b/xt/42-util.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/42-voucher.pg
+++ b/xt/42-voucher.pg
@@ -1,3 +1,4 @@
+-- HARNESS-DURATION-SHORT
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;

--- a/xt/43-dbchange.t
+++ b/xt/43-dbchange.t
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-SHORT
 =head1 UNIT TESTS FOR
 
 LedgerSMB::Database::Change

--- a/xt/43-schema-upgrades.t
+++ b/xt/43-schema-upgrades.t
@@ -1,4 +1,5 @@
 #!perl
+# HARNESS-DURATION-SHORT
 
 =head1 UNIT TESTS FOR
 

--- a/xt/44-templates.t
+++ b/xt/44-templates.t
@@ -1,4 +1,5 @@
 #!perl
+# HARNESS-DURATION-SHORT
 
 =head1 UNIT TESTS FOR
 

--- a/xt/45.1-ledgersmb-file.t
+++ b/xt/45.1-ledgersmb-file.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-SHORT
 
 =head1 UNIT TESTS FOR LedgerSMB::File
 

--- a/xt/45.2-ledgersmb-file-internal.t
+++ b/xt/45.2-ledgersmb-file-internal.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-SHORT
 
 =head1 UNIT TESTS FOR LedgerSMB::File::Internal
 

--- a/xt/45.3-ledgersmb-setting.t
+++ b/xt/45.3-ledgersmb-setting.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-SHORT
 
 =head1 UNIT TESTS FOR LedgerSMB::Setting
 

--- a/xt/45.4-ledgersmb-batch.t
+++ b/xt/45.4-ledgersmb-batch.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-SHORT
 
 =head1 UNIT TESTS FOR LedgerSMB::Batch
 

--- a/xt/46.1-pgold.t
+++ b/xt/46.1-pgold.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-SHORT
 
 =head1 UNIT TESTS FOR LedgerSMB::PGOld
 

--- a/xt/47.1-ledgersmb-dbobject-payment.t
+++ b/xt/47.1-ledgersmb-dbobject-payment.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-SHORT
 
 =head1 UNIT TESTS FOR LedgerSMB::DBObject::Payment
 

--- a/xt/48.1-ledgersmb-report-unapproved-batch_overview.t
+++ b/xt/48.1-ledgersmb-report-unapproved-batch_overview.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-SHORT
 
 =head1 UNIT TESTS FOR LedgerSMB::Report::Unapproved::Batch_Overview
 

--- a/xt/50-upgrade-tests.t
+++ b/xt/50-upgrade-tests.t
@@ -1,4 +1,5 @@
 #!perl
+# HARNESS-DURATION-SHORT
 
 use Test2::V0;
 

--- a/xt/64-x12.t
+++ b/xt/64-x12.t
@@ -1,4 +1,5 @@
 #!perl
+# HARNESS-DURATION-SHORT
 
 # X12 tests for LedgerSMB 1.4
 #

--- a/xt/65-browser.t
+++ b/xt/65-browser.t
@@ -1,4 +1,5 @@
 #!perl
+# HARNESS-DURATION-SHORT
 
 use strict;
 use warnings;

--- a/xt/66-cucumber.feature
+++ b/xt/66-cucumber.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-SHORT
 @weasel
 Feature: Test redirection
 

--- a/xt/66-cucumber/01-basic/change_password.feature
+++ b/xt/66-cucumber/01-basic/change_password.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-LONG
 @one-db @weasel
 Feature: Check correct operation of Change Password screen
 

--- a/xt/66-cucumber/01-basic/closing.feature
+++ b/xt/66-cucumber/01-basic/closing.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-LONG
 @one-db @weasel
 Feature: correct operation of period closing and year end posting
   As an accounting admin, I want to make sure users can't post new

--- a/xt/66-cucumber/01-basic/login.feature
+++ b/xt/66-cucumber/01-basic/login.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-MEDIUM
 @weasel
 Feature: Correct operation of setup.pl and login.pl login pages
    In order to assess the further quality of the software,

--- a/xt/66-cucumber/01-basic/menu.feature
+++ b/xt/66-cucumber/01-basic/menu.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-LONG
 @one-db @weasel @weasel-one-session
 Feature: correct operation of the menu and immediate linked pages
   As an end-user, I want to be able to navigate the menu and open

--- a/xt/66-cucumber/01-basic/preferences.feature
+++ b/xt/66-cucumber/01-basic/preferences.feature
@@ -1,6 +1,7 @@
 # Using one db would be quicker but the menu language would persist from
 # previous pass and PageObject/App/Menu.pm would have to be able to handle
 # non-english menus
+# HARNESS-DURATION-LONG
 @one-db @weasel
 Feature: Check correct operation of Preferences screen
 

--- a/xt/66-cucumber/01-basic/setup.feature
+++ b/xt/66-cucumber/01-basic/setup.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-LONG
 @weasel
 Feature: setup.pl database creation and migration functionalities
   In order to create company databases or migrate company databases

--- a/xt/66-cucumber/04-users/change-permissions.feature
+++ b/xt/66-cucumber/04-users/change-permissions.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-LONG
 @weasel
 Feature: Change user permissions
   As a LedgerSMB administrator I want to change the permissions of an

--- a/xt/66-cucumber/05-settings/currency.feature
+++ b/xt/66-cucumber/05-settings/currency.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-LONG
 @weasel
 Feature: Currency
   As a LedgerSMB user, I want to be able to view the available currencies,

--- a/xt/66-cucumber/05-settings/rate_types.feature
+++ b/xt/66-cucumber/05-settings/rate_types.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-LONG
 @weasel
 Feature: Rate types
   As a LedgerSMB user, I want to be able to view the available exchange

--- a/xt/66-cucumber/05-settings/rates.feature
+++ b/xt/66-cucumber/05-settings/rates.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-LONG
 @weasel
 Feature: Exchange rates
   As a LedgerSMB user, I want to be able to view the default exchange

--- a/xt/66-cucumber/10-gl/account-add-delete.feature
+++ b/xt/66-cucumber/10-gl/account-add-delete.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-LONG
 @weasel
 Feature: Add and delete new account
   As a LedgerSMB user I want to be able to add a new account and see that

--- a/xt/66-cucumber/10-gl/account-heading-add-delete.feature
+++ b/xt/66-cucumber/10-gl/account-heading-add-delete.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-LONG
 @weasel
 Feature: Add and delete new account heading
   As a LedgerSMB user I want to be able to add a new account heading and see

--- a/xt/66-cucumber/10-gl/chart-of-accounts.feature
+++ b/xt/66-cucumber/10-gl/chart-of-accounts.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-LONG
 @weasel
 Feature: Chart of Accounts
   As a LedgerSMB user I want to be able to view the chart of accounts

--- a/xt/66-cucumber/10-gl/edit-account-heading-translation.feature
+++ b/xt/66-cucumber/10-gl/edit-account-heading-translation.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-LONG
 @weasel
 Feature: Edit account translation
   As a LedgerSMB user I want to be able to specify account heading

--- a/xt/66-cucumber/10-gl/edit-account-translation.feature
+++ b/xt/66-cucumber/10-gl/edit-account-translation.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-MEDIUM
 @weasel
 Feature: Edit account translation
   As a LedgerSMB user I want to be able to specify account descriptions

--- a/xt/66-cucumber/11-ar/customer_history_report.feature
+++ b/xt/66-cucumber/11-ar/customer_history_report.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-MEDIUM
 @weasel
 Feature: Customer History Report
   As a LedgerSMB user I want to be able to search the purchase history

--- a/xt/66-cucumber/11-ar/invoice.feature
+++ b/xt/66-cucumber/11-ar/invoice.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-LONG
 @weasel
 Feature: AR transaction document handling
   As a LedgerSMB user, I want to be able to create transactions,

--- a/xt/66-cucumber/11-ar/transactions.feature
+++ b/xt/66-cucumber/11-ar/transactions.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-MEDIUM
 @weasel
 Feature: AR transaction document handling
   As a LedgerSMB user, I want to be able to create transactions,

--- a/xt/66-cucumber/12-ap/invoice.feature
+++ b/xt/66-cucumber/12-ap/invoice.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-LONG
 @weasel
 Feature: AP transaction document handling
   As a LedgerSMB user, I want to be able to create transactions,

--- a/xt/66-cucumber/12-ap/transactions.feature
+++ b/xt/66-cucumber/12-ap/transactions.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-MEDIUM
 @weasel
 Feature: AP transaction document handling
   As a LedgerSMB user, I want to be able to create transactions,

--- a/xt/66-cucumber/13-cash/reconciliation-search.feature
+++ b/xt/66-cucumber/13-cash/reconciliation-search.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-LONG
 @weasel
 Feature: Reconciliation Report Search
   As a LedgerSMB user I want to be able to search for reconciliation

--- a/xt/66-cucumber/13-cash/reconciliation.feature
+++ b/xt/66-cucumber/13-cash/reconciliation.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-LONG
 @weasel
 Feature: Reconciliation
   As a LedgerSMB user I want to be able to create a new bank reconciliation

--- a/xt/66-cucumber/13-cash/single-payments.feature
+++ b/xt/66-cucumber/13-cash/single-payments.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-LONG
 @weasel
 Feature: Single payment
   As a LedgerSMB user I want to be able to create a single payment to

--- a/xt/66-cucumber/13-cash/vouchers-payment.feature
+++ b/xt/66-cucumber/13-cash/vouchers-payment.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-LONG
 @weasel
 Feature: Bulk payments
   As a LedgerSMB user I want to be able to create a new batch of payment

--- a/xt/66-cucumber/14-transaction_approval/delete-batches.feature
+++ b/xt/66-cucumber/14-transaction_approval/delete-batches.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-MEDIUM
 @weasel
 Feature: Delete Batches
   As a LedgerSMB user I want to search for previously created

--- a/xt/66-cucumber/14-transaction_approval/search-batches.feature
+++ b/xt/66-cucumber/14-transaction_approval/search-batches.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-LONG
 @weasel
 Feature: Search Batches
   As a LedgerSMB user I want to be able to search for previously created

--- a/xt/66-cucumber/16-cogs/in-arrears-purchase.feature
+++ b/xt/66-cucumber/16-cogs/in-arrears-purchase.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-SHORT
 Feature: COGS posted on purchase when inventory sold short
   In case inventory is sold short - which can both happen when the true
   sequence is to sell before buy *or* when transactions are entered

--- a/xt/66-cucumber/16-cogs/simple-ar.feature
+++ b/xt/66-cucumber/16-cogs/simple-ar.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-MEDIUM
 Feature: FIFO COGS posting on AR invoice
   As part of posting an AR invoice which includes goods, there
   should be posting of Cost Of Goods Sold (COGS). COGS are known

--- a/xt/66-cucumber/16-cogs/undoing-purchases.feature
+++ b/xt/66-cucumber/16-cogs/undoing-purchases.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-MEDIUM
 Feature: COGS from performing corrections on purchases
    In the event a purchase invoice needs correction, COGS may need to
    be corrected as a consequence.

--- a/xt/66-cucumber/16-cogs/undoing-sales.feature
+++ b/xt/66-cucumber/16-cogs/undoing-sales.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-MEDIUM
 Feature: COGS from performing corrections on sales
    In the event a sales invoice needs correction, COGS may need to
    be corrected as a consequence.

--- a/xt/66-cucumber/30-inventory/adjustments.feature
+++ b/xt/66-cucumber/30-inventory/adjustments.feature
@@ -1,3 +1,4 @@
+# HARNESS-DURATION-LONG
 @weasel
 Feature: Adjusting stock levels
   As a trading or manufacturing company, I want to be able to


### PR DESCRIPTION
- Set YATH duration tags in tests to optimize running sequence.
- Allow failed test to be retried 2 times to compensate for random failure of feature tests