### PR TITLE
Fix hashfiles arguments for Dojo caching

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: UI/js
-          key: dojo-${{ hashFiles('UI/{js-src,css}/**','UI/**/*.html','doc/sources/**') }}
+          key: dojo-${{ hashFiles('UI/js-src/**', 'UI/css/**','UI/**/*.html','doc/sources/**') }}
 
       - name: Build Dojo
         run: |


### PR DESCRIPTION
The docs at https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
don't list the bash form of "alternate path segment" using curlies. List
each path separately.
