### PR TITLE
Do not delimit returned Customer History result by country by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
 Changelog    merge=union
-sql/changes/LOADORDER merge=union

--- a/UI/Reports/filters/purchase_history.html
+++ b/UI/Reports/filters/purchase_history.html
@@ -97,13 +97,15 @@
               </tr>
               <tr>
                 <th align=right nowrap>[% text('Country') %]</th>
-                <td>[% country_list.unshift({});
-                     INCLUDE select_country element_data = {
+                <td>[%
+                     INCLUDE select element_data = {
                          name = "country_id",
                          text_attr = 'name',
                          value_attr = 'id',
                          options = country_list,
-                    } %]</td>
+                         default_blank = 1
+                  } %]
+                </td>
               </tr>
               <tr>
                 <th align=right nowrap>[% text('Startdate') %]</th>


### PR DESCRIPTION
By preselecting a country, the result gets delimited to that country,
but on versions where a selection can't be undone (1.8 & 1.7), it's
impossible to get a result for customers/vendors without location
data.

Context: `select_country` preselects the default country if one
has been set in System > Defaults.

Fixes #4361.
