### PR TITLE
Fix mini-css-extract-plugin version [ci_skip]

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "markdown-spellcheck": "1.3.1",
     "markdownlint": "0.24.0",
     "markdownlint-cli": "0.29.0",
-    "mini-css-extract-plugin": "2.3.0",
+    "mini-css-extract-plugin": "=2.3.0",
     "npm-run-all": "4.1.5",
     "path-browserify": "1.0.1",
     "prettier": "2.4.1",


### PR DESCRIPTION
Latest upgrade of mini-css-extract-plugin conflicts with other webpack plugins, notably dojo-webpack-plugin so fix it to current 2.3 version