### PR TITLE
Update creation date in recurring transactions

### DIFF
--- a/old/bin/am.pl
+++ b/old/bin/am.pl
@@ -38,6 +38,7 @@ use LedgerSMB::Form;
 use LedgerSMB::User;
 use LedgerSMB::GL;
 use LedgerSMB::Legacy_Util;
+use LedgerSMB::PGDate;
 use LedgerSMB::Template::UI;
 use LedgerSMB::Sysconfig;
 
@@ -1093,6 +1094,8 @@ sub process_transactions {
                     $form->{duedate} =
                       $form->add_date( \%myconfig, $form->{transdate},
                         $pt->{overdue}, "days" );
+                    # set create date
+                    $form->{crdate} = LedgerSMB::PGDate->now->to_output();
 
                     if ( $pt->{payment} ) {
 


### PR DESCRIPTION
Sets the creation date for recurring transactions to the
date they were created.

Fixes #6432