### PR TITLE
Old code entry points expect an empty argument list...

### DIFF
--- a/old/lib/LedgerSMB/oldHandler.pm
+++ b/old/lib/LedgerSMB/oldHandler.pm
@@ -150,7 +150,7 @@ sub handle {
              && "lsmb_legacy"->can($form->{action}) ) {
             $logger->trace("action $form->{action}");
 
-            &{ $form->{action} };
+            &{ $form->{action} }();
             $form->{dbh}->commit;
         }
         else {
@@ -176,6 +176,7 @@ sub handle {
     $logger->trace("leaving after script=old/bin/$form->{script} action=$form->{action}");#trace flow
 
     $form->{dbh}->disconnect() if defined $form->{dbh};
+    return 1; # PSGI.pm expects a 'true' response
 }
 
 


### PR DESCRIPTION
... at least when called from the web. However, oldHandler doesn't stick
to that rule... It secretly passes its own argument list down to the
entry point!
