### PR TITLE
Re #2306: Enable filtering in customer/vendor dropdown

### DIFF
--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -469,7 +469,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" name=intnotes rows=$rows cols=
 
     $name =
       ( $form->{"select$form->{vc}"} )
-      ? qq|<select data-dojo-type="dijit/form/Select" id="$form->{vc}" name="$form->{vc}">$form->{"select$form->{vc}"}</select>|
+      ? qq|<select data-dojo-type="dijit/form/FilteringSelect" data-dojo-props="queryExpr:'*\${0}*'" id="$form->{vc}" name="$form->{vc}"><option></option>$form->{"select$form->{vc}"}</select>|
       : qq|<input data-dojo-type="dijit/form/TextBox" id="$form->{vc}" name="$form->{vc}" value="$form->{$form->{vc}}" size=35>
                  <a href="erp.pl?action=root#contact.pl?action=add&entity_class=$eclass"
                     id="new-contact" target="_blank">[|

--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -346,7 +346,7 @@ sub form_header {
 |;
 
     if ( $form->{selectvendor} ) {
-        $vendor = qq|<select data-dojo-type="dijit/form/Select" id=vendor name=vendor>$form->{selectvendor}</select>|;
+        $vendor = qq|<select data-dojo-type="dijit/form/FilteringSelect" data-dojo-props="queryExpr:'*\${0}*'" id=vendor name=vendor><option></option>$form->{selectvendor}</select>|;
     }
     else {
         $vendor = qq|<input data-dojo-type="dijit/form/TextBox" name=vendor id=vendor value="$form->{vendor}" size=35>

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -345,7 +345,7 @@ sub form_header {
 |;
 
     if ( $form->{selectcustomer} ) {
-        $customer = qq|<select data-dojo-type="dijit/form/Select" id="customer" name="customer">$form->{selectcustomer}</select>|;
+        $customer = qq|<select data-dojo-type="dijit/form/FilteringSelect" data-dojo-props="queryExpr:'*\${0}*'" id="customer" name="customer"><option></option>$form->{selectcustomer}</select>|;
     }
     else {
         $customer = qq|<input data-dojo-type="dijit/form/TextBox" id="customer" name="customer" value="$form->{customer}" size="35">

--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -506,7 +506,7 @@ sub form_header {
 <input type=hidden name=oldtransdate value=$form->{oldtransdate}>|;
 
     if ( $form->{"select$form->{vc}"} ) {
-        $vc = qq|<select data-dojo-type="dijit/form/Select" name=$form->{vc} id=$form->{vc}>$form->{"select$form->{vc}"}</select>|;
+        $vc = qq|<select data-dojo-type="dijit/form/FilteringSelect" data-dojo-props="queryExpr:'*\${0}*'" name="$form->{vc}" id="$form->{vc}"><option></option>$form->{"select$form->{vc}"}</select>|;
     }
     else {
         if ($form->{vc} eq 'vendor'){

--- a/sql/Pg-database.sql
+++ b/sql/Pg-database.sql
@@ -1373,6 +1373,7 @@ check_prefix|CK
 decimal_places|2
 disable_back|0
 dojo_theme|claro
+vclimit|9999
 \.
 
 -- Sequence handling


### PR DESCRIPTION
In the AR/AP invoices and transactions, enable filtering on customers
and vendors (instead of providing a fixed list of selectable options).
Also enable this selection method by default for up to 9999 customers
or vendors. (Above that number, fall back to the current default which
means providing a text entry box to be used for seaching customers/vendors).

This does not back the filtering select with a service and hence does
not fully close the issue.
