### PR TITLE
Fix line descriptions not shown in AP transaction prints

### DIFF
--- a/old/bin/arapprn.pl
+++ b/old/bin/arapprn.pl
@@ -157,6 +157,7 @@ sub print_transaction {
         push( @{ $form->{accno} },         $form->{tempaccno} );
         push( @{ $form->{account} },       $form->{tempaccount} );
         push( @{ $form->{description} },   $form->{tempdescription} );
+        push( @{ $form->{linedescription} },   $form->{tempdescription} );
         push( @{ $form->{projectnumber} }, $form->{tempprojectnumber} );
 
         push( @{ $form->{amount} }, $form->{"amount_$i"} );

--- a/templates/demo/ap_transaction.csv
+++ b/templates/demo/ap_transaction.csv
@@ -1,7 +1,7 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.0
-   Date:     2021-01-04
+   Version:  1.1
+   Date:     2022-03-28
    File:     ap_transaction.csv
    Set:      demo
 
@@ -10,7 +10,7 @@ releases. No explicit versioning was applied before 2021-01-04.
 
 -?>
 account,amount,description,project
-<?lsmb FOREACH amount ?><?lsmb lc = loop.count - 1 ?><?lsmb accno.${lc} ?>,<?lsmb account.${lc} ?>,<?lsmb amount.${lc} ?>,<?lsmb description.${lc} ?>,<?lsmb projectnumber.${lc} ?>
+<?lsmb FOREACH amount ?><?lsmb lc = loop.count - 1 ?><?lsmb accno.${lc} ?>,<?lsmb account.${lc} ?>,<?lsmb amount.${lc} ?>,<?lsmb linedescription.${lc} ?>,<?lsmb projectnumber.${lc} ?>
 <?lsmb END ?><?lsmb FOREACH t IN taxaccounts.split(' ') ?><?lsmb loop_count = loop.count - 1 -?>
 <?lsmb t.remove('"') ?>,<?lsmb tax.${loop_count} ?>,<?lsmb taxdescription.${loop_count} ?>,
 <?lsmb END ?>

--- a/templates/demo/ap_transaction.html
+++ b/templates/demo/ap_transaction.html
@@ -1,7 +1,7 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.0
-   Date:     2021-01-04
+   Version:  1.1
+   Date:     2022-03-28
    File:     ap_transaction.html
    Set:      demo
 
@@ -95,7 +95,7 @@ releases. No explicit versioning was applied before 2021-01-04.
             <td width="10"></td>
             <td align="right"><?lsmb amount.${loop_count} ?></td>
             <td width="10"></td>
-            <td><?lsmb description.${loop_count}.replace("\n","<br />") ?></td>
+            <td><?lsmb linedescription.${loop_count}.replace("\n","<br />") ?></td>
             <td width="10"></td>
             <td><?lsmb projectnumber.${loop_count} ?></td>
           </tr><?lsmb END ?>

--- a/templates/demo/ap_transaction.tex
+++ b/templates/demo/ap_transaction.tex
@@ -1,7 +1,7 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.0
-   Date:     2021-01-04
+   Version:  1.1
+   Date:     2022-03-28
    File:     ap_transaction.tex
    Set:      demo
 
@@ -82,7 +82,7 @@ Tax Number: <?lsmb vendortaxnumber ?>
   <?lsmb accno.${lc} ?> &
   <?lsmb account.${lc} ?> &
   <?lsmb amount.${lc} ?> &
-  <?lsmb description.${lc} ?> &
+  <?lsmb linedescription.${lc} ?> &
   <?lsmb projectnumber.${lc} ?> \\
 <?lsmb END ?>
 

--- a/templates/demo/ar_transaction.csv
+++ b/templates/demo/ar_transaction.csv
@@ -1,7 +1,7 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.0
-   Date:     2021-01-04
+   Version:  1.1
+   Date:     2022-03-28
    File:     ar_transaction.csv
    Set:      demo
 
@@ -10,7 +10,7 @@ releases. No explicit versioning was applied before 2021-01-04.
 
 -?>
 account,description,amount,memo,project
-<?lsmb FOREACH amount ?><?lsmb lc = loop.count - 1 ?><?lsmb accno.${lc} ?>,<?lsmb account.${lc} ?>,<?lsmb amount.${lc} ?>,<?lsmb description.${lc} ?>,<?lsmb projectnumber.${lc} ?>
+<?lsmb FOREACH amount ?><?lsmb lc = loop.count - 1 ?><?lsmb accno.${lc} ?>,<?lsmb account.${lc} ?>,<?lsmb amount.${lc} ?>,<?lsmb linedescription.${lc} ?>,<?lsmb projectnumber.${lc} ?>
 <?lsmb END ?><?lsmb FOREACH t IN taxaccounts.split(' ') ?><?lsmb loop_count = loop.count - 1 -?>
 <?lsmb t.remove('"') ?>,<?lsmb taxdescription.${loop_count} ?>,<?lsmb tax.${loop_count} ?>,,,
 <?lsmb END ?>

--- a/templates/demo/ar_transaction.html
+++ b/templates/demo/ar_transaction.html
@@ -1,7 +1,7 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.0
-   Date:     2021-01-04
+   Version:  1.1
+   Date:     2022-03-28
    File:     ar_transaction.html
    Set:      demo
 
@@ -93,7 +93,7 @@ releases. No explicit versioning was applied before 2021-01-04.
             <td width="10">&nbsp;</td>
             <td align="right"><?lsmb amount.${loop_count} ?></td>
             <td width="10">&nbsp;</td>
-            <td><?lsmb description.${loop_count}.replace("\n","<br />") ?></td>
+            <td><?lsmb linedescription.${loop_count}.replace("\n","<br />") ?></td>
             <td width="10">&nbsp;</td>
             <td><?lsmb projectnumber.${loop_count} ?></td>
           </tr><?lsmb END ?>

--- a/templates/demo/ar_transaction.tex
+++ b/templates/demo/ar_transaction.tex
@@ -1,7 +1,7 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.0
-   Date:     2021-01-04
+   Version:  1.1
+   Date:     2022-03-28
    File:     ar_transaction.tex
    Set:      demo
 
@@ -99,7 +99,7 @@ releases. No explicit versioning was applied before 2021-01-04.
   <?lsmb accno.${lc} ?> &
   <?lsmb account.${lc} ?> &
   <?lsmb amount.${lc} ?> &
-  <?lsmb description.${lc} ?> &
+  <?lsmb linedescription.${lc} ?> &
   <?lsmb projectnumber.${lc} ?> \\
 <?lsmb END ?>
 

--- a/templates/xedemo/ap_transaction.csv
+++ b/templates/xedemo/ap_transaction.csv
@@ -1,7 +1,7 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.0
-   Date:     2021-01-04
+   Version:  1.1
+   Date:     2022-03-28
    File:     ap_transaction.csv
    Set:      xedemo
 
@@ -10,7 +10,7 @@ releases. No explicit versioning was applied before 2021-01-04.
 
 -?>
 account,amount,description,project
-<?lsmb FOREACH amount ?><?lsmb lc = loop.count - 1 ?><?lsmb accno.${lc} ?>,<?lsmb account.${lc} ?>,<?lsmb amount.${lc} ?>,<?lsmb description.${lc} ?>,<?lsmb projectnumber.${lc} ?>
+<?lsmb FOREACH amount ?><?lsmb lc = loop.count - 1 ?><?lsmb accno.${lc} ?>,<?lsmb account.${lc} ?>,<?lsmb amount.${lc} ?>,<?lsmb linedescription.${lc} ?>,<?lsmb projectnumber.${lc} ?>
 <?lsmb END ?><?lsmb FOREACH t IN taxaccounts.split(' ') ?><?lsmb loop_count = loop.count - 1 -?>
 <?lsmb t.remove('"') ?>,<?lsmb tax.${loop_count} ?>,<?lsmb taxdescription.${loop_count} ?>,
 <?lsmb END ?>

--- a/templates/xedemo/ap_transaction.html
+++ b/templates/xedemo/ap_transaction.html
@@ -1,7 +1,7 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.0
-   Date:     2021-01-04
+   Version:  1.1
+   Date:     2022-03-28
    File:     ap_transaction.html
    Set:      xedemo
 
@@ -95,7 +95,7 @@ releases. No explicit versioning was applied before 2021-01-04.
             <td width="10"></td>
             <td align="right"><?lsmb amount.${loop_count} ?></td>
             <td width="10"></td>
-            <td><?lsmb description.${loop_count}.replace("\n","<br />") ?></td>
+            <td><?lsmb linedescription.${loop_count}.replace("\n","<br />") ?></td>
             <td width="10"></td>
             <td><?lsmb projectnumber.${loop_count} ?></td>
           </tr><?lsmb END ?>

--- a/templates/xedemo/ap_transaction.tex
+++ b/templates/xedemo/ap_transaction.tex
@@ -1,7 +1,7 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.0
-   Date:     2021-01-04
+   Version:  1.1
+   Date:     2022-03-28
    File:     ap_transaction.tex
    Set:      xedemo
 
@@ -80,7 +80,7 @@ Tax Number: <?lsmb vendortaxnumber ?>
   <?lsmb accno.${lc} ?> &
   <?lsmb account.${lc} ?> &
   <?lsmb amount.${lc} ?> &
-  <?lsmb description.${lc} ?> &
+  <?lsmb linedescription.${lc} ?> &
   <?lsmb projectnumber.${lc} ?> \\
 <?lsmb END ?>
 

--- a/templates/xedemo/ar_transaction.csv
+++ b/templates/xedemo/ar_transaction.csv
@@ -1,7 +1,7 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.0
-   Date:     2021-01-04
+   Version:  1.1
+   Date:     2022-03-28
    File:     ar_transaction.csv
    Set:      xedemo
 
@@ -10,7 +10,7 @@ releases. No explicit versioning was applied before 2021-01-04.
 
 -?>
 account,description,amount,memo,project
-<?lsmb FOREACH amount ?><?lsmb lc = loop.count - 1 ?><?lsmb accno.${lc} ?>,<?lsmb account.${lc} ?>,<?lsmb amount.${lc} ?>,<?lsmb description.${lc} ?>,<?lsmb projectnumber.${lc} ?>
+<?lsmb FOREACH amount ?><?lsmb lc = loop.count - 1 ?><?lsmb accno.${lc} ?>,<?lsmb account.${lc} ?>,<?lsmb amount.${lc} ?>,<?lsmb linedescription.${lc} ?>,<?lsmb projectnumber.${lc} ?>
 <?lsmb END ?><?lsmb FOREACH t IN taxaccounts.split(' ') ?><?lsmb loop_count = loop.count - 1 -?>
 <?lsmb t.remove('"') ?>,<?lsmb taxdescription.${loop_count} ?>,<?lsmb tax.${loop_count} ?>,,,
 <?lsmb END ?>

--- a/templates/xedemo/ar_transaction.html
+++ b/templates/xedemo/ar_transaction.html
@@ -1,7 +1,7 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.0
-   Date:     2021-01-04
+   Version:  1.1
+   Date:     2022-03-28
    File:     ar_transaction.html
    Set:      xedemo
 
@@ -93,7 +93,7 @@ releases. No explicit versioning was applied before 2021-01-04.
             <td width="10">&nbsp;</td>
             <td align="right"><?lsmb amount.${loop_count} ?></td>
             <td width="10">&nbsp;</td>
-            <td><?lsmb description.${loop_count}.replace("\n","<br />") ?></td>
+            <td><?lsmb linedescription.${loop_count}.replace("\n","<br />") ?></td>
             <td width="10">&nbsp;</td>
             <td><?lsmb projectnumber.${loop_count} ?></td>
           </tr><?lsmb END ?>

--- a/templates/xedemo/ar_transaction.tex
+++ b/templates/xedemo/ar_transaction.tex
@@ -1,7 +1,7 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.0
-   Date:     2021-01-04
+   Version:  1.1
+   Date:     2022-03-28
    File:     ar_transaction.tex
    Set:      xedemo
 
@@ -97,7 +97,7 @@ releases. No explicit versioning was applied before 2021-01-04.
   <?lsmb accno.${lc} ?> &
   <?lsmb account.${lc} ?> &
   <?lsmb amount.${lc} ?> &
-  <?lsmb description.${lc} ?> &
+  <?lsmb linedescription.${lc} ?> &
   <?lsmb projectnumber.${lc} ?> \\
 <?lsmb END ?>
 


### PR DESCRIPTION
There's overlap in naming the fields: there's a generic string field
`description`, which is invoice-level data. Then, there's an array
field called `description` which contains the descriptions of the rows.

For some reason this naming clash doesn't show when printing the AR
transactions, but it does show when printing AP transactions.

For the purpose of backporting, *add* a field called `linedescription`
which holds the same array of line-related descriptions. For 1.10,
we'll remove support for `description` holding the line descriptions,
but for a patch release, that's would lead to unacceptable breakage.

At the same time, update the templates so that new databases will be
created with future proof templates.

Fixes #6482.
