### PR TITLE
Fix sending mail with multiple bcc addresses

### DIFF
--- a/lib/LedgerSMB/Workflow/Action/Email.pm
+++ b/lib/LedgerSMB/Workflow/Action/Email.pm
@@ -234,15 +234,16 @@ sub send {
                       filename     => $att->{file_name});
     }
 
-
     local $@ = undef;
     eval {
         # On failure, send() throws an exception
         if ( my $bcc = $ctx->param( 'bcc' ) ) {
+            # Split $bcc into separate addresses and de-duplicate them
+            my %bcc = map { $_ => 1 } split /\s*,\s*/, $bcc;
             Email::Sender::Simple->send(
                 $mail->email,
                 {
-                    to => $bcc,
+                    to => [ keys %bcc ],
                     _configure_smtp(),
                 });
         }


### PR DESCRIPTION
Email::Stuffer does the required work for us for To and Cc,
but we need to do it for Bcc ourselves...
