### PR TITLE
Restore TABs to work on e.g. the login page

### DIFF
--- a/UI/src/elements/lsmb-base-input.js
+++ b/UI/src/elements/lsmb-base-input.js
@@ -19,7 +19,7 @@ export class LsmbBaseInput extends LsmbDijit {
     }
 
     _valueAttrs() {
-        return ["title", "name", "value"];
+        return ["title", "name", "value", "tabindex"];
     }
 
     _labelRoot() {


### PR DESCRIPTION
The custom web components changes broke the tabindex functionality on the login page due to the fact that the `tabindex` property is now set on an element that's not part of the rendered page (due to the "display: content" CSS property).

This commit fixes that by copying the property to an element that *is* part of the rendered page.