### PR TITLE
Fix clobbering invoice header data (e.g. fx rate) on 'Update'

### DIFF
--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -2014,7 +2014,7 @@ sub create_links {
         }
 
         foreach my $key (keys %$ref) {
-            $self->{$key} = $ref->{$key};
+            $self->{$key} = $ref->{$key} unless defined $self->{$key};
         }
 
         $sth->finish;


### PR DESCRIPTION
Before this change, a foreign currency transaction without fx rate
could not be assigned an fx rate due to it being clobbered on update.
