### PR TITLE
Use `make devtest` on CI to deduplicate test infrastructure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ commands:
             then
               make devtest TESTS="--no-progress --job-count $JOB_COUNT \"--cover=$DEVEL_COVER_OPTIONS\" t/ xt/"
             else
-               make devtest TESTS='--no-progress t/ xt/'
+               make devtest TESTS='--no-progress --job-count 2 t/ xt/'
             fi
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,34 +34,13 @@ commands:
             fi
 
       - run:
-          name: Create test database
-          command: |
-            source $BASH_ENV
-            PERL5LIB="lib:$HOME/perl5/lib/perl5" \
-            PERL5OPT="$PERL5OPT $STARMAN_DEVEL_COVER_OPTIONS" \
-              ./bin/ledgersmb-admin create $PGUSER@$PGHOST/$PGDB
-
-      - run:
           command: |
             source $BASH_ENV
             if [ "x$COVERAGE" == "x1" ]
             then
-              yath test $YATH_DEVEL_COVER_OPTIONS \
-                --job-count $JOB_COUNT --event-timeout 1800 \
-                --color --no-progress --retry=2 \
-                --pgtap-dbname=$PGDB --pgtap-username=$PGUSER \
-                --pgtap-psql=.circleci/psql-wrap \
-                --Feature-tags=~@wip \
-                t xt
+              make devtest TESTS="--no-progress --job-count $JOB_COUNT \"--cover=$DEVEL_COVER_OPTIONS\" t/ xt/"
             else
-              yath start $YATH_DEVEL_COVER_OPTIONS \
-                       --job-count $JOB_COUNT --event-timeout 1800
-            yath run --color --no-progress --retry=2 \
-                     --pgtap-dbname=$PGDB --pgtap-username=$PGUSER \
-                     --pgtap-psql=.circleci/psql-wrap \
-                     --Feature-tags=~@wip \
-              t xt
-            yath stop
+               make devtest TESTS='--no-progress t/ xt/'
             fi
       - run:
           command: |
@@ -269,7 +248,7 @@ executors:
     environment:
       BROWSER: << parameters.browser >>
       COVERAGE: << parameters.coverage >>
-      DEVEL_COVER_OPTIONS: -silent,1,+ignore,(^x?t/|^utils/|\.lttc$|^/usr/|/home/circleci/perl5|starman$)
+      DEVEL_COVER_OPTIONS: -silent,1,+ignore,(^x?t/|^utils/|\.lttc$|^/usr/|/home/circleci/perl5|starman$$)
       HARNESS_RULESFILE: t/testrules.yml
       JOB_COUNT: 2
       LSMB_BASE_URL: http://127.0.0.1:5000

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -221,7 +221,7 @@ jobs:
 
       - name: Run Perl tests
         run: |
-          make devtest TESTS='--no-progress t xt'
+          make devtest TESTS='--no-progress --job-count 2 t xt'
         env:
           LSMB_TEST_DB: 1
           COA_TESTING: ${{ matrix.COA_TESTING }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,7 +120,7 @@ jobs:
       BROWSER: ${{ matrix.BROWSER }}
       COA_TESTING: ${{ matrix.COA_TESTING }}
       DB_TESTING: ${{ matrix.DB_TESTING }}
-      DEVEL_COVER_OPTIONS: -silent,1,+ignore,(^x?t/|^local/|^utils/|\.lttc$|^/usr/|^/opt/|starman$),-summary,1
+      DEVEL_COVER_OPTIONS: -silent,1,+ignore,(^x?t/|^local/|^utils/|\.lttc$|^/usr/|^/opt/|starman\$\$),-summary,1
       JOB_COUNT: 5
       LSMB_BASE_URL: http://lsmb:5000
       LSMB_NEW_DB: lsmb_test
@@ -207,12 +207,6 @@ jobs:
           echo "JOB_COUNT=2" >> $GITHUB_ENV
         if: ${{ matrix.COVERAGE }}
 
-      - name: Create default test database
-        run: |
-          PERL5OPT="$PERL5OPT $STARMAN_DEVEL_COVER_OPTIONS" \
-          PERL5LIB="lib:$PERL5LIB" \
-            ./bin/ledgersmb-admin create $PGUSER@$PGHOST/$PGDB
-
       - name: Starting 'starman'
         run: |
           PERL5OPT="$PERL5OPT $STARMAN_DEVEL_COVER_OPTIONS" \
@@ -227,13 +221,7 @@ jobs:
 
       - name: Run Perl tests
         run: |
-          yath start --job-count $JOB_COUNT --event-timeout 300
-          yath run --color --no-progress --retry=2 \
-            --pgtap-dbname=$LSMB_NEW_DB --pgtap-username=$PGUSER \
-            --pgtap-psql=.circleci/psql-wrap \
-            --Feature-tags=~@wip \
-            t xt
-          yath stop
+          make devtest TESTS='--no-progress t xt'
         env:
           LSMB_TEST_DB: 1
           COA_TESTING: ${{ matrix.COA_TESTING }}
@@ -243,12 +231,7 @@ jobs:
 
       - name: Run Coverage Perl tests
         run: |
-          yath test --color --no-progress --retry=2 --job-count $JOB_COUNT \
-            --pgtap-dbname=$LSMB_NEW_DB --pgtap-username=$PGUSER \
-            --pgtap-psql=.circleci/psql-wrap \
-            --Feature-tags=~@wip \
-            $YATH_DEVEL_COVER_OPTIONS \
-            t xt
+          make devtest TESTS="--no-progress --job-count $JOB_COUNT \"--cover=${{ env.DEVEL_COVER_OPTIONS }}\" t xt"
         env:
           LSMB_TEST_DB: 1
           COA_TESTING: ${{ matrix.COA_TESTING }}


### PR DESCRIPTION
Use `make devtest` everywhere, so it will work on local test infrastructure when I need it...