### PR TITLE
Only test Chrome on CircleCI due to capacity constraints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,8 +364,8 @@ workflows:
       - test_webpack_chrome:
           filters: *_filters
 
-      - test_webpack_firefox:
-          filters: *_filters
+#      - test_webpack_firefox:
+#          filters: *_filters
 
-      - test_webpack_opera:
-          filters: *_filters
+#      - test_webpack_opera:
+#          filters: *_filters


### PR DESCRIPTION
Incidentally, this also solves the problems we're having with
FireFox /specifically and only/ on CCI.
