### PR TITLE
Yath Github actions setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,27 +16,52 @@ commands:
   prove:
     steps:
       - run:
+          name: Set up coverage
           command: |
-            JOB_COUNT=5
             if [ "x$COVERAGE" == "x1" ]
             then
-              export PERL5OPT="$PERL5OPT -MDevel::Cover=$DEVEL_COVER_OPTIONS"
-              JOB_COUNT=2
+              echo "JOB_COUNT=2" >> $BASH_ENV
               sudo cp utils/patch/Test2/Harness/Collector/JobDir.pm \
                       $HOME/perl5/lib/perl5/Test2/Harness/Collector/JobDir.pm
+              echo "STARMAN_DEVEL_COVER_OPTIONS='-MDevel::Cover=$DEVEL_COVER_OPTIONS'" >> $BASH_ENV
+              echo "YATH_DEVEL_COVER_OPTIONS='--cover=$DEVEL_COVER_OPTIONS'" >> $BASH_ENV
             fi
-            yath start --job-count $JOB_COUNT --event-timeout 1800 # Timeout after 30 min
-            yath --color --no-progress --retry=2 \
-              --pgtap-dbname=$PGDB --pgtap-username=$PGUSER \
-              --pgtap-psql=.circleci/psql-wrap \
-              --Feature-tags=~@wip \
-              t xt
-            yath stop
+
+      - run:
+          name: Create test database
+          command: |
+            source $BASH_ENV
+            PERL5LIB="lib:$HOME/perl5/lib/perl5" \
+            PERL5OPT="$PERL5OPT $STARMAN_DEVEL_COVER_OPTIONS" \
+              ./bin/ledgersmb-admin create $PGUSER@$PGHOST/$PGDB
+
       - run:
           command: |
-            while [ $(pidof plackup) ];
+            source $BASH_ENV
+            if [ "x$COVERAGE" == "x1" ]
+            then
+              yath test $YATH_DEVEL_COVER_OPTIONS \
+                --job-count $JOB_COUNT --event-timeout 1800 \
+                --color --no-progress --retry=2 \
+                --pgtap-dbname=$PGDB --pgtap-username=$PGUSER \
+                --pgtap-psql=.circleci/psql-wrap \
+                --Feature-tags=~@wip \
+                t xt
+            else
+              yath start $YATH_DEVEL_COVER_OPTIONS \
+                --job-count $JOB_COUNT --event-timeout 1800
+              yath run --color --no-progress --retry=2 \
+                --pgtap-dbname=$PGDB --pgtap-username=$PGUSER \
+                --pgtap-psql=.circleci/psql-wrap \
+                --Feature-tags=~@wip \
+                t xt
+              yath stop
+            fi
+      - run:
+          command: |
+            while [ $(pidof starman) ];
             do
-              kill -SIGTERM `pidof plackup`
+              kill -SIGTERM `pidof starman`
               echo -n "."
               sleep 5
             done
@@ -49,14 +74,14 @@ commands:
                     utils/test/monitor.gnuplot || true
             mkdir -p /tmp/artifact/logs;
             mkdir -p /tmp/artifact/screens;
