### PR TITLE
Fix #5453: Retain AR/AP account across Update-s

### DIFF
--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -354,6 +354,8 @@ sub create_links {
           if $myconfig{acs} =~ /$form->{ARAP}--Add Transaction/;
     }
     #$form->generate_selects(\%myconfig);
+    $form->{$form->{ARAP}} = $form->{"$form->{ARAP}_1"} unless $form->{$form->{ARAP}};
+
 }
 
 sub form_header {
@@ -766,6 +768,7 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" size=40 
 
     $form->hide_form( "oldinvtotal", "oldtotalpaid", "taxaccounts" );
 
+     $form->{"select$form->{ARAP}"} =~ s/(\Qoption value="$form->{$form->{ARAP}}"\E)/$1 selected="selected"/;
     print qq|
         <tr>
       <th align=left>$form->{invtotal}</th>

--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -314,6 +314,7 @@ sub form_header {
     $form->{exchangerate} =
       $form->format_amount( \%myconfig, $form->{exchangerate} );
 
+    $form->{selectAP} =~ s/(\Qoption value="$form->{AP}"\E)/$1 selected="selected"/;
     $exchangerate = qq|<tr>|;
     $exchangerate .= qq|
                 <th align=right nowrap>| . $locale->text('Currency') . qq|</th>

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -310,6 +310,8 @@ sub form_header {
     $form->{exchangerate} =
       $form->format_amount( \%myconfig, $form->{exchangerate} );
 
+    $form->{selectAR} =~ s/(\Qoption value="$form->{AR}"\E)/$1 selected="selected"/;
+
     $exchangerate = qq|<tr>|;
     $exchangerate .= qq|
         <th align=right nowrap>| . $locale->text('Currency') . qq|</th>


### PR DESCRIPTION
On invoices, make sure to actually select the value provided on update;
on transactions, don't overwrite the provided value.
