### PR TITLE
Update NodeJS to 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           # Version Spec of the version to use.  Examples: 12.x, 10.15.1, >=10.15.0
-          node-version: 12.x
+          node-version: 16
 
       - name: Cache node modules
         uses: actions/cache@v2


### PR DESCRIPTION
1.9 was upgraded to 16, but 1.8 and 1.7 share the same release environment and need to work on 16 too. We should be certain about it and test.
