### PR TITLE
Fix ignore pattern for changes on the other CI [skip ci]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ commands:
       - checkout
 
       - check-changed-files-or-halt:
-          pattern: ^.github/*$
+          pattern: ^.github/
 
       - run:
           name: "Monitor CPU & MEMORY"


### PR DESCRIPTION
Fix the ignore file regex to ignore changes for Github Actions configuration and plugins on CircleCI