### PR TITLE
Reconciliation fix 1.9

### DIFF
--- a/sql/modules/Reconciliation.sql
+++ b/sql/modules/Reconciliation.sql
@@ -232,11 +232,15 @@ $$Marks the report approved and marks all cleared transactions in it cleared.$$;
 
 
 -- XXX Badly named, rename for 1.4.  --CT
-CREATE OR REPLACE FUNCTION reconciliation__new_report_id
-(in_chart_id int, in_total numeric, in_end_date date, in_recon_fx bool) returns INT as $$
+CREATE OR REPLACE FUNCTION reconciliation__new_report_id(
+    in_chart_id int,
+    in_total numeric,
+    in_end_date date,
+    in_recon_fx bool
+) returns INT as $$
 
     INSERT INTO cr_report(chart_id, their_total, end_date, recon_fx)
-    values ($1, $2, $3, $4);
+    values (in_chart_id, in_total, in_end_date, in_recon_fx);
     SELECT currval('cr_report_id_seq')::int;
 
 $$ language 'sql';
@@ -257,7 +261,6 @@ CREATE OR REPLACE FUNCTION reconciliation__add_entry(
         in_account int;
         la RECORD;
         t_errorcode INT;
-        our_value NUMERIC;
         lid INT;
         in_count int;
         t_scn TEXT;
@@ -300,7 +303,7 @@ CREATE OR REPLACE FUNCTION reconciliation__add_entry(
                                 in_type)
                         RETURNING id INTO lid;
                 ELSIF in_count = 1 THEN
-                        SELECT id INTO lid
+                        SELECT id INTO lid FROM cr_report_line
                         WHERE t_scn = scn AND report_id = in_report_id
                                 AND their_balance = 0 AND post_date = in_date;
                         UPDATE cr_report_line
@@ -310,7 +313,7 @@ CREATE OR REPLACE FUNCTION reconciliation__add_entry(
                 ELSE
                         SELECT count(*) INTO in_count FROM cr_report_line
                         WHERE t_scn ilike scn AND report_id = in_report_id
-                                AND our_value = t_amount and their_balance = 0
+                                AND our_balance = t_amount and their_balance = 0
                                 AND post_date = in_date;
 
                         IF in_count = 0 THEN -- no match among many of values
@@ -330,7 +333,7 @@ CREATE OR REPLACE FUNCTION reconciliation__add_entry(
                         ELSIF in_count = 1 THEN -- EXECT MATCH
                                 SELECT id INTO lid FROM cr_report_line
                                 WHERE t_scn = scn AND report_id = in_report_id
-                                        AND our_value = t_amount
+                                        AND our_balance = t_amount
                                         AND their_balance = 0
                                         AND post_date = in_date;
                                 UPDATE cr_report_line
@@ -342,7 +345,7 @@ CREATE OR REPLACE FUNCTION reconciliation__add_entry(
                         ELSE -- More than one match
                                 SELECT id INTO lid FROM cr_report_line
                                 WHERE t_scn ilike scn AND report_id = in_report_id
-                                        AND our_value = t_amount
+                                        AND our_balance = t_amount
                                         AND post_date = in_date
                                 ORDER BY id ASC limit 1;
 
@@ -370,7 +373,7 @@ CREATE OR REPLACE FUNCTION reconciliation__add_entry(
                         in_type)
                         RETURNING id INTO lid;
                 ELSIF in_count = 1 THEN -- perfect match
-                        SELECT id INTO lid
+                        SELECT id INTO lid FROM cr_report_line
                         WHERE report_id = in_report_id
                                 AND our_balance = t_amount
                                 AND their_balance = 0
@@ -424,8 +427,10 @@ DROP FUNCTION IF EXISTS
                                        in_report_id integer,
                                        in_their_total numeric);
 CREATE OR REPLACE FUNCTION reconciliation__pending_transactions(
-                      in_report_id integer, in_their_total numeric)
-  RETURNS integer AS
+    in_report_id integer,
+    in_their_total numeric
+)
+RETURNS integer AS
 $$
 
     DECLARE
@@ -434,23 +439,52 @@ $$
         t_chart_id       integer;
         t_end_date       date;
         t_report_line_id integer;
+        t_uid int;
     BEGIN
         SELECT end_date, recon_fx, chart_id
          INTO t_end_date, t_recon_fx, t_chart_id
          FROM cr_report
         WHERE id = in_report_id;
 
+        SELECT entity_id INTO t_uid
+        FROM users
+        WHERE username = CURRENT_USER;
+
         /*
 
-        Approach:
+        Approach in 4 steps:
          1. Identify lines to be added *somewhere*
+            That is: all lines before the reconcilation date which
+            are not yet part of any other reconciliation; lines come
+            from two sources: payment transactions and others (the second
+            are usually GL transactions)
          2. Identify lines part of a payment
-            (always added as new lines: payments are natural groupings)
-         3. Identify non-payment lines to be added to existing
-            recon lines due to the same source system reference
-         4. Remaining lines added as new lines, either by source or
-            as individual ones.
-
+            Lines in this category are grouped by payment and added as a
+            single reconciliation line, irrespective of the number of lines
+            identified, *unless* lines have explicitly different 'Source'
+            values - which is weird and unexpected, but possible when the
+            user sets a specific value on each payment line separately - in
+            which case, the lines in the payment will be grouped by the value
+            of the Source field
+         3. Identify non-payment lines that adjust payments
+            When a payment has been entered wrongly or the bank has withheld
+            transaction fees, the payment of the invoice does not correspond
+            to the actual amount on the bank statement - meaning adjustment
+            is required; GL transactions can be used to enter adjustments by
+            listing the same date and the same source as used for the payment
+            transaction. The lines in this category will be added as an
+            adjustment to the existing (coming from the payment) reconciliation
+            line
+         4. Remaining lines added as new lines, either by source (if they
+            have one) or as individual ones.
+            Note that the lines in this category - by logical reasoning - can
+            **not** be payments lines, because those were handled in step 2.
+            Also note that it's not an option to lump all lines without a source
+            into a single line, because that way all lines without a Source
+            would end up as a single reconciliation line, while unknowing users
+            are expected to post GL lines without Source numbers; to help these
+            users, we present lines from non-payment (GL) transactions as
+            individual lines
          */
 
         -- step 1: identify lines to be added somehow
@@ -474,19 +508,17 @@ $$
            select payment_id, array_agg(ac.entry_id) as entries,
                   sum(case when t_recon_fx then amount_tc
                            else amount_bc end) as our_balance,
-                  payment_date
+                  payment_date, source
              from payment_links pl
              join acc_trans ac on pl.entry_id = ac.entry_id
              join payment p on p.id = pl.payment_id
             where ac.chart_id = t_chart_id
                   and pl.entry_id in (select entry_id from lines_to_be_added)
-           group by payment_id, payment_date
+           group by payment_id, payment_date, source
         loop
-           insert into cr_report_line (report_id, their_balance,
+            insert into cr_report_line (report_id, scn, their_balance,
                                        our_balance, post_date, "user")
-              values (in_report_id, 0, t_row.our_balance, t_row.payment_date,
-                      (select entity_id from users
-                        where username = CURRENT_USER))
+            values (in_report_id, t_row.source, 0, t_row.our_balance, t_row.payment_date, t_uid)
            returning id into t_report_line_id;
 
            update lines_to_be_added
@@ -523,8 +555,7 @@ $$
 
         -- step 4: add new lines not part of payments
         for t_row in
-           select source, case when source is null then entry_id
-                               else null end, array_agg(entry_id) as entries,
+           select source, array_agg(entry_id) as entries,
                   sum(case when t_recon_fx then amount_tc
                            else amount_bc end) as our_balance,
                   transdate
@@ -537,10 +568,8 @@ $$
         loop
            insert into cr_report_line (report_id, scn, their_balance,
                                       our_balance, post_date, "user")
-              values (in_report_id, t_row.source, 0,
-                      t_row.our_balance, t_row.transdate,
-                      (select entity_id from users
-                        where username = CURRENT_USER))
+            values (in_report_id, t_row.source, 0,
+                      t_row.our_balance, t_row.transdate, t_uid)
            returning id into t_report_line_id;
 
            update lines_to_be_added
@@ -681,9 +710,11 @@ account.  For asset and expense accounts this is the debit balance, for others
 this is the credit balance.$$;
 
 CREATE OR REPLACE VIEW recon_payee AS
- SELECT n.name AS payee, rr.id, rr.report_id, rr.scn, rr.their_balance, rr.our_balance, rr.errorcode, rr."user", rr.clear_time, rr.insert_time, rr.trans_type, rr.post_date, rr.ledger_id, ac.voucher_id, rr.overlook, rr.cleared
+ SELECT DISTINCT ON (rr.id)
+   n.name AS payee, rr.id, rr.report_id, rr.scn, rr.their_balance, rr.our_balance, rr.errorcode, rr."user", rr.clear_time, rr.insert_time, rr.trans_type, rr.post_date, rr.ledger_id, ac.voucher_id, rr.overlook, rr.cleared
    FROM cr_report_line rr
-   LEFT JOIN acc_trans ac ON rr.ledger_id = ac.entry_id
+   LEFT JOIN cr_report_line_links rll ON rr.id = rll.report_line_id
+   LEFT JOIN acc_trans ac ON rll.entry_id = ac.entry_id
    LEFT JOIN gl ON ac.trans_id = gl.id
    LEFT JOIN (( SELECT ap.id, e.name
    FROM ap

--- a/sql/upgrade/sl3.0.sql
+++ b/sql/upgrade/sl3.0.sql
@@ -256,7 +256,7 @@ CREATE OR REPLACE FUNCTION reconciliation__add_entry(
                                 in_type)
                         RETURNING id INTO lid;
                 ELSIF in_count = 1 THEN
-                        SELECT id INTO lid
+                        SELECT id INTO lid FROM cr_report_line
                         WHERE t_scn = scn AND report_id = in_report_id
                                 AND their_balance = 0 AND post_date = in_date;
                         UPDATE cr_report_line
@@ -326,7 +326,7 @@ CREATE OR REPLACE FUNCTION reconciliation__add_entry(
                         in_type)
                         RETURNING id INTO lid;
                 ELSIF in_count = 1 THEN -- perfect match
-                        SELECT id INTO lid
+                        SELECT id INTO lid FROM cr_report_line
                         WHERE report_id = in_report_id
                                 AND our_balance = t_amount
                                 AND their_balance = 0

--- a/xt/42-reconciliation.pg
+++ b/xt/42-reconciliation.pg
@@ -99,7 +99,7 @@ BEGIN;
                       JOIN cr_report_line_links rll on ac.entry_id = rll.entry_id
                       JOIN cr_report_line rl ON rll.report_line_id = rl.id
                       WHERE report_id = currval('cr_report_id_seq')::int;
-    SELECT results_eq('test',Array[12],'Correct number of transactions 1');
+    SELECT results_eq('test',Array[11],'Correct number of transactions 1');
     DEALLOCATE test;
 
     PREPARE test AS SELECT count(*)::int
@@ -140,7 +140,9 @@ BEGIN;
     SELECT results_eq('test',ARRAY[2],'1 Transactions closed');
     DEALLOCATE test;
 
-    -- all items on account -11112 are part of the same payment
+    -- all items on account -11112 are part of the same payment AR payment,
+    --   except a few GL items, some of which have the same source and transdate == payment_date
+    --   and a few others which have the same source but transdate != payment_date
     PREPARE test AS SELECT reconciliation__new_report_id(test_get_account_id('-11112'), 100, now()::date, false) > 0;
     SELECT results_eq('test',ARRAY[true],'1 Create Recon Report');
     DEALLOCATE test;
@@ -149,37 +151,37 @@ BEGIN;
     SELECT results_eq('test',ARRAY[true],'1 Pending Transactions Ran');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT count(*)::int
-                      FROM cr_report_line
+    PREPARE test AS SELECT count(distinct ac.trans_id)::int
+                      FROM acc_trans ac
+                      JOIN cr_report_line_links rll on ac.entry_id = rll.entry_id
+                      JOIN cr_report_line rl ON rll.report_line_id = rl.id
                       WHERE report_id = currval('cr_report_id_seq')::int;
-    -- 1 payment
-    SELECT results_eq('test',ARRAY[1],'Correct number of transactions 2');
+    SELECT results_eq('test',ARRAY[11],'Correct number of transactions 2');
     DEALLOCATE test;
+
+
+    update gl set approved = true where id = -214;
+    update acc_trans set approved = true
+     where trans_id = -214
+           and chart_id = test_get_account_id('-11112');
 
     PREPARE test AS SELECT reconciliation__pending_transactions(currval('cr_report_id_seq')::int, 110);
     SELECT results_eq('test',$$ SELECT id+3 FROM test_parameters $$,'1 Pending Transactions Ran');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT count(*)::int
-                      FROM cr_report_line
+    PREPARE test AS SELECT count(distinct ac.trans_id)::int
+                      FROM acc_trans ac
+                      JOIN cr_report_line_links rll on ac.entry_id = rll.entry_id
+                      JOIN cr_report_line rl ON rll.report_line_id = rl.id
                       WHERE report_id = currval('cr_report_id_seq')::int;
-    -- 1 payment
-    SELECT results_eq('test',ARRAY[1],'Correct number of transactions 3');
-    DEALLOCATE test;
-
-    PREPARE test AS SELECT count(*)::int
-                      FROM cr_report_line
-                      WHERE scn like '% gl %'
-                      AND report_id = currval('cr_report_id_seq')::int;
-    -- part of a payment means source doesn't matter in the gl lines
-    SELECT results_eq('test',ARRAY[0],'1 Correct number of GL groups');
+    SELECT results_eq('test',ARRAY[12],'Correct number of transactions 3');
     DEALLOCATE test;
 
     PREPARE test AS SELECT count(*)::int
                       FROM cr_report_line
                       WHERE report_id = currval('cr_report_id_seq')::int;
-    -- 1 payment
-    SELECT results_eq('test',ARRAY[1],'1 Correct number of report lines');
+    -- 1 payment, with GL adjustment and two GL lines with the same source (but different date) == 2
+    SELECT results_eq('test',ARRAY[2],'1 Correct number of report lines');
     DEALLOCATE test;
 
     PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int, '{}');
@@ -199,7 +201,7 @@ BEGIN;
                       JOIN account ON (acc_trans.chart_id = account.id)
                       WHERE accno = '-11112'
                       AND NOT cleared;
-    SELECT results_eq('test',ARRAY[14],'1 Transactions open');
+    SELECT results_eq('test',ARRAY[13],'1 Transactions open');
     DEALLOCATE test;
 
     PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11112')) = -10;
@@ -214,11 +216,20 @@ BEGIN;
     SELECT results_eq('test',$$ SELECT id+4 FROM test_parameters $$,'1 Pending Transactions Ran');
     DEALLOCATE test;
 
+    -- 1 payment, with GL adjustment and two GL lines with the same source (but different date) == 2
     PREPARE test AS SELECT count(*)::int
                       FROM cr_report_line
                       WHERE report_id = currval('cr_report_id_seq')::int;
+    SELECT results_eq('test',ARRAY[2],'Correct number of report lines 4');
+    DEALLOCATE test;
+
+    PREPARE test AS SELECT count(distinct ac.trans_id)::int
+                      FROM acc_trans ac
+                      JOIN cr_report_line_links rll on ac.entry_id = rll.entry_id
+                      JOIN cr_report_line rl ON rll.report_line_id = rl.id
+                      WHERE report_id = currval('cr_report_id_seq')::int;
     -- 1 payment
-    SELECT results_eq('test',ARRAY[1],'Correct number of transactions 4');
+    SELECT results_eq('test',ARRAY[12],'Correct number of transactions 4');
     DEALLOCATE test;
 
     PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int, (select as_array(id::int)
@@ -250,7 +261,7 @@ BEGIN;
                       JOIN account a ON (acc_trans.chart_id = a.id)
                       WHERE accno = '-11112'
                       AND NOT cleared;
-    SELECT results_eq('test',ARRAY[2],'Transactions closed');
+    SELECT results_eq('test',ARRAY[1],'Transactions closed');
     DEALLOCATE test;
 
     PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11112'));

--- a/xt/data/42-pg/Reconciliation.sql
+++ b/xt/data/42-pg/Reconciliation.sql
@@ -1,11 +1,37 @@
 -- To run from other transaction test scripts!
 
+/*
+
+Summarizing what's happening below:
+
+ 1. Create 2 asset accounts
+    Test Act 1 -- has no payments associated
+      meaning: all lines will be aggregated by source, or lacking
+      a source, will be listed individually
+    Test Act 2 -- has a payment associated
+      meaning: all lines will be aggregated into a single payment line,
+      irrespective of the date on the journal lines (which *should*
+      all be the same as the payment line, but in this test are not)
+ 2. Create an entity (to be used as counterparty)
+ 3. Create two credit accounts for that counterparty
+    Credit accounts can issue or receive invoices
+ 4. Create 8 receivables, of 10 XTS (a test currency) each,
+    4 created on 1000-01-01 and another 4 created on 1000-01-03
+ 5. Create a payment for use on 'Test Act 2'
+ 6. Create 7 GL transactions, of which 2 on 1000-01-01 and 5 on 1000-01-03
+    5 approved, 2 unapproved
+ 7. Add journal lines with specific source identifiers (simulating payments)
+    These journal lines are the real test cases, as they are the
+    "pending transactions" inputs.
+
+*/
+
 INSERT INTO account(id, accno, description, category, heading, contra)
 values (-200, '-11111', 'Test Act 1', 'A',
         (select id from account_heading WHERE accno  = '000000000000000000000'), false);
 
 INSERT INTO account(id, accno, description, category, heading, contra)
-values (-201, '-11112', 'Test Act 1', 'A',
+values (-201, '-11112', 'Test Act 2', 'A',
         (select id from account_heading WHERE accno  = '000000000000000000000'), false);
 
 INSERT INTO entity (id, control_code, name, entity_class, country_id)
@@ -59,73 +85,99 @@ values (-214, 'gl trans, unapproved lines', '1000-01-03', false);
 
 CREATE OR REPLACE FUNCTION test_get_account_id(in_accno text) returns int as $$ SELECT id FROM account WHERE accno = $1; $$ language sql;
 
+
+-- Test Act 1; 1000-01-01; source '1'
 INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
 values (-200, test_get_account_id('-11111'), '1000-01-01', -10, 'XTS', -10, '1');
-INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source, cleared, approved)
-values (-200, test_get_account_id('-11111'), '1000-01-01', -10, 'XTS', -10, '1', true, false);
-INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source, cleared, approved)
-values (-200, test_get_account_id('-11112'), '1000-01-01', 10, 'XTS', 10, '1', true, false);
-
-INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
-values (-200, test_get_account_id('-11112'), '1000-01-01', 10, 'XTS', 10, '1');
-INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
-values (-201, test_get_account_id('-11111'), '1000-01-03', -10, 'XTS', -10, '1');
-INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
-values (-201, test_get_account_id('-11112'), '1000-01-03', 10, 'XTS', 10, '1');
-INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
-values (-202, test_get_account_id('-11111'), '1000-01-01', -10, 'XTS', -10,'t gl 1');
-INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
-values (-202, test_get_account_id('-11112'), '1000-01-01', 10, 'XTS', 10,'t gl 1');
-INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
-values (-203, test_get_account_id('-11111'), '1000-01-01', -10, 'XTS', -10,'t gl 1');
-INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
-values (-203, test_get_account_id('-11112'), '1000-01-01', 10, 'XTS', 10,'t gl 1');
 INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
 values (-204, test_get_account_id('-11111'), '1000-01-01', -10, 'XTS', -10, '1');
 INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
-values (-204, test_get_account_id('-11112'), '1000-01-01', 10, 'XTS', 10, '1');
-INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
-values (-205, test_get_account_id('-11111'), '1000-01-03', -10, 'XTS', -10, '1');
-INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
-values (-205, test_get_account_id('-11112'), '1000-01-03', 10, 'XTS', 10, '1');
-INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
 values (-206, test_get_account_id('-11111'), '1000-01-01', -10, 'XTS', -10, '1');
+-- not approved, so not included
+INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source, cleared, approved)
+values (-200, test_get_account_id('-11111'), '1000-01-01', -10, 'XTS', -10, '1', true, false);
+
+-- Test Act 1; 1000-01-01; source 't gl 1'
 INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
-values (-206, test_get_account_id('-11112'), '1000-01-01', 10, 'XTS', 10, '1');
+values (-202, test_get_account_id('-11111'), '1000-01-01', -10, 'XTS', -10,'t gl 1');
+INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
+values (-203, test_get_account_id('-11111'), '1000-01-01', -10, 'XTS', -10,'t gl 1');
+
+-- Test Act 1; 1000-01-01; source '2'
+INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
+values (-208, test_get_account_id('-11111'), '1000-01-01', -10, 'XTS', -10,'2');
+
+
+-- Test Act 1; 1000-01-03; source '1' (both AR and GL lines)
+INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
+values (-201, test_get_account_id('-11111'), '1000-01-03', -10, 'XTS', -10, '1');
 INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
 values (-207, test_get_account_id('-11111'), '1000-01-03', -10, 'XTS', -10, '1');
 INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
-values (-207, test_get_account_id('-11112'), '1000-01-03', 10, 'XTS', 10, '1');
+values (-210, test_get_account_id('-11111'), '1000-01-03', -10, 'XTS', -10, '1');
+INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source, cleared)
+values (-213, test_get_account_id('-11111'), '1000-01-03', -10, 'XTS', -10, '1', false);
+-- Don't include cleared or unapproved transactions
+INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source, cleared)
+values (-212, test_get_account_id('-11111'), '1000-01-03', -10, 'XTS', -10, '1', true);
+INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source, approved)
+values (-214, test_get_account_id('-11111'), '1000-01-03', -10, 'XTS', -10, '1', false);
+
+
+-- Test Act 1; 1000-01-03; source 't gl 1'
 INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
