### PR TITLE
Reduce the number preference tests run by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ Help on using this Makefile
                      (without rebuilding the inputs)
     - pod          : Builds POD documentation
     - pot          : Builds LedgerSMB.pot translation lexicon
-	- readme	   : Builds the README.md
+    - readme       : Builds the README.md
     - test         : Runs tests (TESTS='t/')
     - devtest      : Runs all tests including development tests (TESTS='t/ xt/')
     - pherkin      : Runs all BDD tests with 'pherkin' (instead of 'prove')
@@ -140,6 +140,7 @@ else
             --pgtap-dbname=lsmb_test --pgtap-username=postgres \
             --pgtap-psql=.circleci/psql-wrap \
             --Feature-tags=~@wip \
+            --Feature-tags=~@extended \
             $(TESTS)
 endif
 

--- a/cpanfile
+++ b/cpanfile
@@ -192,7 +192,7 @@ on 'develop' => sub {
     requires 'Test::Pod::Coverage';
     requires 'Test2::Harness';
     requires 'Test2::V0';
-    requires 'Test2::Plugin::Feature', '0.001111';
+    requires 'Test2::Plugin::Feature', '0.001112';
     requires 'Test2::Plugin::pgTAP';
     requires 'Text::Diff';
     requires 'Weasel', '0.29';

--- a/xt/66-cucumber/01-basic/preferences.feature
+++ b/xt/66-cucumber/01-basic/preferences.feature
@@ -24,6 +24,11 @@ Scenario: I change user preferences to the <selection> language
     | selection            | translation           | language |
     | American English     | American English      | Language |
     | Brazilian Portuguese | português - Brasil    | Idioma   |
+
+  @extended
+  Examples:
+  Non UTF8 accented characters are confirmed working
+    | selection            | translation           | language |
     | British English      | British English       | Language |
     | Canadian English     | Canadian English      | Language |
     | Canadian French      | français canadien     | Langue   |


### PR DESCRIPTION
For general quality assertion, it's not required to run all possible
combinations; just a set with good coverage and risk-reduction.

Introduces the 'extended' tag to run more extensive tests e.g. on
a release candidate for a new minor release.

This eliminates ca 10 minutes (out of 40) from the coverage tests.