### PR TITLE
Fix repeated saving of invoices popping up an SQL error

### DIFF
--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -63,6 +63,7 @@ sub copy_to_new{
 }
 
 sub edit_and_save {
+    $form->{ARAP} = 'AP';
     my $draft = LedgerSMB::DBObject::Draft->new(%$form);
     $draft->delete();
     delete $form->{id};
@@ -125,6 +126,7 @@ sub add {
 }
 
 sub edit {
+    $form->{ARAP} = 'AP';
     if (not $form->{id} and $form->{workflow_id}) {
         my $wf = FACTORY->fetch_workflow( 'AR/AP', $form->{workflow_id} );
         $form->{id} = $wf->context->param( 'id' );

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -73,6 +73,7 @@ sub copy_to_new{
 }
 
 sub edit_and_save {
+    $form->{ARAP} = 'AR';
     my $draft = LedgerSMB::DBObject::Draft->new(%$form);
     $draft->delete();
     delete $form->{id};
@@ -118,6 +119,7 @@ sub add {
 }
 
 sub edit {
+    $form->{ARAP} = 'AR';
     if (not $form->{id} and $form->{workflow_id}) {
         my $wf = FACTORY->fetch_workflow( 'AR/AP', $form->{workflow_id} );
         $form->{id} = $wf->context->param( 'id' );


### PR DESCRIPTION
Due to the "ARAP" key missing in the `$form` object, the IIAA module
was unable to identify the cash account on which to post the payment.

Fixes #5679.
