### PR TITLE
Add the separator on date fields earlier

### DIFF
--- a/UI/js-src/lsmb/DateTextBox.js
+++ b/UI/js-src/lsmb/DateTextBox.js
@@ -90,7 +90,7 @@ define([
             /* eslint no-cond-assign: 0 */
             on(
                 this.domNode,
-                "keypress",
+                "keyup",
                 lang.hitch(this, function (e) {
                     let value = domAttr.get(e.target, "value");
 


### PR DESCRIPTION
That is to say, add the separator *after* the previous block completes, instead of
adding it before the new block starts (block being year/month/day group of digits),
because there's no indication that the user should not be entering the separator.

Closes #6121
