### PR TITLE
Fix the incorrect default income account in US General.xml

### DIFF
--- a/locale/coa/us/General.xml
+++ b/locale/coa/us/General.xml
@@ -73,6 +73,7 @@
       <account code="4010" description="Sales" category="Income">
         <link code="AR_amount"/>
         <link code="IC_sale"/>
+        <link code="IC_income"/>
       </account>
     </account-heading>
     <account-heading id="h-9" code="4400" description="OTHER REVENUE">


### PR DESCRIPTION
Add `IC_income` link code for account 4010 Sales.
Otherwise the COA defaults to 4430 Shipping and Handling as the default income account.