### PR TITLE
Delete vouchers and batches before deleting transactions

### DIFF
--- a/sql/modules/Voucher.sql
+++ b/sql/modules/Voucher.sql
@@ -489,11 +489,11 @@ BEGIN
 
         DELETE FROM invoice WHERE trans_id = ANY(t_transaction_ids);
         DELETE FROM acc_trans WHERE trans_id = ANY(t_transaction_ids);
+        DELETE FROM voucher WHERE batch_id = in_batch_id;
+        DELETE FROM batch WHERE id = in_batch_id;
         DELETE FROM ar WHERE id = ANY(t_transaction_ids);
         DELETE FROM ap WHERE id = ANY(t_transaction_ids);
         DELETE FROM gl WHERE id = ANY(t_transaction_ids);
-        DELETE FROM voucher WHERE batch_id = in_batch_id;
-        DELETE FROM batch WHERE id = in_batch_id;
         DELETE FROM transactions WHERE id = ANY(t_transaction_ids);
 
         RETURN 1;


### PR DESCRIPTION
Because deleting the transactions may delete the 'transactions' table
row (for consistency purposes), which breaks referential integrity
if the rows haven't been deleted from batch and voucher.

Fixes #6252.
