### PR TITLE
Fix US General COA

### DIFF
--- a/locale/coa/us/General.xml
+++ b/locale/coa/us/General.xml
@@ -73,6 +73,7 @@
       <account code="4010" description="Sales" category="Income">
         <link code="AR_amount"/>
         <link code="IC_sale"/>
+        <link code="IC_income"/>
       </account>
     </account-heading>
     <account-heading id="h-9" code="4400" description="OTHER REVENUE">
@@ -159,6 +160,7 @@
   </currencies>
   <settings>
     <setting name="inventory_accno_id" accno="1510"/>
+    <setting name="earn_id" accno="3500"/>
     <setting name="income_accno_id" accno="4010"/>
     <setting name="expense_accno_id" accno="5010"/>
     <setting name="fxgain_accno_id" accno="4450"/>


### PR DESCRIPTION
Add the 'Current earnings' default setting.
Add the correct link code so that 4010 Sales can be selected as the default 'Income' account.

Before:
![Screen Shot 2021-10-05 at 9 08 57 AM](https://user-images.githubusercontent.com/1809796/136053368-52a4218b-f06b-428e-9914-7e4543f9f9d4.png)

After:
![Screen Shot 2021-10-05 at 10 07 14 AM](https://user-images.githubusercontent.com/1809796/136053420-cea359a5-ca78-41f9-a406-3e1006f6eb8d.png)


