### PR TITLE
Fix 5656 and 5657

### DIFF
--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -690,7 +690,7 @@ $form->open_status_div($status_div_id) . qq|
 
         # format amounts
         $form->{"amount_$i"} =
-          $form->format_amount( \%myconfig,$form->{"amount_$i"}, 2 );
+          $form->format_amount( \%myconfig,$form->{"amount_$i"}, LedgerSMB::Setting->new(%$form)->get('decimal_places') );
 
         $project = qq|
       <td align=right><select data-dojo-type="dijit/form/Select" id="projectnumber_$i" name="projectnumber_$i">$form->{"selectprojectnumber_$i"}</select></td>
@@ -722,7 +722,7 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" size=40 
      <td><input data-dojo-type="dijit/form/TextBox" name="amount_$i" size=10 value="$form->{"amount_$i"}" accesskey="$i"></td>
      <td>| . (($form->{currency} ne $form->{defaultcurrency})
               ? $form->format_amount(\%myconfig, $form->parse_amount( \%myconfig, $form->{"amount_$i"} )
-                                                  * $form->parse_amount( \%myconfig, $form->{exchangerate} ),2)
+                                                  * $form->parse_amount( \%myconfig, $form->{exchangerate} ), LedgerSMB::Setting->new(%$form)->get('decimal_places'))
               : '')  . qq|</td>
      <td><select data-dojo-type="lsmb/FilteringSelect" id="$form->{ARAP}_amount_$i" name="$form->{ARAP}_amount_$i"><option></option>$form->{"select$form->{ARAP}_amount_$i"}</select></td>
       $description
@@ -759,7 +759,7 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" size=40 
         $form->{"calctax_$item"} =
           ( $form->{"calctax_$item"} ) ? "checked" : "";
         $form->{"tax_$item"} =
-          $form->format_amount( \%myconfig, $form->{"tax_$item"}, 2 );
+          $form->format_amount( \%myconfig, $form->{"tax_$item"}, LedgerSMB::Setting->new(%$form)->get('decimal_places') );
         print qq|
         <tr class="transaction-row $form->{ARAP} tax" id="taxrow_$item">
       <td><input data-dojo-type="dijit/form/TextBox" name="tax_$item" id="tax_$item"
@@ -781,7 +781,7 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" size=40 
     }
 
     $form->{invtotal} =
-      $form->format_amount( \%myconfig, $form->{invtotal}, 2 );
+      $form->format_amount( \%myconfig, $form->{invtotal}, LedgerSMB::Setting->new(%$form)->get('decimal_places') );
 
     $form->hide_form( "oldinvtotal", "oldtotalpaid", "taxaccounts" );
 
@@ -792,8 +792,8 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" size=40 
       <th align=left>$form->{invtotal}</th>
      <td>| . (($form->{currency} ne $form->{defaultcurrency})
               ? $form->format_amount(\%myconfig,
-                                     $form->{invtotal}
-                                     * $form->{exchangerate}, 2) : '') . qq|</td>
+                                     $form->parse_amount( \%myconfig, $form->{invtotal} )
+                                     * $form->parse_amount( \%myconfig, $form->{exchangerate} ), LedgerSMB::Setting->new(%$form)->get('decimal_places')) : '') . qq|</td>
      <td><select data-dojo-type="dijit/form/Select" name="$form->{ARAP}" id="$form->{ARAP}">
                  $selectARAP
               </select></td>
