### PR TITLE
Prevent linting error on vue-router

### DIFF
--- a/UI/src/router.js
+++ b/UI/src/router.js
@@ -1,5 +1,6 @@
 /** @format */
 
+/* eslint-disable-next-line import/no-unresolved */
 import { createRouter, createWebHashHistory } from "vue-router";
 
 import Home from "./components/Home";


### PR DESCRIPTION
Prevent linting errors because of `vue-router` being too new for the linting import validator.
Related to https://github.com/import-js/eslint-plugin-import/issues/2293