### PR TITLE
Enable renovate on master and 1.9 [skip ci]

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
     "extends": [
       "config:base"
     ],
+    "baseBranches": [ "master", "1.9" ],
     "packageRules": [
         {
             "matchPackagePatterns": [


### PR DESCRIPTION
Enable renovate processing of master and 1.9.
Contrary to expected usage, renovate only reads config from the default branch, `master`, in our case. It wouldn't process a config in 1.9