### PR TITLE
Fix response status code check

### DIFF
--- a/lib/LedgerSMB/Middleware/MainAppConnect.pm
+++ b/lib/LedgerSMB/Middleware/MainAppConnect.pm
@@ -176,12 +176,16 @@ sub call {
     };
     return Plack::Util::response_cb(
         $self->app->($env), sub {
-            if ($dbh and $dbh->{Active}
-                and not is_server_error($_[0])) {
-                $env->{__app_guard__}->dismiss;
-                $dbh->commit;
+            if ($dbh and $dbh->{Active}) {
+                if (is_server_error($_[0]->[0])) {
+                    $dbh->rollback;
+                }
+                else {
+                    $dbh->commit;
+                }
                 $dbh->disconnect;
-            }
+                $env->{__app_guard__}->dismiss;
+             }
         });
 }
 


### PR DESCRIPTION
The code used to check the status code against the
array return triplet, instead of against the status code
inside that triplet.
