### PR TITLE
The Vue Router makes paths relative to the URL segment...

### DIFF
--- a/UI/js-src/lsmb/menus/Tree.js
+++ b/UI/js-src/lsmb/menus/Tree.js
@@ -148,7 +148,7 @@ define([
                 url += "#" + Date.now();
 
                 if (this.load_link) {
-                    this.load_link(url);
+                    this.load_link("/" + url);
                 }
             }
         },


### PR DESCRIPTION
...and we want to load a new "top level" page in our menu,
regardless of the path currently present in the hash.
