### PR TITLE
Restore GIFI Balance Sheet report

### DIFF
--- a/lib/LedgerSMB/Report/Balance_Sheet.pm
+++ b/lib/LedgerSMB/Report/Balance_Sheet.pm
@@ -95,7 +95,7 @@ sub run_report {
               return ($line->{account_type} eq 'H')
                   ? []
                   : [ [ $line->{account_category},
-                        $line->{gifi_accno} ],
+                        $line->{gifi} ],
                       [ $line->{account_category} ],
                   ];
         } : ($self->legacy_hierarchy) ?
@@ -149,7 +149,7 @@ sub run_report {
         };
     my $row_props = ($self->gifi) ?
         sub { my ($line) = @_;
-              $line->{account_number} = $line->{gifi_accno};
+              $line->{account_number} = $line->{gifi};
               $line->{account_description} = $line->{gifi_description};
               $line->{order} = $line->{account_number};
               return $line;


### PR DESCRIPTION
Make sure that the GIFI acounts are used in Balance Sheet report when desired.
