### PR TITLE
Work around Workflow 1.59 changing context->param() in list context

### DIFF
--- a/lib/LedgerSMB/Workflow/Action/Email.pm
+++ b/lib/LedgerSMB/Workflow/Action/Email.pm
@@ -277,8 +277,10 @@ sub save {
     my ($self, $wf) = @_;
     my $dbh = $self->_factory->get_persister_for_workflow_type('Email')->handle;
 
-    my @values =
-        map { $wf->context->param($_) } qw(from to cc bcc notify subject body);
+    my @values = (
+        map { scalar $wf->context->param($_) }
+        qw(from to cc bcc notify subject body)
+        );
 
     if ( my $expansions = $wf->context->param( 'expansions' ) ) {
         push @values, $json->encode( $expansions );


### PR DESCRIPTION
Direct branch commit rationale:  this commit does not apply to `master` as this code has since been moved to the E-mail persister.