### PR TITLE
Add missing field 'taxform' in details report

### DIFF
--- a/lib/LedgerSMB/Report/Taxform/Details.pm
+++ b/lib/LedgerSMB/Report/Taxform/Details.pm
@@ -39,6 +39,8 @@ This is the id of the taxform.
 
 has tax_form_id => (is => 'ro', isa => 'Int', required => '1');
 
+has taxform => (is => 'rw', isa => 'Str', required => 0);
+
 =head2 meta_number
 
 This is the vendor number.


### PR DESCRIPTION
A field by the same name is in the summary variant
of the same report, but it's referenced in the details
variant as well...

Fixes #6458