### PR TITLE
Make dojo with proper version, regardless of leftovers in js-src

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,7 +69,7 @@ function findDataDojoTypes(fileName) {
 
 // Compute used data-dojo-type
 glob.sync("**/*.html", {
-    ignore: ["lib/ui-header.html", "js/**"],
+    ignore: ["lib/ui-header.html", "js/**", "js-src/{dojo,dijit,util}/**"],
     cwd: "UI"
 }).map(function (filename) {
     const requires = findDataDojoTypes("UI/" + filename);


### PR DESCRIPTION
Don't consider old dojo version in `UI/js-src` for `make dojo`