### PR TITLE
1.9 Fix hierarchy coa heading doesn't set its parent

### DIFF
--- a/lib/LedgerSMB/Company/Configuration/Heading.pm
+++ b/lib/LedgerSMB/Company/Configuration/Heading.pm
@@ -119,7 +119,7 @@ sub save {
     my ($row) = $self->call_dbmethod(
         funcname => 'account_heading_save',
         args => {
-            parent_id => $self->heading_id,
+            parent => $self->heading_id,
         });
     return $self->_id($row->{account_heading_save});
 }


### PR DESCRIPTION
account_heading_save accept the arg named in_parent not parent_id