### PR TITLE
Fix regression of errors not creating pop-ups

### DIFF
--- a/UI/js-src/lsmb/MainContentPane.js
+++ b/UI/js-src/lsmb/MainContentPane.js
@@ -112,7 +112,11 @@ define([
              }
              req.setRequestHeader("X-Requested-With", "XMLHttpRequest");
              req.addEventListener("load", function () {
+                    if (req.status >= 400) {
+                        dfd.reject(req);
+                    } else {
                  dfd.resolve(req);
+                    }
              });
              req.addEventListener("error", function () {
                  dfd.reject(req);
@@ -125,19 +129,31 @@ define([
          return dfd.then(
              function (request) {
                  if (domReject(request)) {
+                        self.report_error("Server returned insecure response");
                      return self.show_main_div();
                  }
 
                  self.hide_main_div();
                  return self.set_main_div(request.response);
              },
-             function (request) {
-                 if (domReject(request)) {
-                     return self.show_main_div();
+                function (errOrReq) {
+                    var errstr;
+                    if (errOrReq instanceof Error) {
+                        errstr = "JavaScript error: " + errOrReq.toString();
+                    } else if (errOrReq instanceof XMLHttpRequest) {
+                        if (errOrReq.status === 0) {
+                            errstr = "Could not connect to server";
+                        } else if (domReject(errOrReq)) {
+                            errstr = "Server returned insecure response";
+                        } else {
+                            errstr = errOrReq.response;
+                        }
+                    } else {
+                        errstr = "Unknown (JavaScript) error";
                  }
 
                  self.show_main_div();
-                 return self.report_request_error({ err: request });
+                    return self.report_error(errstr);
              }
          );
       },


### PR DESCRIPTION
The fix for CVE-2021-3693 regressed, causing errors to be presented
as page content instead of as pop-ups.

Fixes #5921.