-            cp logs/* /tmp/artifact/logs || true;
+            cp -r logs/* /tmp/artifact/logs || true;
             cp screens/* /tmp/artifact/screens || true;
           when: always
 
       - run:
           name: Upload coverage data
           command: |
-            if [ "x$COVERAGE" == "x1" ];
+            if [ "x$COVERAGE" == "x1" ]
             then
               cover -report coveralls
               cover -report text > /tmp/artifact/coverage.txt
@@ -163,35 +188,28 @@ commands:
              - $HOME/perl5
 
       - run:
-          name: Create test database
-          command: |
-            PERL5LIB="lib:$HOME/perl5/lib/perl5" \
-              ./bin/ledgersmb-admin create $PGUSER@$PGHOST/$PGDB
-
-      - run:
           name: Set up host IP & BASE variables
           command: |
-            echo "HOST_IP=$(hostname -I |awk '{print $1}')" > $BASH_ENV
+            echo "HOST_IP=$(hostname -I |awk '{print $1}')" >> $BASH_ENV
             echo "export LSMB_BASE_URL=http://\$HOST_IP:5000" >> $BASH_ENV
             echo "export PSGI_BASE_URL=http://\$HOST_IP:5762" >> $BASH_ENV
 
-  start_plackup:
-    description: "Start plackup"
+  start_starman:
+    description: "Start starman"
     steps:
       - run:
           command: |
-            JOB_COUNT=5
             source $BASH_ENV
             if [ "x$COVERAGE" == "x1" ]
             then
-              export PERL5OPT="$PERL5OPT -MDevel::Cover=$DEVEL_COVER_OPTIONS"
               JOB_COUNT=2
             fi
-            starman --preload-app --pid starman.pid --workers $JOB_COUNT \
-                  --max-requests 5000 --error-log logs/starman-error.log \
-                  -Ilib -Iold/lib --port 5762 bin/ledgersmb-server.psgi
-            echo "Plackup done!"
-            touch plackup-done
+            PERL5OPT="$PERL5OPT -MDevel::Cover=$DEVEL_COVER_OPTIONS" \
+              starman --preload-app --pid starman.pid --workers $JOB_COUNT \
+                --max-requests 5000 --error-log logs/starman-error.log \
+                -Ilib -Iold/lib --port 5762 bin/ledgersmb-server.psgi
+            echo "starman done!"
+            touch starman-done
           background: true
 
   start_proxy:
@@ -249,8 +267,9 @@ executors:
     environment:
       BROWSER: << parameters.browser >>
       COVERAGE: << parameters.coverage >>
-      DEVEL_COVER_OPTIONS: -silent,1,+ignore,^x?t/,+ignore,^utils/,+ignore,\.lttc$,+ignore,^/usr/,+ignore,/home/circleci/perl5,+ignore,plackup$
+      DEVEL_COVER_OPTIONS: -silent,1,+ignore,(^x?t/|^utils/|\.lttc$|^/usr/|/home/circleci/perl5|starman$)
       HARNESS_RULESFILE: t/testrules.yml
+      JOB_COUNT: 2
       LSMB_BASE_URL: http://127.0.0.1:5000
       LSMB_NEW_DB: lsmb_test
       LSMB_TEST_DB: 1
@@ -262,6 +281,8 @@ executors:
       PSGI_BASE_URL: http://127.0.0.1:5762
       RELEASE_TESTING: 1
       REMOTE_SERVER_ADDR: selenium-hub
+      STARMAN_DEVEL_COVER_OPTIONS: ''
+      YATH_DEVEL_COVER_OPTIONS: ''
 
 # Define jobs
 jobs:
@@ -276,7 +297,7 @@ jobs:
     steps:
       - prep_env:
           perl: '5.32'
-      - start_plackup
+      - start_starman
       - start_proxy
       - prove
 
@@ -291,7 +312,7 @@ jobs:
     steps:
       - prep_env:
           perl: '5.30'
-      - start_plackup
+      - start_starman
       - start_proxy
       - prove
     environment:
@@ -308,7 +329,7 @@ jobs:
     steps:
       - prep_env:
           perl: '5.28'
-      - start_plackup
+      - start_starman
       - start_proxy
       - prove
     environment:
@@ -327,7 +348,7 @@ jobs:
     steps:
       - prep_env:
           perl: '5.28'
-      - start_plackup
+      - start_starman
       - start_proxy
       - prove
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,13 +49,13 @@ commands:
                 t xt
             else
               yath start $YATH_DEVEL_COVER_OPTIONS \
-                --job-count $JOB_COUNT --event-timeout 1800
-              yath run --color --no-progress --retry=2 \
-                --pgtap-dbname=$PGDB --pgtap-username=$PGUSER \
-                --pgtap-psql=.circleci/psql-wrap \
-                --Feature-tags=~@wip \
-                t xt
-              yath stop
+                       --job-count $JOB_COUNT --event-timeout 1800
+            yath run --color --no-progress --retry=2 \
+                     --pgtap-dbname=$PGDB --pgtap-username=$PGUSER \
+                     --pgtap-psql=.circleci/psql-wrap \
+                     --Feature-tags=~@wip \
+              t xt
+            yath stop
             fi
       - run:
           command: |
@@ -205,9 +205,9 @@ commands:
               JOB_COUNT=2
             fi
             PERL5OPT="$PERL5OPT -MDevel::Cover=$DEVEL_COVER_OPTIONS" \
-              starman --preload-app --pid starman.pid --workers $JOB_COUNT \
-                --max-requests 5000 --error-log logs/starman-error.log \
-                -Ilib -Iold/lib --port 5762 bin/ledgersmb-server.psgi
+            starman --preload-app --pid starman.pid --workers $JOB_COUNT \
+                  --max-requests 5000 --error-log logs/starman-error.log \
+                  -Ilib -Iold/lib --port 5762 bin/ledgersmb-server.psgi
             echo "starman done!"
             touch starman-done
           background: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -202,6 +202,34 @@ jobs:
             --feature=xls \
             --feature=edi
 
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2.1.2
+        with:
+          # Version Spec of the version to use.  Examples: 12.x, 10.15.1, >=10.15.0
+          node-version: 15.x
+
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: ./node-modules
+          key: modules-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Cache Dojo
+        id: cache-dojo
+        uses: actions/cache@v2
+        with:
+          path: UI/js
+          key: dojo-${{ hashFiles('UI/{js-src,css}/**') }}
+
+      - name: Install Node modules Dependencies
+        run: npm ci
+        if: steps.node-cache.outputs.cache-hit != 'true'
+
+      - name: Build Dojo
+        run: npm run build
+        if: steps.cache-node-modules.outputs.cache-hit != 'true' || steps.cache-dojo.outputs.cache-hit != 'true'
+
       - name: Starting 'nginx'
         run: |
           nginx -c $GITHUB_WORKSPACE/doc/conf/webserver/nginx-github.conf \
@@ -270,9 +298,9 @@ jobs:
         run: |
           yath start --job-count $JOB_COUNT --event-timeout 300
           yath run --color --no-progress --retry=2 \
-            --pgtap-dbname=$LSMB_NEW_DB --pgtap-username=$PGUSER \
-            --pgtap-psql=.circleci/psql-wrap \
-            --Feature-tags=~@wip \
+                --pgtap-dbname=$LSMB_NEW_DB --pgtap-username=$PGUSER \
+                --pgtap-psql=.circleci/psql-wrap \
+                --Feature-tags=~@wip \
             t xt
           yath stop
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -170,19 +170,19 @@ jobs:
         with:
           # The Perl version to download (if necessary) and use. Example: 5.30.0
           perl-version: ${{ matrix.perl }} # optional, default is 5
-          # The distribution of Perl binary.
-
-      - name: Cache cpan modules
-        id: cache-cpan-modules
-        uses: actions/cache@v2
-        with:
-          # A list of files, directories, and wildcard patterns to cache and restore
-          path: /opt/hostedtoolcache/perl
-          # Keys for restoring and saving the cache
-          key: |
-            cpan-${{ matrix.perl }}-${{ hashFiles('cpanfile') }}
-            cpan-${{ matrix.perl }}-
-            cpan-
+          install-modules-with: cpm
+#          install-modules:
+#            Devel::Cover
+#            Devel::Cover::Report::Coveralls
+#            Devel::NYTProf
+          # Features and Devel modules
+          install-modules-args: >
+            --with-develop
+            --feature=starman
+            --feature=latex-pdf-ps
+            --feature=openoffice
+            --feature=xls
+            --feature=edi
 
       - uses: actions/download-artifact@v2
         with:
@@ -190,17 +190,6 @@ jobs:
 
       - name: 'Untar Webpacked files'
         run: tar -xf webpacked_js.tar
-
-      # Update packages restored from the above cache
-      - name: Install required features
-        run: |
-          cpm install -g -v --resolver=metacpan --notest \
-            --with-develop \
-            --feature=starman \
-            --feature=latex-pdf-ps \
-            --feature=openoffice \
-            --feature=xls \
-            --feature=edi
 
       - name: Starting 'nginx'
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -202,34 +202,6 @@ jobs:
             --feature=xls \
             --feature=edi
 
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v2.1.2
-        with:
-          # Version Spec of the version to use.  Examples: 12.x, 10.15.1, >=10.15.0
-          node-version: 15.x
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          path: ./node-modules
-          key: modules-${{ hashFiles('**/package-lock.json') }}
-
-      - name: Cache Dojo
-        id: cache-dojo
-        uses: actions/cache@v2
-        with:
-          path: UI/js
-          key: dojo-${{ hashFiles('UI/{js-src,css}/**') }}
-
-      - name: Install Node modules Dependencies
-        run: npm ci
-        if: steps.node-cache.outputs.cache-hit != 'true'
-
-      - name: Build Dojo
-        run: npm run build
-        if: steps.cache-node-modules.outputs.cache-hit != 'true' || steps.cache-dojo.outputs.cache-hit != 'true'
-
       - name: Starting 'nginx'
         run: |
           nginx -c $GITHUB_WORKSPACE/doc/conf/webserver/nginx-github.conf \
