### PR TITLE
Ensure the order parameters end up in the URL's query string

### DIFF
--- a/UI/asset/begin_approval.html
+++ b/UI/asset/begin_approval.html
@@ -1,7 +1,7 @@
 \[% PROCESS "elements.html" -%]
 <body class="lsmb [% dojo_theme %]">
 <div id="assets">
-<form data-dojo-type="lsmb/Form" action="[% request.script %]" method="post">
+<form data-dojo-type="lsmb/Form" action="[% request.script %]" method="GET">
 <div class="listtop">[% text('New Asset Report Search') %]</div>
 <div class="inputrow" id="classrow"><div class="inputgroup" id="classgrp">
 [% PROCESS select element_data = {

--- a/UI/asset/begin_report.html
+++ b/UI/asset/begin_report.html
@@ -1,7 +1,7 @@
 [% PROCESS "elements.html" -%]
 <body class="lsmb [% dojo_theme %]">
 <div id="assets">
-<form data-dojo-type="lsmb/Form" action="[% request.script %]" method="post">
+<form data-dojo-type="lsmb/Form" action="[% request.script %]" method="GET">
 <div class="listtop">[% text('New Asset Report') %]</div>
 <div class="inputrow" id="classrow"><div class="inputgroup" id="classgrp">
 [% PROCESS select element_data = {

--- a/UI/asset/search_class.html
+++ b/UI/asset/search_class.html
@@ -2,7 +2,7 @@
 <body class="lsmb [% dojo_theme %]">
 <div id="assetclass-search">
 <div class="listtop">[% text('Search Asset Class') %]</div>
-<form data-dojo-type="lsmb/Form" action="[% request.script %]" method="post">
+<form data-dojo-type="lsmb/Form" action="[% request.script %]" method="GET">
 <div class="inputrow" id="labelrow">
 [% PROCESS input element_data = {
         type = "text"


### PR DESCRIPTION
When the URL doesn't have a query string already, add and empty one
at the end.

Fixes #6151
