### PR TITLE
Fix user preference lookup in 'old code'

### DIFF
--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -1226,8 +1226,9 @@ sub db_init {
 
 sub _set_datestyle {
     my $dbh = shift;
-    my $datequery = q{select "value" from user_preference join users using(id)
-                      where "name" = 'dateformat' and username = CURRENT_USER};
+    my $datequery =
+        q{select "value" from user_preference p join users u on u.id = p.user_id
+           where "name" = 'dateformat' and username = CURRENT_USER};
     my $date_sth = $dbh->prepare($datequery);
     $date_sth->execute;
     my ($datestyle) = $date_sth->fetchrow_array;


### PR DESCRIPTION
In 1.9, user preferences have changed from column based setup to
row-based setup. The query to retrieve user settings in Form.pm
unfortunately didn't correctly join users and preferences.

Closes #6040
