### PR TITLE
Repair GitHub Actions on 'master'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,16 +83,20 @@ jobs:
 
       - name: install with cpm
         run: |
-          cpanm --notest App::cpm
           cpm install -g -v --resolver=metacpan --notest --with-develop --feature=starman --feature=latex-pdf-ps --feature=openoffice --feature=xls --feature=edi
 
       - name: Build JS
         run: make dojo
 
-      - name: Other preparations
+      - name: Create logging directories
         run: |
           mkdir screens logs
           cp doc/conf/ledgersmb.conf.default ledgersmb.conf
+
+      - name: Create default test database
+        run: perl -Ilib bin/ledgersmb-admin create postgres@localhost:5432/lsmbinstalltest
+        env:
+          PGPASSWORD: test
 
       - name: Starting 'starman'
         run: starman --preload-app --pid starman.pid --workers 2 -Ilib -Iold/lib --port 5762 bin/ledgersmb-server.psgi &

--- a/lib/LedgerSMB/Admin.pm
+++ b/lib/LedgerSMB/Admin.pm
@@ -54,7 +54,7 @@ sub _load_config {
         },
         @potential_configs
         );
-    return {} unless $cfg_path;
+    return { connect_data => {} } unless $cfg_path;
 
     my $cfg = LoadFile($cfg_path->{path});
     ###TODO: check type of $cfg... we really need it to be a hash!
@@ -126,11 +126,13 @@ sub run_command {
 
 
     Getopt::Long::Configure(qw(permute));
-    my $class = compose_module_name('LedgerSMB::Admin::Command', $cmd);
+    my $class  = compose_module_name('LedgerSMB::Admin::Command', $cmd);
+    my $config = LedgerSMB::Admin::Configuration->new(
+        config => _load_config(),
+        );
+
     return use_module($class)->new(
-        config => LedgerSMB::Admin::Configuration->new(
-            config => _load_config()
-        ),
+        config => $config
         )->run(@cmd_args);
 }
 

--- a/lib/LedgerSMB/Admin/Configuration.pm
+++ b/lib/LedgerSMB/Admin/Configuration.pm
@@ -26,7 +26,7 @@ use namespace::autoclean;
 =cut
 
 has config => (is => 'ro', required => 0,
-               default => sub { {} });
+               default => sub { { connect_data => {} } });
 
 =head1 METHODS
 


### PR DESCRIPTION
The tests on 'master' were failing because the test suite
no longer includes 40-dbsetup and 89-dropdb.

At the same time, it turns out that `bin/ledgersmb-admin` can't function without a configuration file available, even when full connection details were specified on the command line. Fixing that too.