@@ -869,9 +869,9 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" size=40 
         # format amounts
         $form->{"paidfx_$i"} = $form->format_amount(
             \%myconfig,
-            ($form->{"paid_$i"} // 0) * ($form->{"exchangerate_$i"} // 1) , 2 );
+            ($form->{"paid_$i"} // 0) * ($form->{"exchangerate_$i"} // 1) , LedgerSMB::Setting->new(%$form)->get('decimal_places') );
         $form->{"paid_$i"} =
-          $form->format_amount( \%myconfig, $form->{"paid_$i"}, 2 );
+          $form->format_amount( \%myconfig, $form->{"paid_$i"}, LedgerSMB::Setting->new(%$form)->get('decimal_places') );
         $form->{"exchangerate_$i"} =
           $form->format_amount( \%myconfig, $form->{"exchangerate_$i"} );
 

--- a/old/bin/am.pl
+++ b/old/bin/am.pl
@@ -527,7 +527,7 @@ sub display_taxes {
         ( $null, $i ) = split /_/, $_;
 
         $form->{"taxrate_$i"} =
-          $form->format_amount( \%myconfig, $form->{"taxrate_$i"},3,'0');
+          $form->format_amount( \%myconfig, $form->{"taxrate_$i"}, LedgerSMB::Setting->new(%$form)->get('decimal_places'),'0');
 
         $hiddens{"taxdescription_$i"} = $form->{"taxdescription_$i"};
         $hiddens{"old_validto_$i"} = $form->{"old_validto_$i"};
@@ -866,7 +866,7 @@ sub recurring_transactions {
             $column_data{howmany} =
                 $form->format_amount( \%myconfig, $ref->{howmany} );
             $column_data{amount} =
-                $form->format_amount( \%myconfig, $ref->{amount}, 2 );
+                $form->format_amount( \%myconfig, $ref->{amount}, LedgerSMB::Setting->new(%$form)->get('decimal_places') );
 
             my @temp_split;
             my @f = split /:/, $ref->{recurringemail};
@@ -1064,12 +1064,12 @@ sub process_transactions {
                         for ( 1 .. $form->{rowcount} - 1 ) {
                             $form->{"amount_$_"} =
                               $form->format_amount( \%myconfig,
-                                $form->{"amount_$_"}, 2 );
+                                $form->{"amount_$_"}, LedgerSMB::Setting->new(%$form)->get('decimal_places') );
                         }
                         for ( 1 .. $form->{paidaccounts} ) {
                             $form->{"paid_$_"} =
                               $form->format_amount( \%myconfig,
-                                $form->{"paid_$_"}, 2 );
+                                $form->{"paid_$_"}, LedgerSMB::Setting->new(%$form)->get('decimal_places') );
                         }
 
                     }

--- a/old/bin/arap.pl
+++ b/old/bin/arap.pl
@@ -741,11 +741,11 @@ sub reprint {
             $form->{rowcount}--;
             for ( 1 .. $form->{rowcount} ) {
                 $form->{"amount_$_"} =
-                  $form->format_amount( \%myconfig, $form->{"amount_$_"}, 2 );
+                  $form->format_amount( \%myconfig, $form->{"amount_$_"}, LedgerSMB::Setting->new(%$form)->get('decimal_places') );
             }
             for ( split / /, $form->{taxaccounts} ) {
                 $form->{"tax_$_"} =
-                  $form->format_amount( \%myconfig, $form->{"tax_$_"}, 2 );
+                  $form->format_amount( \%myconfig, $form->{"tax_$_"}, LedgerSMB::Setting->new(%$form)->get('decimal_places') );
             }
             $pf = "print_transaction";
         }
@@ -765,7 +765,7 @@ sub reprint {
 
     for ( 1 .. $form->{paidaccounts} ) {
         $form->{"paid_$_"} =
-          $form->format_amount( \%myconfig, $form->{"paid_$_"}, 2 );
+          $form->format_amount( \%myconfig, $form->{"paid_$_"}, LedgerSMB::Setting->new(%$form)->get('decimal_places') );
     }
 
     $form->{copies} = 1;

--- a/old/bin/arapprn.pl
+++ b/old/bin/arapprn.pl
@@ -220,7 +220,7 @@ sub print_transaction {
     $form->{integer_amount} = $form->format_amount( \%myconfig, $whole );
 
     foreach my $field (qw(invtotal subtotal paid total)) {
-        $form->{$field} = $form->format_amount( \%myconfig, $form->{$field}, 2 );
+        $form->{$field} = $form->format_amount( \%myconfig, $form->{$field}, LedgerSMB::Setting->new(%$form)->get('decimal_places') );
     }
 
     ( $form->{employee} ) = split /--/, $form->{employee};

--- a/old/bin/gl.pl
+++ b/old/bin/gl.pl
@@ -228,7 +228,7 @@ sub display_form
 
   for (qw(totaldebit totalcredit)) {
       $form->{$_} =
-    $form->format_amount( \%myconfig, $form->{$_}, 2, "0" );
+    $form->format_amount( \%myconfig, $form->{$_}, LedgerSMB::Setting->new(%$form)->get('decimal_places'), "0" );
   }
 
   $transdate = $form->datetonum( \%myconfig, $form->{transdate} );
@@ -384,7 +384,7 @@ sub display_row {
 
             for (qw(debit debit_fx credit credit_fx)) {
                 $form->{"${_}_$i"} = ($form->{"${_}_$i"})
-                    ? $form->format_amount( \%myconfig, $form->{"${_}_$i"}, 2 )
+                    ? $form->format_amount( \%myconfig, $form->{"${_}_$i"}, LedgerSMB::Setting->new(%$form)->get('decimal_places') )
                     : "";
                 $temphash1->{$_} = $form->{"${_}_$i"};
             }
@@ -485,9 +485,9 @@ sub gl_subtotal_tt {
 
     my %column_data;
     $subtotaldebit =
-      $form->format_amount( \%myconfig, $subtotaldebit, 2, " " );
+      $form->format_amount( \%myconfig, $subtotaldebit, LedgerSMB::Setting->new(%$form)->get('decimal_places'), " " );
     $subtotalcredit =
-      $form->format_amount( \%myconfig, $subtotalcredit, 2, " " );
+      $form->format_amount( \%myconfig, $subtotalcredit, LedgerSMB::Setting->new(%$form)->get('decimal_places'), " " );
 
     for (@column_index) { $column_data{$_} = " " }
     $column_data{class} = 'subtotal';
@@ -505,9 +505,9 @@ sub gl_subtotal_tt {
 
 sub gl_subtotal {
     $subtotaldebit =
-      $form->format_amount( \%myconfig, $subtotaldebit, 2, "&nbsp;" );
+      $form->format_amount( \%myconfig, $subtotaldebit, LedgerSMB::Setting->new(%$form)->get('decimal_places'), "&nbsp;" );
     $subtotalcredit =
-      $form->format_amount( \%myconfig, $subtotalcredit, 2, "&nbsp;" );
+      $form->format_amount( \%myconfig, $subtotalcredit, LedgerSMB::Setting->new(%$form)->get('decimal_places'), "&nbsp;" );
 
     for (@column_index) { $column_data{$_} = "<td>&nbsp;</td>" }
 

--- a/old/bin/ic.pl
+++ b/old/bin/ic.pl
@@ -1064,7 +1064,7 @@ sub vendor_row {
       $vendor
       <td><input data-dojo-type="dijit/form/TextBox" name="partnumber_$i" size=20 value="$form->{"partnumber_$i"}"></td>
       <td><input data-dojo-type="dijit/form/TextBox" name="lastcost_$i" size=10 value=|
-          . $form->format_amount( \%myconfig, $form->{"lastcost_$i"}, 2 )
+          . $form->format_amount( \%myconfig, $form->{"lastcost_$i"}, LedgerSMB::Setting->new(%$form)->get('decimal_places') )
           . qq|></td>
       $currency
       <td nowrap><input data-dojo-type="dijit/form/TextBox" name="leadtime_$i" size=5 value=|
@@ -1176,7 +1176,7 @@ sub customer_row {
           . $form->format_amount( \%myconfig, $form->{"pricebreak_$i"} )
           . qq|></td>
       <td><input data-dojo-type="dijit/form/TextBox" name="customerprice_$i" size=10 value=|
-          . $form->format_amount( \%myconfig, $form->{"customerprice_$i"}, 2 )
+          . $form->format_amount( \%myconfig, $form->{"customerprice_$i"}, LedgerSMB::Setting->new(%$form)->get('decimal_places') )
           . qq|></td>
       $currency
       <td><input class="date" data-dojo-type="lsmb/DateTextBox" name="validfrom_$i" size=11 title="$myconfig{dateformat}" value="$form->{"validfrom_$i"}"></td>
@@ -1303,11 +1303,11 @@ sub assembly_row {
           $form->format_amount( \%myconfig, $form->{"qty_$i"} );
 
         $linetotalsellprice =
-          $form->format_amount( \%myconfig, $linetotalsellprice, 2 );
+          $form->format_amount( \%myconfig, $linetotalsellprice, LedgerSMB::Setting->new(%$form)->get('decimal_places') );
         $linetotallistprice =
-          $form->format_amount( \%myconfig, $linetotallistprice, 2 );
+          $form->format_amount( \%myconfig, $linetotallistprice, LedgerSMB::Setting->new(%$form)->get('decimal_places') );
         $linetotallastcost =
-          $form->format_amount( \%myconfig, $linetotallastcost, 2 );
+          $form->format_amount( \%myconfig, $linetotallastcost, LedgerSMB::Setting->new(%$form)->get('decimal_places') );
 
         if ( $i == $numrows && !$form->{project_id} ) {
 
@@ -1378,13 +1378,13 @@ qq|<td><input type=hidden name="description_$i" value="$form->{"description_$i"}
 
     $column_data{sellprice} =
       "<th align=right>"
-      . $form->format_amount( \%myconfig, $form->{sellprice}, 2 ) . "</th>";
+      . $form->format_amount( \%myconfig, $form->{sellprice}, LedgerSMB::Setting->new(%$form)->get('decimal_places') ) . "</th>";
     $column_data{listprice} =
       "<th align=right>"
-      . $form->format_amount( \%myconfig, $form->{listprice}, 2 ) . "</th>";
+      . $form->format_amount( \%myconfig, $form->{listprice}, LedgerSMB::Setting->new(%$form)->get('decimal_places') ) . "</th>";
     $column_data{lastcost} =
       "<th align=right>"
-      . $form->format_amount( \%myconfig, $form->{lastcost}, 2 ) . "</th>";
+      . $form->format_amount( \%myconfig, $form->{lastcost}, LedgerSMB::Setting->new(%$form)->get('decimal_places') ) . "</th>";
 
     print qq|
         <tr>|;

--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -456,7 +456,7 @@ qq|<td align=right class="qty"><input data-dojo-type="dijit/form/TextBox" id="qt
           . qq|"></td>|;
         $column_data{linetotal} =
             qq|<td align=right class="linetotal">|
-          . $form->format_amount( \%myconfig, $linetotal, 2 )
+          . $form->format_amount( \%myconfig, $linetotal, LedgerSMB::Setting->new(%$form)->get('decimal_places') )
           . qq|</td>|;
         $form->{"bin_$i"} //= '';
         $column_data{bin}    = qq|<td class="bin">$form->{"bin_$i"}</td>|;

--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -723,7 +723,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id=intnotes name=intnotes rows
                 $form->{invtotal} += $form->round_amount($form->{taxes}{$item}, 2);
                 $form->{"${taccno}_total"} =
                     $form->round_amount($form->{taxes}{$item}, 2);
-                my $item_total_formatted=$form->format_amount(\%myconfig,$form->{"${item}_total"},2,0);
+                my $item_total_formatted=$form->format_amount(\%myconfig,$form->{"${item}_total"},LedgerSMB::Setting->new(%$form)->get('decimal_places'),0);
                 $tax .= qq|
                 <tr class="invoice-auto-tax">
                   <th align=right>$form->{"${item}_description"}</th>
@@ -735,11 +735,11 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id=intnotes name=intnotes rows
         }
 
         $form->{invsubtotal} =
-          $form->format_amount( \%myconfig, $form->{invsubtotal}, 2, 0 );
+          $form->format_amount( \%myconfig, $form->{invsubtotal}, LedgerSMB::Setting->new(%$form)->get('decimal_places'), 0 );
         my $invsubtotal_bc =
             $form->format_amount( \%myconfig,
                                   $form->{invsubtotal} * $form->{exchangerate},
-                                  2);
+                                  LedgerSMB::Setting->new(%$form)->get('decimal_places'));
 
         $subtotal = qq|
           <tr class="invoice-subtotal">
@@ -752,7 +752,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id=intnotes name=intnotes rows
 
     $form->{oldinvtotal} = $form->{invtotal};
     $form->{invtotal} =
-    $form->format_amount( \%myconfig, $form->{invtotal}, 2, 0 );
+    $form->format_amount( \%myconfig, $form->{invtotal}, LedgerSMB::Setting->new(%$form)->get('decimal_places'), 0 );
 
     my $hold;
 
@@ -812,7 +812,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id=intnotes name=intnotes rows
       (($form->{currency} ne $form->{defaultcurrency})
        ? ("<tr><td><!-- total --></td><td align=right>" . $form->format_amount( \%myconfig,
                                                      $form->{invtotal}
-                                                     * $form->{exchangerate}, 2)
+                                                     * $form->{exchangerate}, LedgerSMB::Setting->new(%$form)->get('decimal_places'))
           . "</td><td>$form->{defaultcurrency}</td></tr>") : '') . qq|
         </table>
       </td>
@@ -911,9 +911,9 @@ s/option value="\Q$form->{"AP_paid_$i"}\E"/option value="$form->{"AP_paid_$i"}" 
         $form->{"paidfx_$i"} =
             $form->format_amount(
                 \%myconfig,
-                $form->{"paid_$i"} * ($form->{"exchangerate_$i"} // 1), 2 );
+                $form->{"paid_$i"} * ($form->{"exchangerate_$i"} // 1), LedgerSMB::Setting->new(%$form)->get('decimal_places') );
         $form->{"paid_$i"} =
-          $form->format_amount( \%myconfig, $form->{"paid_$i"}, 2 );
+          $form->format_amount( \%myconfig, $form->{"paid_$i"}, LedgerSMB::Setting->new(%$form)->get('decimal_places') );
         $form->{"exchangerate_$i"} =
           $form->format_amount( \%myconfig, $form->{"exchangerate_$i"} );
 

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -803,7 +803,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id="intnotes" name="intnotes" 
                 <th align=right>$form->{"${taccno}_description"}</th>
                 <td><input data-dojo-type="dijit/form/TextBox" type="text" name="mt_amount_$item"
                         id="mt-amount-$item" value="|
-                        .$form->format_amount(\%myconfig, $form->{"mt_amount_$item"}, 2)
+                        .$form->format_amount(\%myconfig, $form->{"mt_amount_$item"}, LedgerSMB::Setting->new(%$form)->get('decimal_places'))
                         .qq|" size="10"/></td>
                 <td><input data-dojo-type="dijit/form/TextBox" type="text" name="mt_rate_$item"
                          id="mt-rate-$item" value="|
@@ -811,7 +811,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id="intnotes" name="intnotes" 
                         .qq|" size="4"/></td>
                 <td><input data-dojo-type="dijit/form/TextBox" type="text" name="mt_basis_$item"
                          id="mt-basis-$item" value="|
-                        .$form->format_amount(\%myconfig, $form->{"mt_basis_$item"}, 2)
+                        .$form->format_amount(\%myconfig, $form->{"mt_basis_$item"}, LedgerSMB::Setting->new(%$form)->get('decimal_places'))
                         .qq|" size="10"/></td>
                 <td><input data-dojo-type="dijit/form/TextBox" type="text" name="mt_ref_$item"
                          id="mt-ref-$item" value="|
@@ -824,7 +824,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id="intnotes" name="intnotes" 
            $form->{invtotal} += $form->round_amount($form->{taxes}{$item}, 2);
                 $form->{"${taccno}_total"} =
                       $form->format_amount( \%myconfig,
-                           $form->round_amount( $form->{taxes}{$item}, 2 ), 2 );
+                           $form->round_amount( $form->{taxes}{$item}, 2 ), LedgerSMB::Setting->new(%$form)->get('decimal_places') );
                 next if !$form->{"${taccno}_total"};
                 $tax .= qq|
                 <tr class="invoice-auto-tax">
@@ -836,7 +836,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id="intnotes" name="intnotes" 
             $tax .= q|<tr><td>&nbsp;</td></tr>|;
         }
         $form->{invsubtotal} =
-          $form->format_amount( \%myconfig, $form->{invsubtotal}, 2, 0 );
+          $form->format_amount( \%myconfig, $form->{invsubtotal}, LedgerSMB::Setting->new(%$form)->get('decimal_places'), 0 );
 
         $subtotal = qq|
           <tr class="invoice-subtotal">
@@ -854,11 +854,11 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id="intnotes" name="intnotes" 
 
     $form->{oldinvtotal} = $form->{invtotal};
     $form->{invtotal} =
-    $form->format_amount( \%myconfig, $form->{invtotal}, 2, 0 );
+    $form->format_amount( \%myconfig, $form->{invtotal}, LedgerSMB::Setting->new(%$form)->get('decimal_places'), 0 );
     my $invtotal_bc;
     $invtotal_bc =
         $form->format_amount( \%myconfig,
-                              $form->{invtotal} * $form->{exchangerate}, 2)
+                              $form->{invtotal} * $form->{exchangerate}, LedgerSMB::Setting->new(%$form)->get('decimal_places'))
         if $form->{currency} ne $form->{defaultcurrency};
 
 
@@ -1020,9 +1020,9 @@ s/option value="\Q$form->{"AR_paid_$i"}\E"/option value="$form->{"AR_paid_$i"}" 
         $form->{"paidfx_$i"} =
             $form->format_amount(
                 \%myconfig,
-                $form->{"paid_$i"} * ($form->{"exchangerate_$i"} // 1), 2 );
+                $form->{"paid_$i"} * ($form->{"exchangerate_$i"} // 1), LedgerSMB::Setting->new(%$form)->get('decimal_places') );
         $form->{"paid_$i"} =
-          $form->format_amount( \%myconfig, $form->{"paid_$i"}, 2 );
+          $form->format_amount( \%myconfig, $form->{"paid_$i"}, LedgerSMB::Setting->new(%$form)->get('decimal_places') );
         $form->{"exchangerate_$i"} =
           $form->format_amount( \%myconfig, $form->{"exchangerate_$i"} );
 

--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -790,7 +790,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id=intnotes name=intnotes rows
             $form->{"${taccno}_total"} = $form->format_amount(
                 \%myconfig,
                 $form->round_amount( $form->{taxes}{$item}, 2 ),
-                2
+                LedgerSMB::Setting->new(%$form)->get('decimal_places')
             );
             next if !$form->{"${taccno}_total"};
             $tax .= qq|
@@ -801,7 +801,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id=intnotes name=intnotes rows
         }
 
         $form->{invsubtotal} =
-          $form->format_amount( \%myconfig, $form->{invsubtotal}, 2, 0 );
+          $form->format_amount( \%myconfig, $form->{invsubtotal}, LedgerSMB::Setting->new(%$form)->get('decimal_places'), 0 );
 
         $subtotal = qq|
           <tr>
@@ -813,7 +813,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id=intnotes name=intnotes rows
     }
     $form->{oldinvtotal} = $form->{invtotal};
     $form->{invtotal} =
-      $form->format_amount( \%myconfig, $form->{invtotal}, 2, 0 );
+      $form->format_amount( \%myconfig, $form->{invtotal}, LedgerSMB::Setting->new(%$form)->get('decimal_places'), 0 );
 
     print qq|
   <tr>
@@ -2410,7 +2410,7 @@ sub generate_purchase_orders {
 
         $form->{"lastcost_$i"} =
           $form->format_amount( \%myconfig,
-            $form->{orderitems}{$parts_id}{lastcost}, 2 );
+            $form->{orderitems}{$parts_id}{lastcost}, LedgerSMB::Setting->new(%$form)->get('decimal_places') );
 
         $form->{"qty_$i"} = $required;
 
@@ -2444,7 +2444,7 @@ sub generate_purchase_orders {
                     \%myconfig,
                     $form->{orderitems}{$parts_id}{"parts$form->{vc}"}{$id}
                       {lastcost},
-                    2
+                    LedgerSMB::Setting->new(%$form)->get('decimal_places')
                 );
                 $form->{"leadtime_$i"} = $form->format_amount( \%myconfig,
                     $form->{orderitems}{$parts_id}{"parts$form->{vc}"}{$id}
@@ -2456,7 +2456,7 @@ sub generate_purchase_orders {
                         $form->{orderitems}{$parts_id}{"parts$form->{vc}"}{$id}
                           {curr}
                       },
-                    2
+                    LedgerSMB::Setting->new(%$form)->get('decimal_places')
                 );
 
                 $form->{"id_$i"} = $parts_id;

--- a/old/bin/pe.pl
+++ b/old/bin/pe.pl
@@ -998,7 +998,7 @@ sub project_jcitems_list {
         }
         for (qw(amount sellprice)) {
             $form->{"${_}_$i"} =
-              $form->format_amount( \%myconfig, $form->{"${_}_$i"}, 2 );
+              $form->format_amount( \%myconfig, $form->{"${_}_$i"}, LedgerSMB::Setting->new(%$form)->get('decimal_places') );
         }
     }
 


### PR DESCRIPTION
The default currency amount for payable should be calculated without format.
The decimal places should always stick to the user defined value and never used constant value in code unless it is intentional.

Closes #5656 
Closes #5657 