### PR TITLE
Remove undefined interval warning in PNL reports

### DIFF
--- a/lib/LedgerSMB/Report/Dates.pm
+++ b/lib/LedgerSMB/Report/Dates.pm
@@ -47,7 +47,7 @@ Either 'none', 'month', 'quarter', or 'year'
 
 =cut
 
-has interval => (is => 'ro', isa => 'Str', required => 0);
+has interval => (is => 'ro', isa => 'Str', required => 0, default => 'None');
 
 =item from_month int
 


### PR DESCRIPTION
Make sure that PNL header is properly initialized