### PR TITLE
Downgrade Chrome to a version less prone to timeout on page loading

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,7 +295,7 @@ jobs:
       perl: '5.34'
       postgres: '11'
       browser: chrome
-      selenium: selenium/node-chrome:3
+      selenium: selenium/node-chrome:3.141.59-20210607
       coverage: 1
     steps:
       - prep_env:

--- a/utils/selenium/docker-compose-chrome.yml
+++ b/utils/selenium/docker-compose-chrome.yml
@@ -3,7 +3,7 @@ version: '2.1'
 services:
 
   chrome:
-    image: selenium/node-chrome:3
+    image: selenium/node-chrome:3.141.59-20210607
     depends_on:
       - hub
     volumes:


### PR DESCRIPTION
Latest Chrome and many more before have been prone to timeout on page loading.
We had reliability with 3.141.59-20210607 for months.