### PR TITLE
Initialize 'check_max_invoices' and fix off-by-one invoice

### DIFF
--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -474,7 +474,8 @@ sub print {
             my $inv_count;
             my $check_max_invoices = $request->setting->get(
                          'check_max_invoices'
-            );
+                );
+            $check_max_invoices ||= scalar(@{$contact->{invoices}});
             if ($check_max_invoices > scalar(@{$contact->{invoices}})) {
                 $inv_count = scalar(@{$contact->{invoices}});
             } else {
@@ -482,6 +483,7 @@ sub print {
             }
 
             for my $invoice (@{$contact->{invoices}}) {
+                last if scalar(@{$check->{invoices}}) > $inv_count;
                 if ($contact->{paid} eq 'some'){
                     $invoice->{paid} = LedgerSMB::PGNumber
                         ->from_input($invoice->{payment});
@@ -496,8 +498,7 @@ sub print {
                     format => '1000.00',
                     money => 1
                 );
-                push @{$check->{invoices}}, $invoice
-                    if scalar(@{$check->{invoices}}) <= $inv_count;
+                push @{$check->{invoices}}, $invoice;
             }
             my $amt = $check->{amount}->copy;
             $amt->bfloor();

--- a/sql/Pg-database.sql
+++ b/sql/Pg-database.sql
@@ -1371,6 +1371,7 @@ decimal_places|2
 disable_back|0
 dojo_theme|claro
 vclimit|9999
+check_max_invoices|45
 \.
 
 -- Sequence handling


### PR DESCRIPTION
@neilt indicates the template can hold as many as 45 invoices in the
voucher section. Therefore, initialize the maximum at 45 by default.

At the same time, fix the code which would add one more invoice to
the voucher than set by the 'check_max_invoices' setting. One too
many, then. But no longer.

Closes #6253
