### PR TITLE
Fix repeated saving of invoices popping up an SQL error

### DIFF
--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -63,6 +63,7 @@ sub copy_to_new{
 }
 
 sub edit_and_save {
+    $form->{ARAP} = 'AP';
     my $draft = LedgerSMB::DBObject::Draft->new(%$form);
     $draft->delete();
     delete $form->{id};
@@ -125,6 +126,7 @@ sub add {
 }
 
 sub edit {
+    $form->{ARAP} = 'AP';
 
     &invoice_links;
     &prepare_invoice;

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -71,6 +71,7 @@ sub copy_to_new{
 }
 
 sub edit_and_save {
+    $form->{ARAP} = 'AR';
     my $draft = LedgerSMB::DBObject::Draft->new(%$form);
     $draft->delete();
     delete $form->{id};
@@ -116,6 +117,7 @@ sub add {
 }
 
 sub edit {
+    $form->{ARAP} = 'AR';
 
     &invoice_links;
     &prepare_invoice;


### PR DESCRIPTION
Due to the "ARAP" key missing in the `$form` object, the IIAA module
was unable to identify the cash account on which to post the payment.

Fixes #5679.
