### PR TITLE
Update welcome page removing Freenode and new Element link

### DIFF
--- a/UI/welcome.html
+++ b/UI/welcome.html
@@ -27,22 +27,18 @@
             website</a></li>
         <li>The <a href="https://ledgersmb.org/FAQ" target="_blank"
                    rel="noopener noreferrer">FAQ</a></li>
-        <li>The <a href="http://archive.ledgersmb.org/">mailing list
+        <li>The <a href="http://archive.ledgersmb.org/" target="_blank"
+                   rel="noopener noreferrer">mailing list
             archives</a></li>
       </ul>
-      <p>More interactive resources:</p>
-      <ul>
-        <li>The <a href="http://forums.ledgersmb.org">forums</a></li>
-        <li>The <a href="http://lists.ledgersmb.org/">mailing lists</a></li>
-      </ul>
-      <p>The near realtime resources (depending on availability):</p>
-      <ul>
-        <li>The <a href="https://riot.im/app/%23/room/%23ledgersmb:matrix.org">matrix
-            &quot;LedgerSMB&quot; room</a></li>
-        <li>The <a href="https://freenode.net/">FreeNode</a>
-          <a href="irc://chat.freenode.net/%23ledgersmb">#ledgersmb
-            IRC channel</a></li>
-      </ul>
+      <p>For a more interactive experience, please join
+        one of the <a href="http://lists.ledgersmb.org/" target="_blank"
+                      rel="noopener noreferrer">mailing lists</a></p>
+
+      <p>There's also the near-realtime chat experience in the
+        <a href="https://app.element.io/%23/room/%23ledgersmb:matrix.org"
+           target="_blank" rel="noopener noreferrer">matrix
+            &quot;LedgerSMB&quot; room</a></p>
     </div>
     <div style="float:left; width:calc(33.3% - 1em); padding: 1em; margin: 0.5em; border: 1px solid black; border-radius: 0.5em; min-width: 300px; box-sizing: border-box">
       <h2>Contributing</h2>


### PR DESCRIPTION
Some time ago, Riot was renamed to Element, but our Welcome page
wasn't updated. Last week, Freenode was left by all of its staff;
we can't stay behind. Stop recommending Freenode as a channel to
reach us.
