### PR TITLE
Fix typo in variable name ($from instead of $form)

### DIFF
--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -216,7 +216,7 @@ sub create_links {
 
     my $vc = $form->{vc};
     AA->get_name( \%myconfig, \%$form )
-            unless ($from->{"old$vc"} and $form->{$vc} and $form->{"old$vc"} eq $form->{$vc})
+            unless ($form->{"old$vc"} and $form->{$vc} and $form->{"old$vc"} eq $form->{$vc})
                     or ($form->{"old$vc"} and $form->{"old$vc"} =~ /^\Q$form->{$vc}\E--/);
 
     $form->{currency} =~ s/ //g if $form->{currency};


### PR DESCRIPTION
Fixes #5581: Due to the incorrectly named variable `AA::get_name()` is always
being run, even when a customer/vendor has already been selected. The get_name
call overwrites a number of form values, including the currency.
