### PR TITLE
Fix end date doesn't bind correctly

### DIFF
--- a/UI/Contact/divs/credit.html
+++ b/UI/Contact/divs/credit.html
@@ -122,7 +122,7 @@ PROCESS dynatable
                         label = text('End Date'),
                         name = "enddate",
                         class = "date",
-                        value = credit.enddate,
+                        value = credit_act.enddate,
                         type = "text",
                         size = "12",
                         maxlength = "10"


### PR DESCRIPTION
Might be because of the typo, UI enddate field is bind with "credit.enddate" where "credit" object doesn't exist. The correct object name is "credit_act".