### PR TITLE
Remove empty mail fields from the workflow context

### DIFF
--- a/lib/LedgerSMB/Scripts/email.pm
+++ b/lib/LedgerSMB/Scripts/email.pm
@@ -44,8 +44,14 @@ sub render {
     my $wf = FACTORY()->fetch_workflow('Email', $request->{id});
 
     if ($request->{wf_action}) {
-        $wf->context->param( $_ => $request->{$_} )
-            for qw( from to cc bcc subject body );
+        for my $field (qw( from to cc bcc subject body )) {
+            if (defined $request->{$field}) {
+                $wf->context->param( $_ => $request->{$field} );
+            }
+            else {
+                $wf->context->delete_param( $field );
+            }
+        }
 
         my $upload = $request->{_uploads}->{attachment_content};
         if ($upload) {


### PR DESCRIPTION
When passing `<undef>` to the `param` function, the current value
is returned, but nothing more. However, in this case, it's intended
that the value be removed or cleared so as not to include the
addresses, subject or other fields in the mail message.

Closes #6168
