### PR TITLE
Don't show the overpayment section without overpayment accounts configured

### DIFF
--- a/UI/payments/payment2.html
+++ b/UI/payments/payment2.html
@@ -334,6 +334,8 @@ onLoad="maximize_minimize_on_load(event, 'div_topay_state', 'payments/img/down.g
         <th colspan="2">[% topay_subtotal -%]&nbsp;[% curr.value -%]</th>
       </tr>
     </table>
+
+[% IF overpayment_account.size > 0 %]
     <table width="100%" id="overpayments">
       <tr>
         <th class="listheading" colspan="7" >[% text('OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT') %]</th>
@@ -475,11 +477,22 @@ onLoad="maximize_minimize_on_load(event, 'div_topay_state', 'payments/img/down.g
    <th colspan="5" align="right">[% text('Subtotal') -%]</th>
    <th colspan="2">[% overpayment_subtotal -%]&nbsp;[% curr.value -%]</th>
    </tr>
+   <!-- this bit is repeated in the ELSE section too -->
    <tr class="listtotal">
    <th colspan="5" align="right">[% text('Total') -%]</th>
    <th colspan="2">[% payment_total -%]&nbsp;[% curr.value -%]</th>
    </tr>
    </table>
+
+[% ELSE; # IF overpayment_account.size == 0  %]
+   <table width="100%" id="overpayments">
+   <!-- this bit is repeated in the IF section too -->
+   <tr class="listtotal">
+   <th colspan="5" align="right">[% text('Total') -%]</th>
+   <th colspan="2">[% payment_total -%]&nbsp;[% curr.value -%]</th>
+   </tr>
+   </table>
+[% END; # IF overpayment_account.size == 0 %]
 
    <hr />
    [% PROCESS button element_data={


### PR DESCRIPTION
As per the comments on the chat and in the issue, the current input screen
gives the wrong impression of what the screen actually means. The first step
to improvement is to remove the part that is irrelevant due to missing
configuration.

Closes #6059
