### PR TITLE
Fix persisting context of E-mail workflows

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -109,6 +109,7 @@ requires 'Template::Provider';
 requires 'Text::CSV';
 requires 'Text::Markdown';
 requires 'URI::Escape';
+requires 'Workflow', '1.59';
 requires 'Workflow::Context', '1.59';
 requires 'Workflow::Exception', '1.59';
 requires 'Workflow::Factory', '1.59';

--- a/lib/LedgerSMB/Workflow/Action/Email.pm
+++ b/lib/LedgerSMB/Workflow/Action/Email.pm
@@ -215,7 +215,7 @@ sub send {
     }
 
     for my $att ( ($ctx->param( 'attachments' ) // [])->@* ) {
-        $mail->attach($att->{content}->(disable_cache => 1),
+        $mail->attach($wf->attachment_content($att->{id}, disable_cache => 1),
                       content_type => $att->{mime_type},
                       disposition  => 'attachment',
                       filename     => $att->{file_name});

--- a/lib/LedgerSMB/Workflow/Action/SpawnWorkflow.pm
+++ b/lib/LedgerSMB/Workflow/Action/SpawnWorkflow.pm
@@ -97,7 +97,7 @@ sub execute {
     }
     my $new_wf = FACTORY()->create_workflow( $self->spawn_type, $context );
     my $wf_id  = $new_wf->id;
-    $wf->context->param( spawned_workflow => $new_wf );
+    $wf->context->param( spawned_workflow => $wf_id );
     $wf->add_history(
         {
             action      => $self->name,

--- a/lib/LedgerSMB/Workflow/Email.pm
+++ b/lib/LedgerSMB/Workflow/Email.pm
@@ -1,0 +1,76 @@
+package LedgerSMB::Workflow::Email;
+
+=head1 NAME
+
+LedgerSMB::Workflow::Email - Class for e-mail sending state machines
+
+=head1 SYNOPSIS
+
+  <workflow class="LedgerSMB::Workflow::Email">
+    ...
+  </workflow>
+
+=head1 DESCRIPTION
+
+This module handles persistence of workflow (history) data through the
+existing database connection in C<LedgerSMB::App_State::DBH()>.
+
+The class inherits from Workflow::Persister::DBI and uses
+the same configuration semantics.
+
+=head1 METHODS
+
+=cut
+
+use warnings;
+use strict;
+use base qw( Workflow );
+
+use Workflow::Factory qw(FACTORY);
+
+=head2 attachment_content( $id, disable_cache => $boolean )
+
+Returns the content of an attachment to an e-mail, *if* the attachment
+with C<$id> belongs to the Email workflow.
+
+The C<disable_cache> parameter determines whether or not the content
+will be cached in the workflow for later retrieval, or that future calls
+will retrieve the content from the database again.
+
+=cut
+
+sub attachment_content {
+    my ($self, $id, %args) = @_;
+
+    return $self->{_content}->{$id} if $self->{_content}->{$id};
+
+    my $persister = FACTORY()->get_persister( $self->type );
+    my $dbh       = $persister->handle;
+    my $sth       = $dbh->prepare(
+        q{select content from file_email where ref_key = ? and id = ?})
+        or die $dbh->errstr;
+    $sth->execute( $self->id, $id )
+        or die $sth->errstr;
+    ($self->{_content}->{$id}) = $sth->fetchrow_array();
+    if (not defined $self->{_content}->{$id} and $sth->err) {
+        die $sth->errstr;
+    }
+    $sth->finish;
+
+    return $args{disable_cache} ?
+        delete $self->{_content}->{$id} : $self->{_content}->{$id};
+}
+
+
+
+1;
+
+
+=head1 LICENSE AND COPYRIGHT
+
+Copyright (C) 2022 The LedgerSMB Core Team
+
+This file is licensed under the GNU General Public License version 2, or at your
+option any later version.  A copy of the license should have been included with
+your software.
+

--- a/lib/LedgerSMB/Workflow/Persister/Email.pm
+++ b/lib/LedgerSMB/Workflow/Persister/Email.pm
@@ -84,26 +84,6 @@ sub _fetch_attachments {
     $sth->finish;
 
     $wf->context->param( 'attachments' => $rows);
-    for my $row ($rows->@*) {
-        $row->{content} = sub {
-            my %args = @_;
-            return $row->{_content} if $row->{_content};
-
-            my $sth = $dbh->prepare(
-                q{select content from file_email where id = ?})
-                or die $sth->errstr;
-            $sth->execute( $row->{id} )
-                or die $sth->errstr;
-            ($row->{_content}) = $sth->fetchrow_array();
-            if (not defined $row->{_content} and $sth->err) {
-                die $sth->errstr;
-            }
-            $sth->finish;
-
-            return $args{disable_cache} ?
-                delete $row->{_content} : $row->{_content};
-        };
-    }
 }
 
 

--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -1494,8 +1494,7 @@ sub print_form {
 
         $trans_wf->context->param( 'email-data' => $email_data );
         $trans_wf->execute_action( 'E-mail' );
-        $wf = $trans_wf->context->param( 'spawned_workflow' );
-        my $id = $wf->id;
+        my $id = $trans_wf->context->param( 'spawned_workflow' );
         if (not $form->{header}) {
             print "Location: email.pl?id=$id&action=render&callback=$form->{script}%3F"
                 . "id%3D$form->{id}%26action%3Dedit\n";

--- a/t/01-load.t
+++ b/t/01-load.t
@@ -239,6 +239,7 @@ my @modules =
      'LedgerSMB::Workflow::Action::Null',
      'LedgerSMB::Workflow::Action::RecordSpawnedWorkflow',
      'LedgerSMB::Workflow::Action::SpawnWorkflow',
+     'LedgerSMB::Workflow::Email',
      'LedgerSMB::Workflow::Persister',
      'LedgerSMB::Workflow::Persister::Email',
      'LedgerSMB::Workflow::Persister::ExtraData',

--- a/workflows/email.workflow.xml
+++ b/workflows/email.workflow.xml
@@ -1,5 +1,6 @@
 <workflow>
   <type>Email</type>
+  <class>LedgerSMB::Workflow::Email</class>
   <persister>Email</persister>
  <description>Handles lifecycle of e-mail</description>
  <state name="INITIAL" autorun="yes">


### PR DESCRIPTION
Due to the fact that entire workflows were stored in the context,
serialization of the context - for E-mail workflows - was seriously
broken. This commit moves attachments out of the context. And similarly
it moves the spawned workflow out of the context as well.

Follows up on the PR which introduces context serialization.
