### PR TITLE
Improve upgrade script based on real-life data

### DIFF
--- a/sql/changes/1.6/track-deleted-transactions.sql.checks.pl
+++ b/sql/changes/1.6/track-deleted-transactions.sql.checks.pl
@@ -8,7 +8,7 @@ check q|Found files associated with non-existing transactions|,
     query => q|
       select id from file_transaction ft
        where not exists (select 1 from ar
-                          where ft.file_transaction_ref_key = ar.id)
+                          where ft.ref_key = ar.id)
              and not exists (select 1 from ap
                               where ft.file_transaction_ref_key = ap.id)
              and not exists (select 1 from gl
@@ -28,8 +28,10 @@ Click 'Continue' once you verified the files have been correctly saved.
 
         describe;
 
+        my $dbname = $dbh->{pg_db};
+        $dbname =~ s/[^a-zA-Z0-9_-]//g; # clean the database name
         my $tmp_dir = File::Spec->rel2abs(
-            'deleted_transaction_files',
+            File::Spec->catdir('deleted_transaction_files', $dbname),
             File::Spec->tmpdir
             );
         unless (-e $tmp_dir) {

--- a/sql/changes/1.6/track-deleted-transactions.sql@1
+++ b/sql/changes/1.6/track-deleted-transactions.sql@1
@@ -1,0 +1,47 @@
+
+delete from voucher v
+ where exists (select 1 from transactions t
+                where not exists (select 1 from ap where t.id = ap.id)
+                      and not exists (select 1 from ar where t.id = ar.id)
+                      and not exists (select 1 from gl where t.id = gl.id)
+                      and v.trans_id = t.id);
+
+delete from invoice_tax_form itf
+ where exists (select 1 from invoice i
+                where itf.invoice_id = i.id
+                      and exists (select 1 from transactions t
+                                   where not exists (select 1 from ap where t.id = ap.id)
+                                         and not exists (select 1 from ar where t.id = ar.id)
+                                         and not exists (select 1 from gl where t.id = gl.id)
+                                         and i.trans_id = t.id));
+
+delete from invoice i
+ where exists (select 1 from transactions t
+                where not exists (select 1 from ap where t.id = ap.id)
+                      and not exists (select 1 from ar where t.id = ar.id)
+                      and not exists (select 1 from gl where t.id = gl.id)
+                      and i.trans_id = t.id);
+
+delete from transactions t
+ where not exists (select 1 from ap where t.id = ap.id)
+       and not exists (select 1 from ar where t.id = ar.id)
+       and not exists (select 1 from gl where t.id = gl.id);
+
+
+CREATE TRIGGER ap_track_deleted_transaction
+  AFTER DELETE
+  ON ap
+  FOR EACH ROW
+  EXECUTE PROCEDURE track_global_sequence();
+
+CREATE TRIGGER ar_track_deleted_transaction
+  AFTER DELETE
+  ON ar
+  FOR EACH ROW
+  EXECUTE PROCEDURE track_global_sequence();
+
+CREATE TRIGGER gl_track_deleted_transaction
+  AFTER DELETE
+  ON gl
+  FOR EACH ROW
+  EXECUTE PROCEDURE track_global_sequence();


### PR DESCRIPTION
As we found real-life data where the records in the `transactions`
table were still linked to the `invoice` table and `invoice_tax_form`,
remove those records before deleting the ones in `transactions`.

Also change the namespace to which the salvaged files are stored,
in order to prevent collision of multiple databases (as much as
possible)