### PR TITLE
Do not delimit returned Customer History result by country by default

### DIFF
--- a/UI/Reports/filters/purchase_history.html
+++ b/UI/Reports/filters/purchase_history.html
@@ -98,7 +98,7 @@
               <tr>
                 <th align=right nowrap>[% text('Country') %]</th>
                 <td>[%
-                     INCLUDE select_country element_data = {
+                     INCLUDE select element_data = {
                          name = "country_id",
                          text_attr = 'name',
                          value_attr = 'id',


### PR DESCRIPTION
By preselecting a country, the result gets delimited to that country,
but on versions where a selection can't be undone (1.8 & 1.7), it's
impossible to get a result for customers/vendors without location
data.

Context: `select_country` preselects the default country if one
has been set in System > Defaults.

Fixes #4361.
