### PR TITLE
Change dependency to YAML::PP from YAML

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -56,6 +56,8 @@ Dependency updates
 * PGObject::Util::DBAdmin 1.6.1 (updated from 1.4.0)
 * PostgreSQL 13 (updated from 10)
 * Workflow 1.59 (upadted from 1.56)
+* YAML::PP (new)
+* YAML (dropped)
 
 
 Changelog for 1.9 Series

--- a/cpanfile
+++ b/cpanfile
@@ -118,7 +118,7 @@ requires 'Workflow::Persister::DBI', '1.59';
 requires 'Workflow::Persister::DBI::ExtraData', '1.59';
 requires 'XML::LibXML';
 requires 'XML::LibXML::XPathContext';
-requires 'YAML';
+requires 'YAML::PP';
 requires 'namespace::autoclean';
 
 recommends 'Math::BigInt::GMP';

--- a/lib/LedgerSMB/Admin.pm
+++ b/lib/LedgerSMB/Admin.pm
@@ -25,7 +25,7 @@ use Log::Any::Adapter::Log4perl;
 use Log::Log4perl qw(:easy);
 use Module::Runtime qw(use_module compose_module_name);
 use Pod::Usage qw(pod2usage);
-use YAML qw(LoadFile);
+use YAML::PP qw(LoadFile);
 
 our $VERSION = '0.0.1';
 


### PR DESCRIPTION
YAML::PP allows loading of boolean values as true boolean values
by leveraging JSON::PP::Boolean for loading 'true'/'false'.

This is a requirement for JSON schema validation down the road.
