### PR TITLE
Allow deletion of draft transactions with shipto addresses

### DIFF
--- a/sql/changes/1.7/new_shipto-fkey.sql
+++ b/sql/changes/1.7/new_shipto-fkey.sql
@@ -1,0 +1,5 @@
+
+alter table new_shipto drop constraint new_shipto_trans_id_fkey;
+alter table new_shipto add constraint new_shipto_trans_id_fkey
+   foreign key (trans_id) references transactions(id) on delete cascade;
+

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -112,3 +112,4 @@ mc/delete-migration-validation-data.sql
 1.7/to-location-pkeys-optimization.sql
 1.7/create-trans_id-index.sql
 1.7/fix-oe-person_id-fkey.sql
+1.7/new_shipto-fkey.sql


### PR DESCRIPTION
This fixes a problem reported on the Matrix chat channel by matthew14.
