### PR TITLE
Fix #5583: UTF-8 characters incorrectly encoded on journal entry screen

### DIFF
--- a/old/lib/LedgerSMB/Legacy_Util.pm
+++ b/old/lib/LedgerSMB/Legacy_Util.pm
@@ -68,7 +68,7 @@ response as required by legacy code.
 sub render_psgi {
     my $psgi = shift;
 
-    binmode STDOUT, 'utf8';
+    binmode STDOUT, ':bytes';
     print "Status: 200 OK\n";
     print "Content-Type: text/html; charset=UTF-8\n\n";
     print join('', @{$psgi->[2]});


### PR DESCRIPTION
When clicking 'Update' on a journal entry screen which contains non-ascii
characters, these characters get mangled.
