### PR TITLE
Remove printed-queued documents

### DIFF
--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -326,12 +326,6 @@ def 'localepath',
     doc => q{};
 
 
-# spool directory for batch printing
-def 'spool',
-    section => 'paths',
-    default => 'spool',
-    doc => q{};
-
 # templates base directory
 def 'templates',
     section => 'paths',

--- a/old/bin/am.pl
+++ b/old/bin/am.pl
@@ -1113,7 +1113,7 @@ sub process_transactions {
                         $form->{paidaccounts} = -1;
                     }
 
-                    for (qw(id recurring intnotes printed emailed queued)) {
+                    for (qw(id recurring intnotes printed emailed)) {
                         delete $form->{$_};
                     }
 
@@ -1225,7 +1225,7 @@ sub process_transactions {
                         $pt->{req}, "days" )
                       if $form->{reqdate};
 
-                    for (qw(id recurring intnotes printed emailed queued)) {
+                    for (qw(id recurring intnotes printed emailed)) {
                         delete $form->{$_};
                     }
                     for ( 1 .. $form->{rowcount} ) {

--- a/old/bin/arap.pl
+++ b/old/bin/arap.pl
@@ -321,7 +321,7 @@ sub add_transaction {
 sub post_as_new {
 
     $form->{old_workflow_id} = $form->{workflow_id};
-    for (qw(id printed emailed queued workflow_id)) { delete $form->{$_} }
+    for (qw(id printed emailed workflow_id)) { delete $form->{$_} }
     &post;
 
 }
@@ -329,7 +329,7 @@ sub post_as_new {
 sub print_and_post_as_new {
 
     $form->{old_workflow_id} = $form->{workflow_id};
-    for (qw(id printed emailed queued workflow_id)) { delete $form->{$_} }
+    for (qw(id printed emailed workflow_id)) { delete $form->{$_} }
     &print_and_post;
 
 }

--- a/old/bin/arapprn.pl
+++ b/old/bin/arapprn.pl
@@ -101,25 +101,6 @@ sub print {
         }
     }
 
-    if ( $filename = $queued{ $form->{formname} } ) {
-        $form->{queued} =~ s/$form->{formname} $filename//;
-        unlink( LedgerSMB::Sysconfig::spool() . "/$filename");
-        $filename =~ s/\..*$//g;
-    }
-    else {
-        $filename = time;
-        $filename .= $$;
-    }
-
-    $filename .= ( $form->{format} eq 'postscript' ) ? '.ps' : '.pdf';
-
-    if ( $form->{media} ne 'screen' ) {
-        $form->{OUT} = LedgerSMB::Sysconfig::spool() . "/$filename";
-        $form{printmode} = '>';
-    }
-
-    $form->{queued} .= " $form->{formname} $filename";
-    $form->{queued} =~ s/^ //;
     $printform = Form->new;
     for ( keys %$form ) {
         $printform->{$_} = $form->{$_};
@@ -131,6 +112,7 @@ sub print {
         &post;
     }
     else {
+        # the only supported formname for transactions is 'transaction'...
         &{"print_$form->{formname}"}( $old_form, 1 );
     }
 
@@ -243,31 +225,6 @@ sub print_transaction {
     }
     if ( $form->{format} =~ /(postscript|pdf)/ ) {
         $form->{IN} =~ s/html$/tex/;
-    }
-    if ( $form->{media} eq 'queue' ) {
-        %queued = split / /, $form->{queued};
-
-        if ( $filename = $queued{ $form->{formname} } ) {
-            $form->{queued} =~ s/$form->{formname} $filename//;
-            unlink LedgerSMB::Sysconfig::spool() . "/$filename";
-            $filename =~ s/\..*$//g;
-        }
-        else {
-            $filename = time;
-            $filename .= $$;
-        }
-
-        $filename .= ( $form->{format} eq 'postscript' ) ? '.ps' : '.pdf';
-        $form->{OUT}       = LedgerSMB::Sysconfig::spool() . "/$filename";
-        $form->{printmode} = '>';
-
-        $form->{queued} .= " $form->{formname} $filename";
-        $form->{queued} =~ s/^ //;
-
-        # save status
-        $form->update_status;
-
-        $old_form->{queued} = $form->{queued};
     }
 
     if ( lc($form->{media}) eq 'zip'){

--- a/old/bin/gl.pl
+++ b/old/bin/gl.pl
@@ -675,7 +675,7 @@ sub check_balanced {
 }
 
 sub save_as_new {
-    for (qw(id printed emailed queued)) { delete $form->{$_} }
+    for (qw(id printed emailed)) { delete $form->{$_} }
     $form->{approved} = 0;
     &post;
 }

--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -1028,7 +1028,7 @@ sub quotation {
 
 sub create_form {
 
-    for (qw(id printed emailed queued workflow_id)) { delete $form->{$_} }
+    for (qw(id printed emailed workflow_id)) { delete $form->{$_} }
 
     $form->{script} = 'oe.pl';
 
@@ -1480,30 +1480,6 @@ sub print_form {
         $output_options{filename} =
             $form->{formname} . '-'. $form->{"${inv}number"} .
             '.'. $form->{format}; # assuming pdf or htm
-    } elsif ( $form->{media} eq 'queue' ) {
-        %queued = split / /, $form->{queued};
-
-        if ( $filename = $queued{ $form->{formname} } ) {
-            $form->{queued} =~ s/$form->{formname} $filename//;
-            unlink( LedgerSMB::Sysconfig::spool() . "/$filename");
-            $filename =~ s/\..*$//g;
-        }
-        else {
-            $filename = time;
-            $filename .= $$;
-        }
-
-        $filename .= ( $form->{format} eq 'postscript' ) ? '.ps' : '.pdf';
-        $form->{OUT}       = LedgerSMB::Sysconfig::spool() . "/$filename";
-        $form->{printmode} = '>';
-
-        $form->{queued} .= " $form->{formname} $filename";
-        $form->{queued} =~ s/^ //;
-
-        # save status
-        $form->update_status;
-
-        $old_form->{queued} = $form->{queued};
     }
 
     $form->{fileid} = $form->{"${inv}number"};

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -406,7 +406,7 @@ sub form_header {
 |;
 
     $form->hide_form(
-        qw(form_id id type printed emailed queued title vc terms discount
+        qw(form_id id type printed emailed title vc terms discount
            creditlimit creditremaining tradediscount business closedto locked
            shipped oldtransdate recurring reverse batch_id subtype tax_id
            meta_number separate_duties lock_description nextsub

--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -572,7 +572,7 @@ sub form_header {
     }
     $form->hide_form(qw(entity_control_code meta_number tax_id address city));
     $form->hide_form(
-        qw(id type printed emailed queued vc title discount creditlimit creditremaining tradediscount business recurring form_id nextsub
+        qw(id type printed emailed vc title discount creditlimit creditremaining tradediscount business recurring form_id nextsub
    lock_description)
     );
 
@@ -1430,7 +1430,7 @@ sub yes {
         $err = $locale->text('Cannot delete quotation!');
     }
 
-    if ( OE->delete( \%myconfig, \%$form, LedgerSMB::Sysconfig::spool() ) ) {
+    if ( OE->delete( \%myconfig, \%$form ) ) {
         $form->redirect($msg);
     }
     else {
@@ -1519,7 +1519,7 @@ sub invoice {
     }
     my $lib = uc($script);
 
-    for (qw(id subject message printed emailed queued)) { delete $form->{$_} }
+    for (qw(id subject message printed emailed)) { delete $form->{$_} }
     $form->{ $form->{vc} } =~ s/--.*//g;
     $form->{type} = "invoice";
 
@@ -1560,7 +1560,7 @@ sub invoice {
         }
     }
 
-    for (qw(id subject message printed emailed queued audittrail)) {
+    for (qw(id subject message printed emailed audittrail)) {
         delete $form->{$_};
     }
 
@@ -1700,7 +1700,7 @@ sub create_backorder {
     }
 
     # clear flags
-    for (qw(id subject message cc bcc printed emailed queued audittrail)) {
+    for (qw(id subject message cc bcc printed emailed audittrail)) {
         delete $form->{$_};
     }
 
@@ -1734,7 +1734,7 @@ sub save_as_new {
     # orders don't have a quonumber
     # quotes don't have an ordnumber
     $form->{old_workflow_id} = $form->{workflow_id};
-    for (qw(closed id printed emailed queued ordnumber quonumber workflow_id)) {
+    for (qw(closed id printed emailed ordnumber quonumber workflow_id)) {
         delete $form->{$_}
     }
     &_save;
@@ -1745,7 +1745,7 @@ sub print_and_save_as_new {
     # orders don't have a quonumber
     # quotes don't have an ordnumber
     $form->{old_workflow_id} = $form->{workflow_id};
-    for (qw(closed id printed emailed queued ordnumber quonumber workflow_id)) {
+    for (qw(closed id printed emailed ordnumber quonumber workflow_id)) {
         delete $form->{$_}
     }
     &_print_and_save;
@@ -1844,7 +1844,7 @@ sub display_ship_receive {
 <input type=hidden name=display_form value=display_ship_receive>
 |;
 
-    $form->hide_form(qw(id type media format printed emailed queued vc));
+    $form->hide_form(qw(id type media format printed emailed vc));
 
     print qq|
 <input type=hidden name="old$form->{vc}" value="$form->{"old$form->{vc}"}">

--- a/old/bin/pe.pl
+++ b/old/bin/pe.pl
@@ -1300,8 +1300,7 @@ sub generate_sales_orders {
 
         if ( OE->save( \%myconfig, \%$order ) ) {
             if ( !PE->allocate_projectitems( \%myconfig, \%$order ) ) {
-                OE->delete( \%myconfig, \%$order,
-                            LedgerSMB::Sysconfig::spool() );
+                OE->delete( \%myconfig, \%$order );
             }
         }
         else {

--- a/old/bin/printer.pl
+++ b/old/bin/printer.pl
@@ -129,6 +129,7 @@ sub print_options {
                 text => $locale->text('Screen'),
                 value => 'screen'}
                 ]};
+
         if (   LedgerSMB::Sysconfig::printer()->%*
             && LedgerSMB::Sysconfig::latex() )
         {

--- a/old/lib/LedgerSMB/AA.pm
+++ b/old/lib/LedgerSMB/AA.pm
@@ -506,7 +506,7 @@ sub post_transaction {
 
     IIAA->process_form_payments($myconfig, $form);
 
-    # save printed and queued
+    # save printed
     $form->save_status($dbh);
     return 1 unless $dbh->errstr;
 }

--- a/old/lib/LedgerSMB/IS.pm
+++ b/old/lib/LedgerSMB/IS.pm
@@ -1281,7 +1281,7 @@ sub post_invoice {
     $form->{name} =~ s/--$form->{customer_id}//;
     $form->add_shipto($form->{id});
 
-    # save printed, emailed and queued
+    # save printed, emailed
     $form->save_status($dbh);
 
     if (!$form->{separate_duties}){


### PR DESCRIPTION
This functionality can't be triggered anymore. Also, in today's world
building a queue into our software isn't useful anymore. Modern lpr
implementations (e.g. CUPS) have their own queueing implementations.
Also, CUPS offers scheduled printing using `-o job-hold-until`.

Now that 'queued' is removed, the spool directory also lost its purpose.
