### PR TITLE
Fix #5583: UTF-8 characters incorrectly encoded on journal entry screen

### DIFF
--- a/old/lib/LedgerSMB/Legacy_Util.pm
+++ b/old/lib/LedgerSMB/Legacy_Util.pm
@@ -34,7 +34,7 @@ response as required by legacy code.
 sub render_psgi {
     my ($form, $psgi) = @_;
 
-    binmode STDOUT, 'utf8';
+    binmode STDOUT, ':bytes';
 
     if (not $form->{header}) {
         print "Status: 200 OK\n";


### PR DESCRIPTION
When clicking 'Update' on a journal entry screen which contains non-ascii
characters, these characters get mangled.
