### PR TITLE
Fix to pay value not retained on update

### DIFF
--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -1095,7 +1095,7 @@ sub payment2 {
                 name  => "memo_invoice_$invoice_id",
                 value => $request->{"memo_invoice_$invoice_id"}
             },#END HASH
-            orig_topay_fx     => ($request->{"topay_fx_$invoice->{invoice_id}"} // LedgerSMB::PGNumber->new($due_fx)->to_output(money => 1)),
+            orig_topay_fx     => LedgerSMB::PGNumber->new($due_fx)->to_output(money => 1),
             topay_fx          =>  {
                 name  => "topay_fx_$invoice_id",
                 value => ($request->{"topay_fx_$invoice_id"}


### PR DESCRIPTION
Fix 5614, original to pay amount should always take due amount and never replace by user typed amount.