-values (-208, test_get_account_id('-11111'), '1000-01-01', -10, 'XTS', -10,'2');
-INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
-values (-208, test_get_account_id('-11112'), '1000-01-01', 10, 'XTS', 10,'2');
+values (-211, test_get_account_id('-11111'), '1000-01-03', -10, 'XTS', -10,'t gl 1');
+
+-- Test Act 1; 1000-01-03; source '2'
 INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
 values (-209, test_get_account_id('-11111'), '1000-01-03', -10, 'XTS', -10, '2');
+
+
+-- Test Act 2; presented as a single line,
+--   because all part of the same payment (AR)
+--   or with the same source and transdate==payment_date (GL)
 INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
-values (-209, test_get_account_id('-11112'), '1000-01-03', 10, 'XTS', 10,'2');
+values (-200, test_get_account_id('-11112'), '1000-01-01', 10, 'XTS', 10, '1');
 INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
-values (-210, test_get_account_id('-11111'), '1000-01-03', -10, 'XTS', -10, '1');
+values (-201, test_get_account_id('-11112'), '1000-01-03', 10, 'XTS', 10, '1');
+INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
+values (-204, test_get_account_id('-11112'), '1000-01-01', 10, 'XTS', 10, '1');
+-- id -206 intentionally left out to create a different number of rows in accounts -11111 and -11112
+INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
+values (-208, test_get_account_id('-11112'), '1000-01-01', 10, 'XTS', 10,'1');
+INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
+values (-205, test_get_account_id('-11112'), '1000-01-03', 10, 'XTS', 10, '1');
+INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
+values (-207, test_get_account_id('-11112'), '1000-01-03', 10, 'XTS', 10, '1');
+INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
+values (-209, test_get_account_id('-11112'), '1000-01-03', 10, 'XTS', 10,'1');
 INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
 values (-210, test_get_account_id('-11112'), '1000-01-03', 10, 'XTS', 10, '1');
 INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
