### PR TITLE
Show payment lines immediately after saving

### DIFF
--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -330,7 +330,7 @@ sub create_links {
         }
     }
 
-    $form->{paidaccounts} = 1 if not defined $form->{paidaccounts};
+    $form->{paidaccounts} = 1 if not $form->{paidaccounts};
 
 
     # check if calculated is equal to stored
@@ -843,7 +843,8 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" size=40 
         </tr>
 ";
 
-    $form->{paidaccounts}++ if ( $form->{"paid_$form->{paidaccounts}"} );
+     # add 0 to numify the value in paid_$paidaccounts...
+    $form->{paidaccounts}++ if ( $form->{"paid_$form->{paidaccounts}"}+0 );
     if (defined $form->{cash_accno}) {
         $form->{"select$form->{ARAP}_paid"} =~ /value="(\Q$form->{cash_accno}\E--[^<]*)"/;
         $form->{"$form->{ARAP}_paid_$form->{paidaccounts}"} = $1;

--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -241,7 +241,7 @@ sub invoice_links {
 
     }
 
-    $form->{paidaccounts} = 1 unless ( exists $form->{paidaccounts} );
+    $form->{paidaccounts} = 1 if not $form->{paidaccounts};
 
     $form->{AP} = $form->{AP_1} unless $form->{id};
     $form->{AP} //= $form->{AP_links}->{AP}->[0]->{accno} unless $form->{id};
@@ -888,7 +888,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id=intnotes name=intnotes rows
     </tr>
 |;
 
-    $form->{paidaccounts}++ if ( $form->{"paid_$form->{paidaccounts}"} );
+    $form->{paidaccounts}++ if ( $form->{"paid_$form->{paidaccounts}"}+0 );
     $form->{"selectAP_paid"} =~ /value="(\Q$form->{cash_accno}\E--[^<]*)"/;
     $form->{"AP_paid_$form->{paidaccounts}"} = $1;
     foreach my $i ( 1 .. $form->{paidaccounts} ) {

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -233,7 +233,7 @@ sub invoice_links {
     $form->{AR} //= $form->{AR_links}->{AR}->[0]->{accno} unless $form->{id};
     for (qw(AR_links acc_trans)) { delete $form->{$_} }
 
-    $form->{paidaccounts} = 1 unless ( exists $form->{paidaccounts} );
+    $form->{paidaccounts} = 1 if not $form->{paidaccounts};
 
     if ( !$form->{readonly} ) {
         $form->{readonly} = 1 if $myconfig{acs} =~ /AR--Sales Invoice/;
@@ -997,7 +997,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id="intnotes" name="intnotes" 
     print "
         </tr>
 ";
-    $form->{paidaccounts}++ if ( $form->{"paid_$form->{paidaccounts}"} );
+    $form->{paidaccounts}++ if ( $form->{"paid_$form->{paidaccounts}"}+0 );
     $form->{"selectAR_paid"} =~ /value="(\Q$form->{cash_accno}\E--[^<]*)"/;
     $form->{"AR_paid_$form->{paidaccounts}"} = $1;
     foreach my $i ( 1 .. $form->{paidaccounts} ) {


### PR DESCRIPTION
Neither transactions nor invoices showed payment lines immediately
after saving a transaction when none had been added on entry
(Update would make them reappear).

Closes #6017
