### PR TITLE
Implement counter-measure for I[SR]->post_invoice mangling invoice amounts

### DIFF
--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -1573,6 +1573,8 @@ sub invoice {
 
         # $lib contains either 'IS' or 'IR': the sales and purchase invoice libs
         $lib->post_invoice(\%myconfig, $form);
+        $lib->retrieve_invoice(\%myconfig, $form);
+        &prepare_invoice;
     }
     $wf->context->param( 'spawned_id'   => $form->{workflow_id} );
     $wf->context->param( 'spawned_type' => 'AR/AP' );

--- a/old/lib/LedgerSMB/IR.pm
+++ b/old/lib/LedgerSMB/IR.pm
@@ -112,6 +112,9 @@ sub post_invoice {
     my $invoice_id;
     my $fxdiff = 0;
 
+    $form->{acc_trans} = ();
+
+
     ( $null, $form->{employee_id} ) = split /--/, $form->{employee}
         if $form->{employee};
 


### PR DESCRIPTION
The invoice saving process overwrites the "sellprice_$i" value in "$form"
which causes the invoice to be displayed incorrectly; this change makes
sure the invoice is loaded from disk and "prepared" for presentation
after being saved, so the data gets rendered correctly in the screen.

Note: The data always *was* correct in the saved data (but re-saving it
will clobber the correct data with the data from the form...)

Closes #6125
