### PR TITLE
Fix #5453: Retain AR/AP account across Update-s

### DIFF
--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -318,6 +318,7 @@ sub form_header {
     $form->{exchangerate} =
       $form->format_amount( \%myconfig, $form->{exchangerate} );
 
+    $form->{selectAP} =~ s/(\Qoption value="$form->{AP}"\E)/$1 selected="selected"/;
     $exchangerate = qq|<tr>|;
     $exchangerate .= qq|
                 <th align=right nowrap>| . $locale->text('Currency') . qq|</th>
@@ -1224,6 +1225,9 @@ sub update {
              billing => 1,
              job => 1 );
      $form->generate_selects();
+
+    # wow... check_form() in io.pl also *displays* the form!!
+    # at least... in some cases
     check_form();
 
     $form->{rowcount}--;

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -319,6 +319,8 @@ sub form_header {
     $form->{exchangerate} =
       $form->format_amount( \%myconfig, $form->{exchangerate} );
 
+    $form->{selectAR} =~ s/(\Qoption value="$form->{AR}"\E)/$1 selected="selected"/;
+
     $exchangerate = qq|<tr>|;
     $exchangerate .= qq|
         <th align=right nowrap>| . $locale->text('Currency') . qq|</th>


### PR DESCRIPTION
On invoices, make sure to actually select the value provided on update;
on transactions, don't overwrite the provided value.
