### PR TITLE
Retain $form->{id} even when `check_form()` renders the form

### DIFF
--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -1278,10 +1278,10 @@ sub update {
 
     # wow... check_form() in io.pl also *displays* the form!!
     # at least... in some cases
+    $form->{id} = $form_id;
     check_form();
 
     $form->{rowcount}--;
-    $form->{id} = $form_id;
     display_form();
 }
 

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -651,8 +651,7 @@ sub form_header {
         else {
             if ( $transdate > $closedto ) {
                 # Added on_hold, by Aurynn.
-                for ( "update", "ship_to", "post",
-                    "schedule")
+                for ( "update", "ship_to", "post", "schedule")
                 {
                     $allowed{$_} = 1;
                 }
@@ -1406,10 +1405,9 @@ sub update {
 #             billing => 1,
 #             job => 1 );
 #    $form->generate_selects(\%myconfig);
-    check_form();
-
-    $form->{rowcount}--;
     $form->{id} = $form_id;
+    check_form();
+    $form->{rowcount}--;
     display_form();
 }
 


### PR DESCRIPTION
Closes #5680
