### PR TITLE
On authentication failure report 401 Unauthorized

### DIFF
--- a/lib/LedgerSMB/Middleware/MainAppConnect.pm
+++ b/lib/LedgerSMB/Middleware/MainAppConnect.pm
@@ -61,7 +61,10 @@ sub _connect {
     if (!$dbh) {
         my $cb = $env->{'lsmb.db_cb'};
         if ($cb) {
-            $dbh = $cb->($env, @_);
+            my ($r, $e) = $cb->($env, @_);
+
+            return (undef, $e) if $e;
+            $dbh = $r;
         }
         else {
             die q{Environment contains neither 'db' nor 'db_cb'};


### PR DESCRIPTION
Before this change, the error being reported was 500 Internal
Server Error, which is an indication of problems processing the
request in the server, not one of incorrect parameters having been
provided or unallowed access given the parameters provided.