@@ -298,9 +270,9 @@ jobs:
         run: |
           yath start --job-count $JOB_COUNT --event-timeout 300
           yath run --color --no-progress --retry=2 \
-                --pgtap-dbname=$LSMB_NEW_DB --pgtap-username=$PGUSER \
-                --pgtap-psql=.circleci/psql-wrap \
-                --Feature-tags=~@wip \
+            --pgtap-dbname=$LSMB_NEW_DB --pgtap-username=$PGUSER \
+            --pgtap-psql=.circleci/psql-wrap \
+            --Feature-tags=~@wip \
             t xt
           yath stop
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -266,6 +266,9 @@ jobs:
           yath stop
         env:
           LSMB_TEST_DB: 1
+          COA_TESTING: ${{ matrix.COA_TESTING }}
+          COVERAGE: ${{ matrix.COVERAGE }}
+          DB_TESTING: ${{ matrix.DB_TESTING }}
 
       - name: Upload coverage data
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,7 +117,7 @@ jobs:
       BROWSER: ${{ matrix.BROWSER }}
       COA_TESTING: ${{ matrix.COA_TESTING }}
       DB_TESTING: ${{ matrix.DB_TESTING }}
-      DEVEL_COVER_OPTIONS: -silent,1,+ignore,^x?t/,+ignore,^utils/,+ignore,\.lttc$,+ignore,^/usr/,+ignore,/home/circleci/perl5,+ignore,plackup$
+      DEVEL_COVER_OPTIONS: -silent,1,+ignore,(^x?t/|^local/|^utils/|\.lttc$|^/usr/|^/opt/|starman$),-summary,1
       JOB_COUNT: 5
       LSMB_BASE_URL: http://lsmb:5000
       LSMB_NEW_DB: lsmb_test
