### PR TITLE
Set the 'tax' checkmark on an account when taxes are provided

### DIFF
--- a/lib/LedgerSMB/Company/Configuration.pm
+++ b/lib/LedgerSMB/Company/Configuration.pm
@@ -289,7 +289,7 @@ sub _process_coa_account {
         unless $parent;
 
     my %args;
-    for my $arg (qw(description category contra tax recon
+    for my $arg (qw(description category contra recon
                     obsolete is_temp gifi)) {
         my $value = $account_xml->getAttribute($arg);
         $args{$arg} = $value if defined $value;
@@ -311,6 +311,7 @@ sub _process_coa_account {
         heading_id  => $parent->id,
         gifi_id     => $args{gifi},
         link        => \@links,
+        tax         => (scalar @taxes > 0 ? 1 : 0),
         %args,
         );
     $account->save;

--- a/t/22-company-configuration.t
+++ b/t/22-company-configuration.t
@@ -248,7 +248,7 @@ is($queries[0]->{bound_params}, [ 1, 'en', 'MACHINES' ],
 @queries = grep { $_->{statement} =~ m/account__save(?!_)/ } $history->@*;
 is(scalar(@queries), 1, 'Test 2: account__save');
 is($queries[0]->{bound_params},
-   [ undef, '0410', 'Maschinen', 'A', undef, 1, 0, 0, [ 'AP_paid' ], 0 ],
+   [ undef, '0410', 'Maschinen', 'A', undef, 1, 0, 1, [ 'AP_paid' ], 0 ],
    'Test 2: account__save() arguments');
 
 


### PR DESCRIPTION
During testing, it was discovered that the Tax check mark in the account
screen wasn't checked, even though tax configuration records were imported.
