### PR TITLE
Fix issues with balance sheet and income statement PDF templates

### DIFF
--- a/templates/demo/PNL.tex
+++ b/templates/demo/PNL.tex
@@ -31,8 +31,9 @@ releases. No explicit versioning was applied before 2021-01-04.
 
  -?>
 
-\documentclass[12pt]{article}
+\documentclass[10pt]{article}
 \usepackage{longtable}
+\usepackage[letterpaper,top=2cm,bottom=1.5cm,left=1.1cm,right=1.5cm]{geometry}
 \begin{document}
 \renewcommand\baselinestretch{1.2}\selectfont
 \begin{center}
@@ -93,7 +94,7 @@ releases. No explicit versioning was applied before 2021-01-04.
 -?>%
 %
 <?lsmb
-  j = 1;
+  j = 0;
   WHILE j < path_prefix_len ;
     '& ';
     j = j + 1;

--- a/templates/demo/balance_sheet.tex
+++ b/templates/demo/balance_sheet.tex
@@ -9,8 +9,7 @@ Template version numbers are explicitly not aligned across templates or
 releases. No explicit versioning was applied before 2021-01-04.
 
 -?>
-<?lsmb FILTER latex { format="$FORMAT(pdflatex)" };
-       INCLUDE "preamble-pdflatex.tex"; -?>
+<?lsmb FILTER latex { format="$FORMAT(pdflatex)" } -?>
 
 <?lsmb
   IF hierarchy == 'flat-hierarchy';
@@ -32,8 +31,9 @@ releases. No explicit versioning was applied before 2021-01-04.
 
  -?>
 
-\documentclass[12pt]{article}
+\documentclass[10pt]{article}
 \usepackage{longtable}
+\usepackage[letterpaper,top=2cm,bottom=1.5cm,left=1.1cm,right=1.5cm]{geometry}
 \begin{document}
 \renewcommand\baselinestretch{1.2}\selectfont
 \begin{center}
@@ -96,7 +96,7 @@ releases. No explicit versioning was applied before 2021-01-04.
   END;
 -?>%
 <?lsmb
-   j = 1;
+   j = 0;
    WHILE j < path_prefix_len ;
     '& ';
     j = j + 1;

--- a/templates/xedemo/PNL.tex
+++ b/templates/xedemo/PNL.tex
@@ -31,8 +31,9 @@ releases. No explicit versioning was applied before 2021-01-04.
 
  -?>
 
-\documentclass[12pt]{article}
+\documentclass[10pt]{article}
 \usepackage{longtable}
+\usepackage[letterpaper,top=2cm,bottom=1.5cm,left=1.1cm,right=1.5cm]{geometry}
 \begin{document}
 \renewcommand\baselinestretch{1.2}\selectfont
 \begin{center}
@@ -93,7 +94,7 @@ releases. No explicit versioning was applied before 2021-01-04.
 -?>%
 %
 <?lsmb
-  j = 1;
+  j = 0;
   WHILE j < path_prefix_len ;
     '& ';
     j = j + 1;

--- a/templates/xedemo/balance_sheet.tex
+++ b/templates/xedemo/balance_sheet.tex
@@ -9,8 +9,7 @@ Template version numbers are explicitly not aligned across templates or
 releases. No explicit versioning was applied before 2021-01-04.
 
 -?>
-<?lsmb FILTER latex { format="$FORMAT(xelatex)" };
-       INCLUDE "preamble-xelatex.tex" -?>
+<?lsmb FILTER latex { format="$FORMAT(xelatex)" } -?>
 
 <?lsmb
   IF hierarchy == 'flat-hierarchy';
@@ -32,8 +31,9 @@ releases. No explicit versioning was applied before 2021-01-04.
 
  -?>
 
-\documentclass[12pt]{article}
+\documentclass[10pt]{article}
 \usepackage{longtable}
+\usepackage[letterpaper,top=2cm,bottom=1.5cm,left=1.1cm,right=1.5cm]{geometry}
 \begin{document}
 \renewcommand\baselinestretch{1.2}\selectfont
 \begin{center}
@@ -96,7 +96,7 @@ releases. No explicit versioning was applied before 2021-01-04.
   END;
 -?>%
 <?lsmb
-   j = 1;
+   j = 0;
    WHILE j < path_prefix_len ;
     '& ';
     j = j + 1;


### PR DESCRIPTION
 * Overall total shifts by 1 column to the right
 * Huge font presents little information on the reports
 * Large (book) margins shift report content off the right of  the report

Balance sheet specific:
 * Solve an error of duplicate `\documentclass`
