### PR TITLE
Layout improvements for reconciliation reports

### DIFF
--- a/UI/css/ledgersmb-common.css
+++ b/UI/css/ledgersmb-common.css
@@ -562,3 +562,12 @@ span.indicator {
     font-size: var(--listtop-font-size);
     font-weight: bold;
 }
+
+#reconciliation #report_headings,
+#reconciliation #csv-file,
+#reconciliation #cleared-table,
+#reconciliation #error-table,
+#reconciliation #outstanding-table {
+    margin-bottom: 2em;
+    margin-top: 2em;
+}

--- a/UI/reconciliation/report.html
+++ b/UI/reconciliation/report.html
@@ -77,10 +77,10 @@ END %]
   <td>[% entered_username %]</td>
 </tr>
 </table>
-<br />
+
 [% IF ! approved and !submitted%]
     <div id="csv-file">
-        <label for="file_upload">[% text('CSV File:') %]</label>
+        <label for="file_upload">[% text('Bank (CSV) transaction file:') %]</label>
         [% PROCESS input element_data = {
                     type="file"
                     name="csv_file"
@@ -219,13 +219,25 @@ END %]
         <td class="money" id="total_cleared_debits">[% total_cleared_debits %]</td>
         <td class="money" id="total_cleared_credits">[% total_cleared_credits %]</td>
     </tr>
-    </table>
+</table>
+
+[%
+
+have_mismatches = 0;
+FOREACH row = report_lines ;
+   IF row.err == 'mismatch' ;
+      have_mismatches = 1;
+      LAST;
+   END;
+END;
+
+IF have_mismatches ; -%]
 <table border=0 id="error-table">
     <tr class="listtop">
         <th colspan="10">[% INCLUDE input element_data = {
         type = "toggle"
         name = "b_mismatch_table"
-        label = text('Mismatched Transactions (From Upload)')
+        label = text('Mismatched Transactions (from upload)')
         checked = b_mismatch_table
         "data-dojo-type" = "lsmb/PublishToggleButton"
         "data-dojo-props" = "topic:'ui/reconciliation/report/b_mismatch_table'"
@@ -282,7 +294,20 @@ END %]
         <td class="money" id="total_mismatch_their_credits">[% mismatch_their_credits %]</td>
     </tr>
     </table>
-    <table id="outstanding-table">
+[% END; # have_mismatches
+
+have_outstanding = 0;
+FOREACH row = report_lines ;
+    IF row.cleared != 'checked' and row.err != 'mismatch';
+      have_outstanding = 1;
+      LAST;
+    END;
+END;
+
+
+IF have_outstanding ;
+-%]
+<table id="outstanding-table">
     <tr class="listtop">
         <th colspan="6">[% INCLUDE input element_data = {
         type = "toggle"
@@ -341,6 +366,7 @@ END %]
         <td class="money" id="total_outstanding_credits">[% total_uncleared_credits %]</td>
     </tr>
 </table>
+[% END; # have_outstanding %]
 [% INCLUDE input element_data = {
     name = "end_date",
     type = "hidden",

--- a/xt/66-cucumber/13-cash/reconciliation.feature
+++ b/xt/66-cucumber/13-cash/reconciliation.feature
@@ -37,9 +37,6 @@ is no previous report from which to get an opening balance.
    And I expect the Cleared Transactions totals to be:
        | Books Debits | Books Credits |
        |         0.00 |          0.00 |
-   And I expect the Mismatched Transactions totals to be:
-       | Our Debits | Our Credits | Their Debits | Their Credits |
-       |       0.00 |        0.00 |         0.00 |          0.00 |
    And I expect the Outstanding Transactions totals to be:
        | Our Debits | Our Credits |
        |    1000.00 |      200.00 |
@@ -56,12 +53,7 @@ is no previous report from which to get an opening balance.
    And I expect the Cleared Transactions totals to be:
        | Books Debits | Books Credits |
        |      1000.00 |        200.00 |
-   And I expect the Mismatched Transactions totals to be:
-       | Our Debits | Our Credits | Their Debits | Their Credits |
-       |       0.00 |        0.00 |         0.00 |          0.00 |
-   And I expect the Outstanding Transactions totals to be:
-       | Our Debits | Our Credits |
-       |       0.00 |        0.00 |
+   And I expect the Outstanding Transactions section to be absent
   When I change the "Ending Statement Balance" to "800.00"
    And I update the page
   Then I should see these Reconciliation Report headings:

--- a/xt/66-cucumber/13-cash/step_definitions/pageobject_steps.pl
+++ b/xt/66-cucumber/13-cash/step_definitions/pageobject_steps.pl
@@ -194,6 +194,16 @@ Then qr/^I expect the (.+) Transactions totals to be/, sub {
     }
 };
 
+Then qr/^I expect the (.+) Transactions section to be absent/, sub {
+
+    my $section  = $1;
+    my $page     = S->{ext_wsl}->page->body->maindiv->content;
+    my @sections = $page->has_reconciliation_section({
+        section => $section,
+    });
+    ok(scalar(@sections)==0, "$section absent");
+};
+
 Then qr/^I expect the open items table to contain (\d+) rows?/, sub {
 
     my $count = $1;

--- a/xt/lib/PageObject/App/Cash/Reconciliation/Report.pm
+++ b/xt/lib/PageObject/App/Cash/Reconciliation/Report.pm
@@ -100,7 +100,20 @@ sub find_reconciliation_totals {
     return $rv;
 }
 
+sub has_reconciliation_section {
+    my $self = shift;
+    my $args = shift;
 
+    if ($args->{section} =~ m/^Outstanding/i) {
+        return $self->find_all(q{//*[@id="outstanding-table"]});
+    }
+    elsif ($args->{section} =~ m/^Mismatched/i) {
+        return $self->find_all(q{//*[@id="error-table"]});
+    }
+    else {
+        die "unknown reconciliation report section: $args->{section}";
+    }
+}
 
 sub _verify {
     my ($self) = @_;


### PR DESCRIPTION
 * More whitespace, reducing crowdedness on the screen
 * Not showing mismatches table when no mismatches
 * Not showing outstandings table when no outstandings
