### PR TITLE
Fix saving AR/AP vouchers

### DIFF
--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -513,7 +513,7 @@ $form->open_status_div($status_div_id) . qq|
     }
     $form->hide_form(
         qw(batch_id approved id printed emailed sort closedto locked
-           oldtransdate audittrail recurring checktax reverse batch_id subtype
+           oldtransdate audittrail recurring checktax reverse subtype
            entity_control_code tax_id meta_number default_reportable address city)
     );
 

--- a/old/lib/LedgerSMB/old_code.pm
+++ b/old/lib/LedgerSMB/old_code.pm
@@ -81,6 +81,7 @@ sub dispatch {
             $script_module =~ s/\.pl//;
             $lsmb_legacy::form = Form->new();
             $lsmb_legacy::form->{$_} = $form_args->{$_} for (keys %$form_args);
+            $lsmb_legacy::form->{script} = $script;
             $lsmb_legacy::logger = Log::Log4perl->get_logger("lsmb.$script_module.$lsmb_legacy::form->{action}");
             %lsmb_legacy::myconfig = %$user;
             $lsmb_legacy::form->{_locale} =


### PR DESCRIPTION
This commit fixes two problems:
 1. `batch_id` added twice to "hiddens" causes duplicate submissions
 2. '$form->{script}` being incorrectly set, causing the AR/AP voucher
    to be posted to `vouchers.pl` instead of `ar.pl` or `ap.pl`

Closes #6327
