### PR TITLE
Fix #5419: Reconciliations not correctly updated on new transactions

### DIFF
--- a/sql/modules/Reconciliation.sql
+++ b/sql/modules/Reconciliation.sql
@@ -509,12 +509,18 @@ $$
                        where la.entry_id = ac.entry_id
                              and rl.report_id = in_report_id)
             where la.report_line_id is null
-           returning report_line_id
+           returning report_line_id, entry_id
         )
         update cr_report_line rl
            set our_balance = (select sum(case when t_recon_fx then ac.amount_tc
                                               else ac.amount_bc end)
-                                from cr_report_line_links rll
+                                from (
+                                     select report_line_id, entry_id
+                                       from cr_report_line_links
+                                     union all
+                                     select report_line_id, entry_id
+                                       from matched_entries
+                                ) rll
                                 join acc_trans ac on rll.entry_id = ac.entry_id
                                 where rl.id = rll.report_line_id)
          where rl.id in (select report_line_id from matched_entries);


### PR DESCRIPTION
This commit updates the total of the journal lines aggregating into a
reconciliation report's total -- taking any *new* journal lines (from
the lines_to_be_added table) into account, instead of just the lines
that were already there.
