### PR TITLE
Disable experimentalUseImportModule option for MiniCssExtractPlugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -251,6 +251,7 @@ var pluginsProd = [
 
     // Handle CSS
     new MiniCssExtractPlugin({
+        experimentalUseImportModule: false,
         filename: "css/[name].css",
         chunkFilename: "css/[id].css"
     }),


### PR DESCRIPTION
Newer version of mini-css-extract-plugin enables experimentalUseImportModule by default, which will be conflict with dojo-webpack-plugin.

Trying to disable this option explicitly, so behavior is consistent with older versions.

This PR will fix the upgrade problem in #6106. Backport of #6119