@@ -137,14 +137,13 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - name: Install apt packages
+      - name: Install TinyTex
+        uses: r-lib/actions/setup-tinytex@v1
+
+      - name: Install missing TeX packages
         run: |
-          sudo apt-get update && \
-          sudo apt-get install -y \
-              texlive-latex-recommended texlive-xetex \
-              gettext gnuplot
-        env:
-          DEBIAN_FRONTEND: noninteractive
+          tlmgr update --self
+          tlmgr install koma-script
 
       - name: Set host alias (why doesn't Github do it itself)
         run: |
@@ -159,22 +158,14 @@ jobs:
           mkdir screens logs
           cp doc/conf/ledgersmb.conf.default ledgersmb.conf
 
-      - name: "Monitor CPU & MEMORY"
-        run: |
-          ./utils/test/monitor_rss.sh logs/${{ env.MONITOR_FILE }}.txt &
-
       - name: Setup Perl environment
-        # You may pin to the exact commit or the version.
-        # uses: shogo82148/actions-setup-perl@341aa635c06050493b41d71134eea58bfc5f4018
         uses: shogo82148/actions-setup-perl@v1
         with:
-          # The Perl version to download (if necessary) and use. Example: 5.30.0
-          perl-version: ${{ matrix.perl }} # optional, default is 5
+          perl-version: ${{ matrix.perl }}
           install-modules-with: cpm
-#          install-modules:
-#            Devel::Cover
-#            Devel::Cover::Report::Coveralls
-#            Devel::NYTProf
+          install-modules: |
+            Devel::Cover
+            Devel::Cover::Report::Coveralls
           # Features and Devel modules
           install-modules-args: >
             --with-develop
@@ -195,17 +186,6 @@ jobs:
         run: |
           nginx -c $GITHUB_WORKSPACE/doc/conf/webserver/nginx-github.conf \
                 -p $GITHUB_WORKSPACE &
-
-      - name: Setup coverage
-        run: |
-          cpm install -g -v --resolver=metacpan --notest \
-              Devel::Cover Devel::Cover::Report::Coveralls
-          echo "PERL5OPT=-MDevel::Cover=${{ env.DEVEL_COVER_OPTIONS }}" >> $GITHUB_ENV
-          echo "JOB_COUNT=2" >> $GITHUB_ENV
-          # Ugly patch to yath to quiet B::Deparse noise.
-          sudo cp -v utils/patch/Test2/Harness/Collector/JobDir.pm \
-            `find /opt/hostedtoolcache/perl/${{ matrix.perl }} -name JobDir.pm`
-        if: ${{ matrix.COVERAGE }}
 
       # This will start a hub and JOB_COUNT matrix.
       - name: Starting hub with ${{ matrix.BROWSER }}
@@ -230,22 +210,25 @@ jobs:
           LANG: en_US.UTF-8
         if: ${{ matrix.BROWSER == 'phantomjs' }}
 
-      - name: Create default test database
-        run: |
-            PERL5LIB="lib:$PERL5LIB" \
-              ./bin/ledgersmb-admin create $PGUSER@$PGHOST/$PGDB
-
       - name: Setup coverage
         run: |
-          cpm install Devel::Cover \
-            Devel::Cover::Report::Coveralls \
-            Devel::NYTProf
-          echo "PERL5OPT=-MDevel::Cover=${{ env.DEVEL_COVER_OPTIONS }}" >> $GITHUB_ENV
+          echo "STARMAN_DEVEL_COVER_OPTIONS=-MDevel::Cover=${{ env.DEVEL_COVER_OPTIONS }}" >> $GITHUB_ENV
+          echo "YATH_DEVEL_COVER_OPTIONS=--cover=${{ env.DEVEL_COVER_OPTIONS }}" >> $GITHUB_ENV
           echo "JOB_COUNT=2" >> $GITHUB_ENV
+          # Ugly patch to yath to quiet B::Deparse noise.
+          sudo cp -v utils/patch/Test2/Harness/Collector/JobDir.pm \
+                  local/lib/perl5/Test2/Harness/Collector/JobDir.pm
         if: ${{ matrix.COVERAGE }}
+
+      - name: Create default test database
+        run: |
+          PERL5OPT="$PERL5OPT $STARMAN_DEVEL_COVER_OPTIONS" \
+          PERL5LIB="lib:$PERL5LIB" \
+            ./bin/ledgersmb-admin create $PGUSER@$PGHOST/$PGDB
 
       - name: Starting 'starman'
         run: |
+          PERL5OPT="$PERL5OPT $STARMAN_DEVEL_COVER_OPTIONS" \
           starman --preload-app --pid starman.pid --workers $JOB_COUNT \
                   --max-requests 5000 --error-log logs/starman-error.log \
                   -Ilib -Iold/lib --port 5762 bin/ledgersmb-server.psgi &
@@ -253,7 +236,7 @@ jobs:
       # Fix the condition to debug
       - name: Setup upterm session
         uses: lhotari/action-upterm@v1
-        if: ${{ matrix.BROWSER == 'chrome' && 0 }}
+        if: ${{ matrix.BROWSER == 'phantomjs' && 0 }}
 
       - name: Run Perl tests
         run: |
@@ -269,12 +252,28 @@ jobs:
           COA_TESTING: ${{ matrix.COA_TESTING }}
           COVERAGE: ${{ matrix.COVERAGE }}
           DB_TESTING: ${{ matrix.DB_TESTING }}
+        if: ${{ !matrix.COVERAGE }}
+
+      - name: Run Coverage Perl tests
+        run: |
+          yath test --color --no-progress --retry=2 --job-count $JOB_COUNT \
+            --pgtap-dbname=$LSMB_NEW_DB --pgtap-username=$PGUSER \
+            --pgtap-psql=.circleci/psql-wrap \
+            --Feature-tags=~@wip \
+            $YATH_DEVEL_COVER_OPTIONS \
+            t xt
+        env:
+          LSMB_TEST_DB: 1
+          COA_TESTING: ${{ matrix.COA_TESTING }}
+          COVERAGE: ${{ matrix.COVERAGE }}
+          DB_TESTING: ${{ matrix.DB_TESTING }}
+        if: ${{ matrix.COVERAGE }}
 
       - name: Upload coverage data
         run: |
           unset PERL5OPT
           cover -report coveralls
-          cover -report text > /tmp/artifact/coverage.txt
+          cover -report text > logs/coverage.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ matrix.COVERAGE && github.repository != 'ledgersmb/LedgerSMB'}}
@@ -285,12 +284,6 @@ jobs:
           dest: 'logs/docker-logs'
         if: always()
 
-      - name: Plot monitoring graph
-        run: |
-          gnuplot -e "filename='logs/${{ env.MONITOR_FILE }}.txt';outputfile='screens/${{ env.MONITOR_FILE }}.png'" \
-                  utils/test/monitor.gnuplot
-        if: always()
-
       - name: Archive production artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -298,6 +291,5 @@ jobs:
           path: |
             logs/**
             screens/**
-            /tmp/artifact/memory-usage-actual.*
             /tmp/nginx*.log
         if: always()


### PR DESCRIPTION
This PR dppely revises CI tests configurations in order to enable:
- multi-browsers configuration for Github Actions
- stop profiling on `prove` or `yath` to greatly speedup coverage tests
- bring stability on both CIs