### PR TITLE
Restrict tests for translatable texts to project sources

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,6 +160,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.4.0
 
+      - name: Install GNU gettext
+        run: sudo apt install gettext
+
       - name: Create logging directories
         run: |
           mkdir screens logs

--- a/xt/06.1-Perl-PO.t
+++ b/xt/06.1-Perl-PO.t
@@ -22,7 +22,8 @@ if ($ENV{COVERAGE} && $ENV{CI}) {
 
 my @on_disk;
 sub collect {
-    return if $File::Find::dir  =~ m(^blib|xt/lib/|xt/66-cucumber/|LaTex|.local/);
+
+    return if $File::Find::dir  =~ m!^\./(blib|xt/lib/|xt/66-cucumber/|LaTex|node_modules|local/lib/perl5|\..+)!;
 
     my $module = $File::Find::name;
     return if $module !~ m(\.(pl|pm|t)$);


### PR DESCRIPTION
Prevent searches in local directories (.git, .github, .circleci, .local, ...)