### PR TITLE
Fix tax account initialization

### DIFF
--- a/old/lib/LedgerSMB/Tax.pm
+++ b/old/lib/LedgerSMB/Tax.pm
@@ -49,7 +49,7 @@ sub init_taxes {
     my @taxes = ();
     do { $_ = '' unless defined $_ } for ($taxaccounts, $taxaccounts2);
     my @accounts = split / /, $taxaccounts;
-    if ( defined $taxaccounts2 ) {
+    if ( scalar(@_) == 3 ) { # 3-argument call; sometimes we only have 2...
         #my @tmpaccounts = @accounts;#unused var
         @accounts=(); # empty @accounts
         for my $acct ( split / /, $taxaccounts2 ) {


### PR DESCRIPTION
Distinguish the two-argument versus the three-argument function
call by counting the number of arguments in the call, not by
determining whether the third argument turns out to be undefined
(which it isn't, since we added an initialization with an empty
string, a few lines up, a few years back...).
