### PR TITLE
When posting url encoded form data, set the content-type header

### DIFF
--- a/UI/js-src/lsmb/Form.js
+++ b/UI/js-src/lsmb/Form.js
@@ -75,6 +75,9 @@ define([
                     );
                 } else {
                     // old code (Form.pm) wants x-www-urlencoded
+                    options.headers = {
+                        "Content-Type": "application/x-www-form-urlencoded"
+                    };
                     options.data =
                         domattr.get(this.clickedAction, "name") +
                         "=" +

--- a/UI/js-src/lsmb/PrintButton.js
+++ b/UI/js-src/lsmb/PrintButton.js
@@ -89,6 +89,10 @@ define([
                         }
                     }
                 };
+                client.setRequestHeader(
+                    "Content-Type",
+                    "application/x-www-form-urlencoded"
+                );
                 client.send(dojo.objectToQuery(data));
                 event.stop(evt);
                 return;


### PR DESCRIPTION
Plack::Request expects the content-type header to match either
the x-www-form-urlencoded or the form-data content-type.

Closes #5901.
