### PR TITLE
Adjust eslint to fail on production when errors are present

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -163,10 +163,8 @@ const CleanWebpackPluginOptions = {
 
 const ESLintPluginOptions = {
     files: "**/!(bootstrap|lsmb.profile).js",
-    emitError: true,
-    emitWarning: true,
-    failOnError: false,
-    failOnWarning: false
+    emitError: prodMode,
+    emitWarning: !prodMode,
 };
 
 const StylelintPluginOptions = {


### PR DESCRIPTION
Webpack build need to abort on eslint errors