### PR TITLE
Restore 1.9 functionality of having shareable URLs

### DIFF
--- a/UI/js-src/lsmb/Form.js
+++ b/UI/js-src/lsmb/Form.js
@@ -8,8 +8,19 @@ define([
     "dojo/dom-attr",
     "dojo/dom-form",
     "dojo/query",
+    "dojo/hash",
     "dijit/registry"
-], function (Form, declare, event, on, domattr, domform, query, registry) {
+], function (
+    Form,
+    declare,
+    event,
+    on,
+    domattr,
+    domform,
+    query,
+    hash,
+    registry
+) {
     var c = 0;
     return declare("lsmb/Form", [Form], {
         clickedAction: null,
@@ -52,7 +63,7 @@ define([
                     "&" +
                     qobj;
                 url = url + "?" + qobj + "#" + c.toString(16);
-                registry.byId("maindiv").load_link(url); // add GET forms to the back button history
+                hash(url); // add GET forms to the back button history
             } else {
                 options.method = method;
                 if (this.domNode.enctype === "multipart/form-data") {

--- a/UI/js-src/lsmb/MainContentPane.js
+++ b/UI/js-src/lsmb/MainContentPane.js
@@ -9,6 +9,7 @@ define([
     "dijit/registry",
     "dojo/dom-style",
     "dojo/on",
+    "dojo/hash",
     "dojo/promise/Promise",
     "dojo/Deferred",
     "dojo/promise/all",
@@ -24,6 +25,7 @@ define([
     registry,
     domStyle,
     on,
+    hash,
     Promise,
     Deferred,
     all,
@@ -57,7 +59,7 @@ define([
             on(dnode, "click", function (e) {
                 if (!e.ctrlKey && !e.shiftKey && mouse.isLeft(e)) {
                     event.stop(e);
-                    self.load_link(href);
+                    hash(href + "#" + Date.now());
                     self.fade_main_div();
                 }
             });
@@ -156,7 +158,10 @@ define([
                     }
 
                     self.hide_main_div();
-                    return self.set_main_div(request.response);
+
+                    let p = new Deferred().resolve(request);
+                    self.set_main_div(request.response);
+                    return p;
                 },
                 function (request) {
                     if (domReject(request)) {
@@ -218,7 +223,7 @@ define([
                     query("a", self.domNode).forEach(function (node) {
                         self.interceptClick(node);
                     });
-                    self.show_main_div();
+                    return self.show_main_div();
                 });
             }
 

--- a/UI/js-src/lsmb/main.js
+++ b/UI/js-src/lsmb/main.js
@@ -1,4 +1,5 @@
 /** @format */
+/* eslint no-console:0 */
 
 define([
     "dojo/_base/declare",
@@ -32,8 +33,20 @@ define([
             for (var i = 0; i < 25; i++) {
                 h += chars.charAt(Math.floor(Math.random() * chars.length));
             }
-            if (options.data && options.data instanceof FormData) {
-                registry.byId("maindiv")._load_form(url, options);
+            if (options && options.data && options.data instanceof FormData) {
+                registry
+                    .byId("maindiv")
+                    ._load_form(url, options)
+                    .then(function (request) {
+                        let l = request.getResponseHeader("Location");
+                        if (l) {
+                            console.log("request Location: " + l);
+                        } else {
+                            console.log(
+                                "request not redirected for back button"
+                            );
+                        }
+                    });
             } else {
                 var q = { url: url, options: options };
                 this.history[h] = q;
@@ -61,11 +74,23 @@ define([
                     }
                 }
                 topic.subscribe("/dojo/hashchange", function (h) {
+                    let hist;
                     if (h in self.history) {
-                        var hist = self.history[h];
-                        mainDiv._load_form(hist.url, hist.options);
+                        hist = self.history[h];
+                    } else if (h in sessionStorage) {
+                        hist = JSON.parse(sessionStorage[h]);
+                    }
+                    if (hist) {
+                        mainDiv
+                            ._load_form(hist.url, hist.options)
+                            .then(function (request) {
+                                let l = request.getResponseHeader("Location");
+                                if (l) {
+                                    console.log("request Location: " + l);
+                                }
+                            });
                     } else if (!h.startsWith("__") && h !== "") {
-                        mainDiv.load_link(h);
+                        mainDiv._load_form(h, {});
                     }
                 });
             }

--- a/UI/js-src/lsmb/menus/Tree.js
+++ b/UI/js-src/lsmb/menus/Tree.js
@@ -4,6 +4,7 @@
 define([
     "dojo/_base/declare",
     "dojo/on",
+    "dojo/hash",
     "dojo/_base/lang",
     "dojo/_base/event",
     "dojo/mouse",
@@ -12,11 +13,11 @@ define([
     "dojo/store/Memory",
     "dijit/Tree",
     "dijit/tree/ObjectStoreModel",
-    "dijit/registry",
     "dojo/topic"
 ], function (
     declare,
     on,
+    hash,
     lang,
     event,
     mouse,
@@ -25,7 +26,6 @@ define([
     Memory,
     Tree,
     ObjectStoreModel,
-    registry,
     topic
 ) {
     // set up the store to get the tree data, plus define the method
@@ -148,8 +148,7 @@ define([
                 // function).
                 url += "#" + Date.now();
 
-                var mainDiv = registry.byId("maindiv");
-                mainDiv.load_link(url);
+                hash(url);
             }
         },
         __onClick: function (e) {


### PR DESCRIPTION
The new `__()` urls used by 1.9 block the use-case of sharing links
to documents for discussion with colleagues. This commit (mostly)
restores the links and thus the use-case.