### PR TITLE
E-mail body expansion and workflow overrides

### DIFF
--- a/UI/email.html
+++ b/UI/email.html
@@ -118,6 +118,34 @@ IF actions.grep('^Attach$').size > 0 ;
 [%
 END ; # IF
 
+IF expansions.keys.size > 0 ;
+
+%]
+
+<p>[% text('The e-mail body may contain variables to be expanded - e.g. <%invnumber%> - the table below specifies the available variables and their expansions for this e-mail') %]</p>
+<table style="min-width:40em">
+  <tr>
+    <th>[% text('Variable') %]</th>
+    <th>[% text('Expansion') %]</th>
+  </tr>
+
+[%
+FOR expansion_key IN expansions.keys ;
+%]
+
+  <tr>
+    <td>[% expansion_key %]</td>
+    <td>[% expansions.$expansion_key %]</td>
+  </tr>
+
+[%
+
+END ; # FOR
+
+%]</table>[%
+
+END ; # IF
+
 %]
 
 

--- a/doc/conf/ledgersmb.conf.default
+++ b/doc/conf/ledgersmb.conf.default
@@ -72,6 +72,18 @@ localepath = locale/po
 #
 #templates_cache = lsmb_templates
 
+# directory where workflow files are stored
+#
+#workflows = workflows
+
+# directory where custom workflow files are stored
+#
+# custom workflows are used to override behaviour of the default workflows by
+# providing actions/conditions/etc by the same name and type or by providing
+# workflows of the same type with e.g. additional states and actions.
+#
+#custom_workflows = custom_workflows
+
 [programs]
 
 [mail]

--- a/doc/conf/ledgersmb.conf.unbuilt-dojo
+++ b/doc/conf/ledgersmb.conf.unbuilt-dojo
@@ -72,6 +72,18 @@ localepath = locale/po
 #
 #templates_cache = lsmb_templates
 
+# directory where workflow files are stored
+#
+#workflows = workflows
+
+# directory where custom workflow files are stored
+#
+# custom workflows are used to override behaviour of the default workflows by
+# providing actions/conditions/etc by the same name and type or by providing
+# workflows of the same type with e.g. additional states and actions.
+#
+#custom_workflows = custom_workflows
+
 [programs]
 
 [mail]

--- a/lib/LedgerSMB/Scripts/email.pm
+++ b/lib/LedgerSMB/Scripts/email.pm
@@ -86,7 +86,8 @@ sub render {
         callback    => $request->{callback},
         id          => $wf->id,
         ( map { $_ => $wf->context->param($_) }
-          qw( from to cc bcc notify subject body sent_date attachments ) ),
+          qw( from to cc bcc notify subject body sent_date
+              attachments expansions ) ),
         actions     => [ $wf->get_current_actions ]
     });
 }

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -344,6 +344,17 @@ def 'workflows',
 
 defaults to './workflows'};
 
+def 'custom_workflows',
+    section => 'paths',
+    default => 'custom_workflows',
+    doc => q{directory where custom workflow files are stored;
+
+custom workflows are used to override behaviour of the default workflows by
+providing actions/conditions/etc by the same name and type or by providing workflows
+of the same type with e.g. additional states and actions.
+
+defaults to './custom_workflows'};
+
 ### SECTION  ---   Template file formats
 
 def 'template_latex',
