### PR TITLE
Fix saving AR/AP vouchers

### DIFF
--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -517,7 +517,7 @@ $form->open_status_div($status_div_id) . qq|
     }
     $form->hide_form(
         qw(batch_id approved id printed emailed sort closedto locked
-           oldtransdate audittrail recurring checktax reverse batch_id subtype
+           oldtransdate audittrail recurring checktax reverse subtype
            entity_control_code tax_id meta_number default_reportable address city)
     );
 

--- a/old/lib/LedgerSMB/old_code.pm
+++ b/old/lib/LedgerSMB/old_code.pm
@@ -77,6 +77,7 @@ sub dispatch {
             local *STDOUT = $stdout;
             $lsmb_legacy::form = Form->new();
             $lsmb_legacy::form->{$_} = $form_args->{$_} for (keys %$form_args);
+            $lsmb_legacy::form->{script} = $script;
             $lsmb_legacy::locale = $LedgerSMB::App_State::Locale;
             %lsmb_legacy::myconfig = %$LedgerSMB::App_State::User;
 


### PR DESCRIPTION
This commit fixes two problems:
 1. `batch_id` added twice to "hiddens" causes duplicate submissions
 2. '$form->{script}` being incorrectly set, causing the AR/AP voucher
    to be posted to `vouchers.pl` instead of `ar.pl` or `ap.pl`

Closes #6327
