### PR TITLE
Rethrow on exceptions that we don't want to catch

### DIFF
--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -1192,6 +1192,9 @@ sub _save_user {
             # return from the 'catch' block
             return _render_user($request, $entrypoint);
         }
+        else {
+            die $var;
+        }
     };
 
     if ($request->{perms} == 1){

--- a/old/lib/LedgerSMB/DBObject/Account.pm
+++ b/old/lib/LedgerSMB/DBObject/Account.pm
@@ -138,10 +138,14 @@ sub save {
         ($id_ref) = $self->call_dbmethod(funcname => $func);
     }
     catch ($var) {
-        die $self->{_locale}->text(
-            'Error: Cannot include summary account in other dropdown menus'
-            )
-        if $var =~ m/Invalid link settings:\s*Summary/;
+        if ($var =~ m/Invalid link settings:\s*Summary/) {
+            die $self->{_locale}->text(
+                'Error: Cannot include summary account in other dropdown menus'
+            );
+        }
+        else {
+            die $var;
+        }
     }
 
     $self->{id} = $id_ref->{$func};


### PR DESCRIPTION
try/catch (Typed) that were in Syntax::Keyword::Try are not yet in 5.34 try/catch implementation and won't be until 5.35.
This works around that to be ok for all Perl versions.