### PR TITLE
Mark all lines in a transaction 'approved' upon approval

### DIFF
--- a/sql/modules/Drafts.sql
+++ b/sql/modules/Drafts.sql
@@ -109,6 +109,10 @@ begin
                 approved_at = now()
         WHERE id = in_id;
 
+        UPDATE acc_trans
+        SET approved = 't'::boolean
+        WHERE trans_id = in_id;
+
         RETURN TRUE;
 END;
 $$ LANGUAGE PLPGSQL SECURITY DEFINER;


### PR DESCRIPTION
Fixes #5582: Since 1.9, the default value on rows is to be posted "not
approved"; it's important to mark rows approved on transaction approval now.
