### PR TITLE
AR/AP transactions don't (yet) have a workflow_id; accomodate for that

### DIFF
--- a/UI/js-src/lsmb/PrintButton.js
+++ b/UI/js-src/lsmb/PrintButton.js
@@ -30,7 +30,7 @@ define([
                         action: this.get("value"),
                         type: f.type.value,
                         id: f.id.value,
-                        workflow_id: f.workflow_id.value,
+                        workflow_id: f.workflow_id ? f.workflow_id.value : "",
                         formname: f.formname.value,
                         language_code: f.language_code.value,
                         media: "screen",


### PR DESCRIPTION
The print button had (apparently) only been tested with AR/AP invoices,
orders and quotes, because those all have workflow_id's.
