### PR TITLE
Remove version comparisons from SL30 migration

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -108,7 +108,6 @@ requires 'Template::Provider';
 requires 'Text::CSV';
 requires 'Text::Markdown';
 requires 'URI::Escape';
-requires 'Version::Compare';
 requires 'Workflow::Context', '1.57';
 requires 'Workflow::Exception', '1.57';
 requires 'Workflow::Factory', '1.57';

--- a/lib/LedgerSMB/Database/Upgrade.pm
+++ b/lib/LedgerSMB/Database/Upgrade.pm
@@ -20,7 +20,6 @@ use File::Temp;
 use List::Util qw( first );
 use Scope::Guard qw( guard );
 use Template;
-use Version::Compare;
 
 use Moose;
 use namespace::autoclean;
@@ -277,7 +276,6 @@ sub run_upgrade_script {
     my $tempfile = File::Temp->new();
     $engine->process("$template.sql",
                      {
-                         VERSION_COMPARE => \&Version::Compare::version_compare,
                          %$vars
                      },
                      $tempfile)

--- a/sql/upgrade/sl3.0.sql
+++ b/sql/upgrade/sl3.0.sql
@@ -912,9 +912,6 @@ insert into ar
         id, invnumber, transdate, crdate, taxincluded,
         amount_bc, netamount_bc,
         amount_tc, netamount_tc,
-[% IF VERSION_COMPARE(lsmbversion,'1.6') < 0; %]
-        paid, datepaid,
-[% END; %]
         duedate, invoice, ordnumber, curr, notes, quonumber, intnotes,
         shipvia, language_code, ponumber, shippingpoint,
         on_hold, approved, reverse, terms, description)
@@ -924,9 +921,6 @@ SELECT
         ar.id, invnumber, transdate, transdate, ar.taxincluded, amount, netamount,
         CASE WHEN exchangerate IS NOT NULL THEN amount/exchangerate ELSE 0 END,
         CASE WHEN exchangerate IS NOT NULL THEN netamount/exchangerate ELSE 0 END,
-[% IF VERSION_COMPARE(lsmbversion,'1.6') < 0; %]
-        paid, datepaid,
-[% END; %]
         duedate, invoice, ordnumber, ar.curr, ar.notes, quonumber,
         intnotes,
         shipvia, ar.language_code, ponumber, shippingpoint,
@@ -942,9 +936,6 @@ insert into ap
 (entity_credit_account, person_id,
         id, invnumber, transdate, crdate, taxincluded, amount_bc, netamount_bc,
         amount_tc, netamount_tc,
-[% IF VERSION_COMPARE(lsmbversion,'1.6') < 0; %]
-        paid, datepaid,
-[% END; %]
         duedate, invoice, ordnumber, curr, notes, quonumber, intnotes,
         shipvia, language_code, ponumber, shippingpoint,
         on_hold, approved, reverse, terms, description)
@@ -955,9 +946,6 @@ SELECT
         ap.id, invnumber, transdate, transdate, ap.taxincluded, amount, netamount,
         CASE WHEN exchangerate IS NOT NULL THEN amount/exchangerate ELSE 0 END,
         CASE WHEN exchangerate IS NOT NULL THEN netamount/exchangerate ELSE 0 END,
-[% IF VERSION_COMPARE(lsmbversion,'1.6') < 0; %]
-        paid, datepaid,
-[% END; %]
         duedate, invoice, ordnumber, ap.curr, ap.notes, quonumber,
         intnotes,
         shipvia, ap.language_code, ponumber, shippingpoint,


### PR DESCRIPTION
The version comparison was a difference between 'current' and 1.6; the latter being
EOL these days, meaning that the version comparison has a constant (negative) outcome.

There's another reason why version comparisons are a bad idea: the migration target
schema for the migration should be constant. That is, it should be a specific version
of the schema determined by a tag in the 'sql/changes/LOADORDER' file. This tag returns
independent of the exact current LedgerSMB version, a constant database schema version.
