### PR TITLE
Date entry: fix removing separator characters

### DIFF
--- a/UI/js-src/lsmb/DateTextBox.js
+++ b/UI/js-src/lsmb/DateTextBox.js
@@ -14,6 +14,7 @@ define([
     return declare("lsmb/DateTextBox", [DateTextBox], {
         _formattedValue: null,
         defaultIsToday: false,
+        _oldValue: "",
         constructor: function (params, srcNodeRef) {
             this._formattedValue = srcNodeRef.value;
 
@@ -90,10 +91,21 @@ define([
             /* eslint no-cond-assign: 0 */
             on(
                 this.domNode,
+                "keydown",
+                lang.hitch(this, function (e) {
+                    this.oldValue = domAttr.get(e.target, "value");
+                })
+            );
+            on(
+                this.domNode,
                 "keyup",
                 lang.hitch(this, function (e) {
                     let value = domAttr.get(e.target, "value");
 
+                    if (this.oldValue.length > value.length) {
+                        // allow removing characters; separators and others alike
+                        return;
+                    }
                     /* Extract the separator and location into an array and if
                      * needed add the separator. */
                     const re = /[^a-z]/gi;


### PR DESCRIPTION
Without this fix, the DateTextBox doesn't allow removal of content
beyond the first separator character (adding it back immediately on
removal), unless *all* text is selected and removed and entry is
started from scratch again.
With this fix, separators are only added when the input value is
appended/added to.
