### PR TITLE
Prevent dismissable Toasts from displaying too short

### DIFF
--- a/UI/src/components/Toast.vue
+++ b/UI/src/components/Toast.vue
@@ -10,7 +10,7 @@ const text = props.data.text;
 const duration = text ? 10 : 2;
 
 
-const { send } = createToastMachine(
+const { send, state } = createToastMachine(
     {
         item: props.data
     },
@@ -23,6 +23,9 @@ const { send } = createToastMachine(
 window.setTimeout(() => { send('dismiss') }, duration * 1000);
 if (props.data.dismissReceiver) {
     props.data.dismissReceiver( () => send('dismiss') );
+    window.setTimeout(() => { send('show') }, 250);
+} else {
+    send('show');
 }
 
 </script>
@@ -30,6 +33,7 @@ if (props.data.dismissReceiver) {
 <template>
     <div class="toast dijitContentPane dijitBorderContainer-child edgePanel"
          :class="type"
+         v-show="state !== 'pending'"
          @click="send('dismiss-immediate')"
          @mouseenter="send('hold')"
          @mouseleave="send('release')">

--- a/UI/src/components/Toaster.machines.js
+++ b/UI/src/components/Toaster.machines.js
@@ -43,6 +43,10 @@ const toasterMachine = createMachine(
 
 const toastMachine = createMachine(
     {
+        pending: state(
+            transition("dismiss", "removing"),
+            transition("show", "showing")
+        ),
         showing: state(
             transition("dismiss", "removing"),
             transition("dismiss-immediate", "removing"),


### PR DESCRIPTION
Vue itself uses a 200ms delay for showing the LoaderComponent in the
router when loading takes too long. This implements a similar idea
for the Toasts, using a 250ms delay, because local testing shows that
there is a clear break with data taking either less than 200ms or far
more to load. 250ms then allows for a little latency and assures the
toast shows long enough.
