### PR TITLE
Fix sending mail with multiple bcc addresses

### DIFF
--- a/old/lib/LedgerSMB/Mailer.pm
+++ b/old/lib/LedgerSMB/Mailer.pm
@@ -252,10 +252,12 @@ sub send {
 
         # On failure, send() throws an exception
         if ($self->{bcc}) {
+            # Split Bcc into separate addresses and de-duplicate them
+            my %bcc = map { $_ => 1 } split /\s*,\s*/, $self->{bcc};
             Email::Sender::Simple->send(
                 $self->{_message}->email,
                 {
-                    to => $self->{bcc},
+                    to => [ keys %bcc ],
                     @transport,
                 });
         }


### PR DESCRIPTION
Email::Stuffer does the required work for us for To and Cc,
but we need to do it for Bcc ourselves...

Manual backport to 1.8 due to rewritten e-mail handling in 1.9.
