### PR TITLE
Fix credit limit remaining calculation issue

### DIFF
--- a/sql/modules/arap.sql
+++ b/sql/modules/arap.sql
@@ -154,11 +154,11 @@ $$
              1
          ELSE
              (SELECT coalesce(rate, 'NaN'::numeric) AS rate
-                FROM exchangerate_default
-               WHERE rate_type = 1
-                 AND current_date BETWEEN valid_from AND valid_to
-                 AND curr = (SELECT curr FROM entity_credit_account
-                              WHERE id = in_eca))
+                FROM exchangerate__get(
+                      (SELECT curr FROM entity_credit_account
+                      WHERE id = in_eca),
+                      1,
+                      current_date))
          END AS used_tc
    FROM (
      SELECT sum(ac.amount_bc *

--- a/sql/modules/arap.sql
+++ b/sql/modules/arap.sql
@@ -151,13 +151,15 @@ $$
                    (SELECT value
                       FROM defaults
                      WHERE setting_key = 'curr') THEN
+             1
+         ELSE
              (SELECT coalesce(rate, 'NaN'::numeric) AS rate
                 FROM exchangerate_default
                WHERE rate_type = 1
                  AND current_date BETWEEN valid_from AND valid_to
                  AND curr = (SELECT curr FROM entity_credit_account
                               WHERE id = in_eca))
-         ELSE 1 END AS used_tc
+         END AS used_tc
    FROM (
      SELECT sum(ac.amount_bc *
                 CASE WHEN al.description = 'AR' THEN -1 ELSE 1 END) AS used


### PR DESCRIPTION
When the ECA's currency and company's currency is same, the exchange rate should be 1. The exchange rate should only retrieve when two currencies are different.

Fix #6237 