### PR TITLE
Force setting transdate on invoice from order

### DIFF
--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -551,7 +551,8 @@ sub form_header {
             my $is_draft = 0;
             if (!$form->{approved}){
                $is_draft = 1;
-               if ($form->is_allowed_role(['draft_post'])) {
+               if ($form->{transdate} and
+                   $form->is_allowed_role(['draft_post'])) {
                  $button{approve} = {
                    ndx   => 3,
                    key   => 'O',

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -620,7 +620,8 @@ sub form_header {
             if (!$form->{approved} && !$form->{batch_id}){
                if (!$form->{batch_id}){
                    $is_draft = 1;
-                   if ($form->is_allowed_role(['draft_post'])) {
+                   if ($form->{transdate} and
+                       $form->is_allowed_role(['draft_post'])) {
                        $button{approve} = {
                            ndx   => 3,
                            key   => 'O',

--- a/workflows/arap.conditions.xml
+++ b/workflows/arap.conditions.xml
@@ -3,4 +3,7 @@
   <condition name="is_sales"
              test="($context->{table_name} eq 'ar')"
              class="Workflow::Condition::Evaluate"/>
+  <condition name="complete"
+             test="$context->{transdate}"
+             class="Workflow::Condition::Evaluate"/>
 </conditions>

--- a/workflows/arap.workflow.xml
+++ b/workflows/arap.workflow.xml
@@ -12,7 +12,9 @@ TODO! Check workflow when 'separate duties' is false!
   <state name="SAVED">
     <action name="save" resulting_state="NOCHANGE" />
     <action name="save_as_new" resulting_state="NOCHANGE" />
-    <action name="post" resulting_state="POSTED" />
+    <action name="post" resulting_state="POSTED">
+      <condition name="complete" />
+    </action>
     <action name="sales_order" resulting_state="NOCHANGE">
       <condition name="is_sales" />
     </action>


### PR DESCRIPTION
By requiring the transaction to be saved before anything else, the
transdate (provided by the client) is added to the invoice; don't offer
the Post button when the transdate hasn't been set yet: that forces the
required Save.
