### PR TITLE
Move assignment of permissions from  function modules to Roles

### DIFF
--- a/sql/modules/Employee.sql
+++ b/sql/modules/Employee.sql
@@ -76,8 +76,6 @@ create view employees as
     JOIN entity_employee ee USING (entity_id)
     LEFT JOIN salutation s ON (p.salutation_id = s.id);
 
-GRANT select ON employees TO public;
-
 DROP TYPE IF EXISTS employee_result CASCADE;
 
 CREATE TYPE employee_result AS (

--- a/sql/modules/Reconciliation.sql
+++ b/sql/modules/Reconciliation.sql
@@ -123,11 +123,6 @@ $$
     RETURNING TRUE;
 $$ LANGUAGE SQL SECURITY DEFINER;
 
--- Granting execute permission to public because everyone has an ability to
--- delete their own reconciliation reports provided they have not been
--- submitted.  --CT
-GRANT EXECUTE ON FUNCTION reconciliation__delete_my_report(in_report_id int)
-TO PUBLIC;
 
 COMMENT ON FUNCTION reconciliation__delete_my_report(in_report_id int) IS
 $$This function allows a user to delete his or her own unsubmitted, unapproved

--- a/sql/modules/Roles.sql
+++ b/sql/modules/Roles.sql
@@ -412,6 +412,8 @@ SELECT lsmb__grant_perms('employees_manage', 'payroll_wage', 'ALL');
 SELECT lsmb__grant_perms('employees_manage', 'payroll_deduction', 'ALL');
 SELECT lsmb__grant_menu('employees_manage', 48, 'allow');
 SELECT lsmb__grant_menu('employees_manage', 49, 'allow');
+GRANT select ON employees TO public;
+
 
 SELECT lsmb__create_role('contact_edit');
 SELECT lsmb__grant_role('contact_edit', 'contact_read');
@@ -788,6 +790,11 @@ SELECT lsmb__grant_menu('reconciliation_approve', 44, 'allow');
 SELECT lsmb__grant_menu('reconciliation_approve', 211, 'allow');
 SELECT lsmb__grant_exec('reconciliation_approve', 'reconciliation__reject_set(in_report_id int)');
 SELECT lsmb__grant_exec('reconciliation_approve', 'reconciliation__delete_unapproved(in_report_id int)');
+-- Granting execute permission to public because everyone has an ability to
+-- delete their own reconciliation reports provided they have not been
+-- submitted.  --CT
+GRANT EXECUTE ON FUNCTION reconciliation__delete_my_report(in_report_id int)
+TO PUBLIC;
 
 SELECT lsmb__create_role('reconciliation_all');
 SELECT lsmb__grant_role('reconciliation_all', 'reconciliation_approve');


### PR DESCRIPTION
The Roles.sql module is meant explicitly to *assign* rights to
roles. (Revoking *may* be part of the function declaration,
assignment must be done centrally to prevent scattered
declarations and loss of insight/oversight.)
