### PR TITLE
Don't select headers for AP/AR default account

### DIFF
--- a/lib/LedgerSMB/Database/Upgrade.pm
+++ b/lib/LedgerSMB/Database/Upgrade.pm
@@ -187,7 +187,8 @@ sub _linked_accounts {
     my @accounts;
 
     my $sth = $dbh->prepare("select id, accno, description
-                               from chart where link = '$link'")
+                               from chart where link = '$link'
+                                and charttype = 'A'")
         or die $dbh->errstr;
 
     $sth->execute() or die $sth->errstr;

--- a/t/16-dbupgrade.t
+++ b/t/16-dbupgrade.t
@@ -60,12 +60,14 @@ my $upgrade =
                     main => (
                         {
                             statement => q{select id, accno, description
-                               from chart where link = 'AR'},
+                               from chart where link = 'AR'
+                               and charttype = 'A'},
                             results   => [[]],
                         },
                         {
                             statement => q{select id, accno, description
-                               from chart where link = 'AP'},
+                               from chart where link = 'AP'
+                               and charttype = 'A'},
                             results   => [[]],
                         },
                     ),

--- a/t/16-dbupgrade.t
+++ b/t/16-dbupgrade.t
@@ -61,13 +61,13 @@ my $upgrade =
                         {
                             statement => q{select id, accno, description
                                from chart where link = 'AR'
-                               and charttype = 'A'},
+                                and charttype = 'A'},
                             results   => [[]],
                         },
                         {
                             statement => q{select id, accno, description
                                from chart where link = 'AP'
-                               and charttype = 'A'},
+                                and charttype = 'A'},
                             results   => [[]],
                         },
                     ),


### PR DESCRIPTION
Make sure that header accounts are not considered in finding the default AP/AR accounts for migration