@@ -550,10 +561,17 @@ sub _workflow_factory_config {
     $wf_type = lc($wf_type // '');
     $wf_type .= '.' if $wf_type;
 
-    my $wf_dir = LedgerSMB::Sysconfig::workflows();
+    my @wf_dirs = (LedgerSMB::Sysconfig::workflows());
+    push @wf_dirs, LedgerSMB::Sysconfig::custom_workflows()
+        if -d LedgerSMB::Sysconfig::custom_workflows();
+
     for my $config_type (qw(action condition persister validator workflow)) {
-        $config{$config_type} = "$wf_dir/${wf_type}${config_type}s.xml"
-            if -f "$wf_dir/${wf_type}${config_type}s.xml";
+        my @configs;
+        $config{$config_type} = \@configs;
+        for my $wf_dir (@wf_dirs) {
+            push @configs, "$wf_dir/${wf_type}${config_type}s.xml"
+                if -f "$wf_dir/${wf_type}${config_type}s.xml";
+        }
     }
 
     return \%config;
@@ -588,15 +606,19 @@ sub initialize {
     }
     else {
         my $r   = sub { File::Find::Rule->new };
-        my $wf_dir = LedgerSMB::Sysconfig::workflows();
-        my %wf_config = (
-            action    => [ $r->()->name( '*.actions.xml' )->in($wf_dir) ],
-            condition => [ $r->()->name( '*.conditions.xml' )->in($wf_dir) ],
-            persister => [ $r->()->name( '*.persisters.xml' )->in($wf_dir) ],
-            validator => [ $r->()->name( '*.validators.xml' )->in($wf_dir) ],
-            workflow  => [ $r->()->name( '*.workflow.xml' )->in($wf_dir) ],
-            );
-        FACTORY()->add_config_from_file(%wf_config);
+        for my $wf_dir (LedgerSMB::Sysconfig::workflows(),
+                        LedgerSMB::Sysconfig::custom_workflows()) {
+            next if not -d $wf_dir;
+
+            my %wf_config = (
+                action    => [ $r->()->name( '*.actions.xml' )->in($wf_dir) ],
+                condition => [ $r->()->name( '*.conditions.xml' )->in($wf_dir) ],
+                persister => [ $r->()->name( '*.persisters.xml' )->in($wf_dir) ],
+                validator => [ $r->()->name( '*.validators.xml' )->in($wf_dir) ],
+                workflow  => [ $r->()->name( '*.workflow.xml' )->in($wf_dir) ],
+                );
+            FACTORY()->add_config_from_file(%wf_config);
+        }
     }
 }
 

--- a/lib/LedgerSMB/Workflow/Persister/Email.pm
+++ b/lib/LedgerSMB/Workflow/Persister/Email.pm
@@ -20,6 +20,7 @@ use warnings;
 use strict;
 use base qw( LedgerSMB::Workflow::Persister::ExtraData );
 
+use JSON::MaybeXS;
 
 =head2 fetch_extra_workflow_data($wf)
 
@@ -57,9 +58,14 @@ named argument C<disable_cache> to prevent caching the content in-memory:
 
 =cut
 
+my $json = JSON::MaybeXS->new( utf8 => 0 );
+
 sub fetch_extra_workflow_data {
     my ($self, $wf) = @_;
     $self->SUPER::fetch_extra_workflow_data($wf);
+    if ( my $expansions = $wf->context->param( 'expansions' ) ) {
+        $wf->context->param( 'expansions', $json->decode( $expansions ) );
+    }
 
     my $dbh = $self->handle;
     my $sth = $dbh->prepare(

--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -1414,6 +1414,23 @@ sub print_form {
 
         my $wf_id;
         my $wf;
+        my %expansions =
+            $form->%{
+                grep { defined $form->{$_} }
+                     ( "${inv}total", "${due}date", qw(
+    formname id
+
+    businessnumber company tel fax address
+
+    invnumber ordnumber quonumber exchangerate terms duedate taxincluded
+    curr employee reverse ponumber crdate duedate transdate terms
+
+    customernumber name address1 address2 city state zipcode country sic iban
+
+    totalqty totalship totalweight totalparts totalservices totalweightship
+
+    paid subtotal total
+                         ))};
         if ($order) {
             ($wf_id) =
                 $form->{dbh}->selectrow_array(
@@ -1453,7 +1470,9 @@ sub print_form {
         $wf->context->param(
             subject => ($form->{subject}
                         // qq|$form->{label} $form->{"${inv}number"}|) );
-
+        $wf->context->param(
+            expansions => \%expansions
+            );
         $wf->context->param(
             attachment => {
                 content => $body,

--- a/old/lib/LedgerSMB/IS.pm
+++ b/old/lib/LedgerSMB/IS.pm
@@ -644,7 +644,7 @@ sub invoice_details {
     for (qw(totalparts totalservices)) {
         $form->{$_} = $form->format_amount( $myconfig, $form->{$_}, 2 );
     }
-    for (qw(totalqty totalship totalweight)) {
+    for (qw(totalqty totalship totalweight totalweightship)) {
         $form->{$_} = $form->format_amount( $myconfig, $form->{$_} );
     }
     $form->{subtotal} = $form->format_amount( $myconfig, $form->{total}, 2 );

--- a/old/lib/LedgerSMB/OE.pm
+++ b/old/lib/LedgerSMB/OE.pm
@@ -1301,7 +1301,7 @@ sub order_details {
     for (qw(totalparts totalservices)) {
         $form->{$_} = $form->format_amount( $myconfig, $form->{$_}, 2 );
     }
-    for (qw(totalqty totalship totalweight)) {
+    for (qw(totalqty totalship totalweight totalweightship)) {
         $form->{$_} = $form->format_amount( $myconfig, $form->{$_} );
     }
     $form->{subtotal} = $form->format_amount( $myconfig, $form->{ordtotal}, 2 );

--- a/sql/changes/1.9/workflow-email-expansion.sql
+++ b/sql/changes/1.9/workflow-email-expansion.sql
@@ -1,0 +1,7 @@
+
+
+alter table email
+   add column if not exists expansions jsonb;
+
+update email set expansions = '{}'::jsonb;
+

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -150,5 +150,6 @@ mc/delete-migration-validation-data.sql
 1.9/transpose_user_prefs.sql
 1.9/file-reconciliation.sql
 1.9/add-vclimit.sql
+1.9/workflow-email-expansion.sql
 # 1.10 changes
 1.10/old-defaults-cleanup.sql

--- a/workflows/email.actions.xml
+++ b/workflows/email.actions.xml
@@ -11,11 +11,14 @@
           action="queue" order="3" />
   <action name="Send"
           class="LedgerSMB::Workflow::Action::Email"
-          action="send" order="4" />
+          action="expand" order="4" />
   <action name="Attach"
           class="LedgerSMB::Workflow::Action::Email"
           action="attach" order="5" />
   <action name="Load"
           class="LedgerSMB::Workflow::Action::Email"
           action="load" order="6" />
+  <action name="do-send"
+          class="LedgerSMB::Workflow::Action::Email"
+          action="send" />
 </actions>

--- a/workflows/email.persisters.xml
+++ b/workflows/email.persisters.xml
@@ -1,8 +1,9 @@
 <persisters>
-  <persister name="Email"
-             class="LedgerSMB::Workflow::Persister::Email"
-             driver="Pg"
-             extra_table="email"
-             extra_data_field="from,to,cc,bcc,notify,subject,body,sent_date">
+  <persister
+      name="Email"
+      class="LedgerSMB::Workflow::Persister::Email"
+      driver="Pg"
+      extra_table="email"
+      extra_data_field="from,to,cc,bcc,notify,subject,body,sent_date,expansions">
   </persister>
 </persisters>

--- a/workflows/email.workflow.xml
+++ b/workflows/email.workflow.xml
@@ -8,7 +8,7 @@
    <action name="Send"   resulting_state="SUCCESS" />
    <action name="Cancel" resulting_state="CANCELLED"/>
 
-<!--
+ <!--
       Commented out in anticipation of functionality to manage the queue
 
    <action name="Queue"  resulting_state="QUEUED">
@@ -16,7 +16,7 @@
   </action>
  -->
  </state>
-<!--
+ <!--
  <state name="QUEUED">
    <action name="Send"   resulting_state="SENT">
      <condition name="Complete" />
@@ -24,6 +24,10 @@
    <action name="Cancel" resulting_state="CANCELLED"/>
  </state>
  -->
+
+ <state name="EXPANDED" autorun="true">
+   <action name="do-send" resulting_state="SUCCESS" />
+ </state>
  <state name="SUCCESS" />
  <state name="CANCELLED" />
 </workflow>


### PR DESCRIPTION
While developing our workflows framework, I had envisioned users wanting to override our workflows *and* I wanted them to be able to do so without the need to patch our files. Apparently, I never implemented that. Here's to correct that.

Additionally, @freelock found that e-mail variable expansion was lost due to the e-mail functionality rewrite. This is repairing that.