### PR TITLE
Add workaround for Pg 14 compat

### DIFF
--- a/sql/Pg-database.sql
+++ b/sql/Pg-database.sql
@@ -3412,10 +3412,19 @@ CREATE INDEX menu_acl_node_id_idx ON menu_acl (node_id);
 -- PostgreSQL database dump complete
 --
 
+CREATE OR REPLACE FUNCTION lsmb_array_append(ary anyarray, elm anyelement)
+RETURNS anyarray
+AS $$
+   SELECT array_append(ary, elm);
+$$ LANGUAGE sql;
+
+COMMENT ON FUNCTION lsmb_array_append(anyarray, anyelement)
+IS $$PostgreSQL 14 vs pre-14 compatibility measure.$$;
+
 CREATE AGGREGATE as_array (
         BASETYPE = ANYELEMENT,
         STYPE = ANYARRAY,
-        SFUNC = ARRAY_APPEND,
+        SFUNC = LSMB_ARRAY_APPEND,
         INITCOND = '{}'
 );
 
@@ -3425,10 +3434,21 @@ $$ A basic array aggregate to take elements and return a one-dimensional array.
 Example:  SELECT as_array(id) from entity_class;
 $$;
 
+
+CREATE OR REPLACE FUNCTION compound_array(ary anyarray, elm anyarray)
+RETURNS anyarray
+AS $$
+   SELECT array_cat(ary, elm);
+$$ LANGUAGE sql;
+
+COMMENT ON FUNCTION compound_array(anyarray, anyarray)
+IS $$PostgreSQL 14 vs pre-14 compatibility measure.$$;
+
+
 CREATE AGGREGATE compound_array (
         BASETYPE = ANYARRAY,
         STYPE = ANYARRAY,
-        SFUNC = ARRAY_CAT,
+        SFUNC = COMPOUND_ARRAY,
         INITCOND = '{}'
 );
 


### PR DESCRIPTION
Pg14 changed the function signature of `array_cat()` and `array_append()`,
making them incompatible with our aggregate definitions. By introducing
wrappers, we get control over our definitions back, allowing both
per Pg13 as well as Pg14+ to load our schema.