-values (-211, test_get_account_id('-11111'), '1000-01-03', -10, 'XTS', -10,'t gl 1');
+values (-211, test_get_account_id('-11112'), '1000-01-03', 10, 'XTS', 10,'1');
 INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
-values (-211, test_get_account_id('-11112'), '1000-01-03', 10, 'XTS', 10,'t gl 1');
-INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source, cleared)
-values (-212, test_get_account_id('-11111'), '1000-01-03', -10, 'XTS', -10, '1', true);
+values (-213, test_get_account_id('-11112'), '1000-01-03', 10, 'XTS', 10, '1');
+-- Don't include GL transactions with the same source, but with a transdate unequal to the payment_date
+INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
+values (-202, test_get_account_id('-11112'), '1000-01-01', 10, 'XTS', 10,'1');
+INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source)
+values (-203, test_get_account_id('-11112'), '1000-01-01', 10, 'XTS', 10,'1');
+
+
+-- Don't include cleared or unapproved transactions
+INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source, cleared, approved)
+values (-200, test_get_account_id('-11112'), '1000-01-01', 10, 'XTS', 10, '1', true, false);
 INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source, cleared)
 values (-212, test_get_account_id('-11112'), '1000-01-03', 10, 'XTS', 10, '1', true);
-INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source, cleared)
-values (-213, test_get_account_id('-11111'), '1000-01-03', -10, 'XTS', -10, '1', false);
-INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source, cleared)
-values (-213, test_get_account_id('-11112'), '1000-01-03', 10, 'XTS', 10, '1', false);
-INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source, approved)
-values (-214, test_get_account_id('-11111'), '1000-01-03', -10, 'XTS', -10, '1', false);
 INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source, approved)
 values (-214, test_get_account_id('-11112'), '1000-01-03', 10, 'XTS', 10, '1', false);
 
+
+
 insert into payment_links (payment_id, entry_id, type)
 select -201, entry_id, 1
-  from acc_trans where trans_id < 0 and chart_id = test_get_account_id('-11112');
+  from acc_trans
+ where trans_id < 0
+       and chart_id = test_get_account_id('-11112')
+       and exists (select 1 from ar where ar.id = acc_trans.trans_id);
 


### PR DESCRIPTION
Summarizing:

* Use named arguments instead of positional
Clean up for better readability

* Fix missing FROM clause in reconciliation
Fix using our_value as column name, our_value doesn't exist in cr_report_line

* Fix payment source doesn't correctly save to scn of cr_report_line

* Fix description always empty in reconciliation
entry_id from acc_trans is not saved in the cr_report_line table. It is saved in cr_report_line_links.

* Fix ID duplication on the payee view because of the cr_report_line_links

* Fix missing FROM caluse in sl3.0

* Undo change adding payments with the wrong granularity to the recon

And add a lot of documentation to (hopefully) explain why this code
looks the way it does.

* Document reconciliation test cases and re-order for clarity

Group the journal lines and add comments for clarity on the actual tests
that are intended to be executed.

* Add and adapt tests

Add test to check adjustment GL lines being added to payments given the same source and date
Adjust tests to incorporate Source as a splitting criterion *within* a payment
Adjust number of lines in test against account -11112 better distinguish test cases

Co-authored-by: Erik Huelsmann <ehuels@gmail.com>