### PR TITLE
Build the Beam::Wire configuration argument

### DIFF
--- a/bin/ledgersmb-server.psgi
+++ b/bin/ledgersmb-server.psgi
@@ -49,8 +49,7 @@ do {
         $wire = Beam::Wire->new( file => $config_file);
     }
     else {
-        my $ini = LedgerSMB::Sysconfig->initialize( $config_file );
-        my $cfg = LedgerSMB::Sysconfig::ini2wire( $ini );
+        my $cfg = LedgerSMB::Sysconfig->ini2wire( $config_file );
         $wire = Beam::Wire->new( config => { extra_middleware => [], %$cfg });
     }
 };

--- a/bin/ledgersmb-server.psgi
+++ b/bin/ledgersmb-server.psgi
@@ -49,9 +49,9 @@ do {
         $wire = Beam::Wire->new( file => $config_file);
     }
     else {
-        $wire = Beam::Wire->new( config => { extra_middleware => [] });
-        my $cfg = LedgerSMB::Sysconfig->initialize( $config_file );
-        LedgerSMB::Sysconfig::ini2wire( $wire, $cfg );
+        my $ini = LedgerSMB::Sysconfig->initialize( $config_file );
+        my $cfg = LedgerSMB::Sysconfig::ini2wire( $ini );
+        $wire = Beam::Wire->new( config => { extra_middleware => [], %$cfg });
     }
 };
 
@@ -66,7 +66,7 @@ Log::Log4perl::Layout::PatternLayout::add_global_cspec(
     'Z',
     sub { return $LedgerSMB::Middleware::RequestID::request_id.''; });
 
-my $log_config = $wire->get( 'logging' )->{config};
+my $log_config = $wire->get( 'logging' )->{file};
 if ($log_config) {
     Log::Log4perl->init($log_config);
 }

--- a/cpanfile
+++ b/cpanfile
@@ -4,7 +4,7 @@
 requires 'perl', '5.32.0';
 
 requires 'Archive::Zip';
-requires 'Authen::SASL';
+recommends 'Authen::SASL';
 requires 'Beam::Wire';
 requires 'CGI::Emulate::PSGI';
 requires 'CGI::Parse::PSGI';

--- a/doc/conf/ledgersmb.yaml
+++ b/doc/conf/ledgersmb.yaml
@@ -25,7 +25,7 @@ extra_middleware: []
 
 logging:
   level: ERROR
-  # config: ledgersmb.log.conf
+  # file: ledgersmb.log.conf
 
 login_settings:
   default_db: ledgersmb
@@ -51,7 +51,7 @@ mail:
 miscellaneous:
   $class: Beam::Wire
   config:
-    backup_email_from:
+    backup_email_from: ''
     max_upload_size: 4194304
     proxy_ip: 127.0.0.1/8 ::1/128 ::ffff:127.0.0.1/108
 

--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -199,7 +199,6 @@ use PGObject;
 use Plack;
 use URI::Escape;
 
-use LedgerSMB::Sysconfig;
 use LedgerSMB::App_State;
 use LedgerSMB::Locale;
 use LedgerSMB::User;

--- a/lib/LedgerSMB/Auth.pm
+++ b/lib/LedgerSMB/Auth.pm
@@ -18,8 +18,7 @@ possible though currently every LedgerSMB user must be a database user.
 =head2 factory($env)
 
 This method instantiates an authentication class as of type
-LedgerSMB::Auth::C<LedgerSMB::Sysconfig::auth()>.
-More about plugin classes is described below.
+LedgerSMB::Auth::DB. More about plugin classes is described below.
 
 =head2 plugin classes
 
@@ -52,7 +51,6 @@ login data is available.
 use strict;
 use warnings;
 
-use LedgerSMB::Sysconfig;
 use Module::Runtime qw(use_module);
 
 

--- a/lib/LedgerSMB/Database/Upgrade.pm
+++ b/lib/LedgerSMB/Database/Upgrade.pm
@@ -13,7 +13,6 @@ use strict;
 use warnings;
 
 use LedgerSMB::I18N;
-use LedgerSMB::Sysconfig;
 use LedgerSMB::Upgrade_Tests;
 
 use File::Temp;

--- a/lib/LedgerSMB/EnvVarSetter.pm
+++ b/lib/LedgerSMB/EnvVarSetter.pm
@@ -43,7 +43,7 @@ sub set {
     my %args = @_;
 
     for my $var (keys %args) {
-        $ENV{$var} = $args{$var}; ## no critic (RequireLocalizedPunctuationVars)
+        $ENV{$var} = ($args{$var} =~ s/^\+/$ENV{$var}/r); ## no critic (RequireLocalizedPunctuationVars)
     }
 }
 

--- a/lib/LedgerSMB/Locale.pm
+++ b/lib/LedgerSMB/Locale.pm
@@ -100,7 +100,6 @@ use warnings;
 use base qw( Locale::Maketext Exporter );
 our @EXPORT_OK = qw(marktext);
 
-use LedgerSMB::Sysconfig;
 use Locale::Maketext::Lexicon;
 use Encode;
 

--- a/lib/LedgerSMB/Middleware/SessionStorage.pm
+++ b/lib/LedgerSMB/Middleware/SessionStorage.pm
@@ -35,7 +35,6 @@ use Plack::Util::Accessor
 use Session::Storage::Secure;
 
 use LedgerSMB::PSGI::Util;
-use LedgerSMB::Sysconfig;
 
 =head1 METHODS
 

--- a/lib/LedgerSMB/PSGI.pm
+++ b/lib/LedgerSMB/PSGI.pm
@@ -237,7 +237,7 @@ sub setup_url_space {
         enable match_if path(qr!.+\.(css|js|png|ico|jp(e)?g|gif)$!),
             'ConditionalGET';
 
-        # not using LedgerSMB::Sysconfig::scripts():
+        # not using LedgerSMB::Magic::SCRIPT_OLDSCRIPTS:
         #   it has more than only entry-points
         mount "/$_.pl" => builder {
             my $script = $_;

--- a/lib/LedgerSMB/PSGI/Preloads.pm
+++ b/lib/LedgerSMB/PSGI/Preloads.pm
@@ -45,7 +45,6 @@ use LedgerSMB::PGObject;
 use LedgerSMB::Scripts::login;
 use LedgerSMB::Setting;
 use LedgerSMB::Setting::Sequence;
-use LedgerSMB::Sysconfig;
 use LedgerSMB::Tax;
 use LedgerSMB::Template::UI;
 

--- a/lib/LedgerSMB/Router.pm
+++ b/lib/LedgerSMB/Router.pm
@@ -67,7 +67,6 @@ use YAML::PP;
 
 use LedgerSMB::Company;
 use LedgerSMB::Locale;
-use LedgerSMB::Sysconfig;
 use LedgerSMB::User;
 
 use constant {

--- a/lib/LedgerSMB/Scripts/vouchers.pm
+++ b/lib/LedgerSMB/Scripts/vouchers.pm
@@ -28,7 +28,6 @@ use LedgerSMB::Report::Unapproved::Batch_Detail;
 use LedgerSMB::Scripts::payment;
 use LedgerSMB::Scripts::reports;
 use LedgerSMB::Setting;
-use LedgerSMB::Sysconfig;
 use LedgerSMB::Template::UI;
 
 use LedgerSMB::old_code qw(dispatch);

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -23,8 +23,9 @@ use Config::IniFiles;
 use English;
 use List::Util qw(pairmap);
 
-sub initialize {
-    my ($module, $cfg_file, %args) = @_;
+
+sub ini2wire {
+    my ($module, $cfg_file) = @_;
 
     my $cfg;
     if ($cfg_file and -r $cfg_file) {
@@ -36,13 +37,6 @@ sub initialize {
             if $cfg_file;  # no name provided? no need to warn...
         $cfg = Config::IniFiles->new();
     }
-
-    return $cfg;
-}
-
-
-sub ini2wire {
-    my ($cfg) = @_;
 
     my %wire_config;
 

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -37,13 +37,6 @@ sub initialize {
         $cfg = Config::IniFiles->new();
     }
 
-    # ENV Paths
-    for my $var (qw(PATH PERL5LIB)) {
-        $ENV{$var} .=
-            $Config{path_sep} .
-            ( join $Config{path_sep}, $cfg->val('environment', $var, ''));
-    }
-
     return $cfg;
 }
 
@@ -245,6 +238,18 @@ sub ini2wire {
                 scalar $cfg->val( 'paths', 'custom_workflows', 'custom_workflows'),
                 ],
         },
+    };
+
+    $wire_config{environment_variables} = {
+        class => 'LedgerSMB::EnvVarSetter',
+        lifecycle => 'eager',
+        method => 'set',
+        args => {
+            map { $_ => join($Config{path_sep}, '+',
+                             $cfg->val('environment', $_, '')) }
+            grep { scalar $cfg->val('environment', $_, '') }
+            qw( PATH PERL5LIB )
+        }
     };
 
     return \%wire_config;

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -18,8 +18,6 @@ This module doesn't specify any methods.
 use strict;
 use warnings;
 
-use Authen::SASL;
-use Beam::Wire;
 use Config;
 use Config::IniFiles;
 use English;
@@ -51,60 +49,53 @@ sub initialize {
 
 
 sub ini2wire {
-    my ($wire, $cfg) = @_;
+    my ($cfg) = @_;
+
+    my %wire_config;
 
     my @printer_names = $cfg->Parameters( 'printers' );
     my $fallback_printer =
         scalar $cfg->val( 'main', 'fallback_printer', $printer_names[0] );
 
-    $wire->set(
-        printers => $wire->create_service(
-            printers => (
-                class => 'LedgerSMB::Printers',
-                args  => {
-                    printers => {
-                        map { $_ => scalar $cfg->val( printers => $_ ) }
-                        $cfg->Parameters( 'printers' )
-                    },
-                    fallback => $fallback_printer
-                }
-            ))
-        );
+    $wire_config{printers} = {
+        class => 'LedgerSMB::Printers',
+        args  => {
+            printers => {
+                map { $_ => scalar $cfg->val( printers => $_ ) }
+                $cfg->Parameters( 'printers' )
+            },
+            fallback => $fallback_printer
+        }
+    };
 
     my @formats = (
-        { class => 'LedgerSMB::Template::Plugin::CSV' },
-        { class => 'LedgerSMB::Template::Plugin::TXT' },
-        { class => 'LedgerSMB::Template::Plugin::HTML' },
+        { '$class' => 'LedgerSMB::Template::Plugin::CSV', args => [] },
+        { '$class' => 'LedgerSMB::Template::Plugin::TXT', args => [] },
+        { '$class' => 'LedgerSMB::Template::Plugin::HTML', args => [] },
         );
     my @optionals = (
-        template_latex => { class => 'LedgerSMB::Template::Plugin::LaTeX',
-                            args => { format => 'PDF' } },
-        template_latex => { class => 'LedgerSMB::Template::Plugin::LaTeX',
-                            args => { format => 'PS' } },
-        template_xlsx  => { class => 'LedgerSMB::Template::Plugin::XLSX',
-                            args => { format => 'XLSX' } },
-        template_xls   => { class => 'LedgerSMB::Template::Plugin::XLSX',
-                            args => { format => 'XLS' } },
-        template_ods   => { class => 'LedgerSMB::Template::Plugin::ODS' },
+        template_latex => { '$class' => 'LedgerSMB::Template::Plugin::LaTeX',
+                            format => 'PDF' },
+        template_latex => { '$class' => 'LedgerSMB::Template::Plugin::LaTeX',
+                            format => 'PS' },
+        template_xlsx  => { '$class' => 'LedgerSMB::Template::Plugin::XLSX',
+                            format => 'XLSX' },
+        template_xls   => { '$class' => 'LedgerSMB::Template::Plugin::XLSX',
+                            format => 'XLS' },
+        template_ods   => { '$class' => 'LedgerSMB::Template::Plugin::ODS' },
         );
     pairmap {
         if ($cfg->val( 'template_format', $a, 'enabled' ) ne 'disabled') {
-            if (eval { "require $b->{class}; 1;" }) {
+            if (eval { "require $b->{'$class'}; 1;" }) {
                 push @formats, $b;
             }
         }
     } @optionals;
-    $wire->set(
-        'output_plugins' => $wire->create_service(
-            'output_plugins',
-            class => 'LedgerSMB::Template::Plugins',
-            args => {
-                plugins => [
-                    map { $wire->create_service( '', %$_ ) }
-                    @formats
-                ]
-            }
-        ));
+
+    $wire_config{output_plugins} = {
+        class => 'LedgerSMB::Template::Plugins',
+        args => { plugins => \@formats }
+    };
 
     my $value;
     if (my $value = $cfg->val( 'mail', 'smtphost' )) {
@@ -117,18 +108,19 @@ sub ini2wire {
         }
 
         if ($value = $cfg->val( 'mail', 'smtpuser' )) {
-            my $auth = Authen::SASL->new(
-                mechanism => scalar $cfg->val( 'mail', 'smtpauthmech' ),
-                callback => {
-                    user => $value,
-                    pass => scalar $cfg->val( 'mail', 'smtppass' ),
-                });
             push @options,
                 # the SMTP transport checks that 'sasl_password' be
                 # defined; however, its implementation (Net::SMTP) allows
                 # the 'sasl_username' to be an Authen::SASL instance which
                 # means the password is already embedded in sasl_username.
-                sasl_username => $auth,
+                sasl_username => {
+                    '$class' => 'Authen::SASL',
+                    mechanism => scalar $cfg->val( 'mail', 'smtpauthmech' ),
+                    callback => {
+                        user => $value,
+                        pass => scalar $cfg->val( 'mail', 'smtppass' ),
+                    }
+                },
                 sasl_password => '';
         }
 
@@ -149,133 +141,113 @@ sub ini2wire {
         if ($value = $cfg->val( 'mail', 'smtpsender_hostname' )) {
             push @options, helo => $value;
         }
-        $wire->set(
-            'mail' => {
-                transport =>
-                    $wire->create_service(
-                        transport => (
-                            class => 'LedgerSMB::Mailer::TransportSMTP',
-                            args  => \@options,
-                        ))
-            });
+
+        $wire_config{mail} = {
+            transport => {
+                '$class' => 'LedgerSMB::Mailer::TransportSMTP',
+                @options,
+            }
+        };
     }
     else {
         my @options;
         if ($value = $cfg->val( 'mail', 'sendmail' )) {
             @options = ( path => $value );
         }
-        $wire->set(
-            'mail' => {
-                transport =>
-                    $wire->create_service(
-                        transport => (
-                            class => 'Email::Sender::Transport::Sendmail',
-                            args  => \@options,
-                        ))
-            });
+        $wire_config{mail} = {
+            transport => {
+                '$class' => 'Email::Sender::Transport::Sendmail',
+                @options,
+            }
+        };
     }
 
     if ($value = $cfg->val( 'main', 'log_config' )) {
-        $wire->set( 'logging', { config => $value } );
+        $wire_config{logging} = { file => $value };
     }
     else {
         $value = $cfg->val( 'main', 'log_level', 'ERROR' );
-        $wire->set( 'logging', { level => $value } );
+        $wire_config{logging} = { level => $value };
     }
 
-    $wire->set('miscellaneous', Beam::Wire->new );
-
-    $wire->set(
-        'miscellaneous/max_upload_size',
-        $wire->create_service(
-            'max_post_size',
-            value => scalar $cfg->val( 'main', 'max_post_size', 4194304 ) ) );
-    $wire->set(
-        'miscellaneous/backup_email_from',
-        $wire->create_service(
-            'backup_email_from',
-            value => scalar $cfg->val( 'mail', 'backup_email_from', '' ) ) );
-    $wire->set(
-        'miscellaneous/proxy_ip',
-        $wire->create_service(
-            'proxy_ip',
-            value => scalar $cfg->val(
+    $wire_config{miscellaneous} = {
+        '$class' => 'Beam::Wire',
+        config => {
+            max_upload_size => scalar $cfg->val(
+                'main', 'max_post_size', 4194304 ),
+            backup_email_from => scalar $cfg->val(
+                'mail', 'backup_email_from', '' ),
+            proxy_ip => scalar $cfg->val(
                 'proxy',
                 'proxy_ip',
                 '127.0.0.1/8 ::1/128 ::ffff:127.0.0.1/108'
-            ) ) );
+                ),
+        }
+    };
 
-    $wire->set(
-        'cookie',
-        {
-            name => scalar $cfg->val( 'main', 'cookie_name' ),
-            secret => scalar $cfg->val( 'main', 'cookie_secret' )
-        });
+    $wire_config{cookie} = {
+        name => scalar $cfg->val( 'main', 'cookie_name' ),
+        secret => scalar $cfg->val( 'main', 'cookie_secret' )
+    };
 
-    $wire->set(
-        'default_locale',
-        $wire->create_service(
-            'default_locale' => (
-                class => 'LedgerSMB::LanguageResolver',
-                args => {
-                    directory => './locale/po/'
-                }
-            )));
+    $wire_config{default_locale} = {
+        '$class' => 'LedgerSMB::LanguageResolver',
+        directory => './locale/po/'
+    };
 
-    $wire->set('paths', Beam::Wire->new );
-    $wire->set('paths/locale',
-               scalar $cfg->val( 'paths', 'localepath', './locale/po/' ) );
-    $wire->set('paths/templates',
-               scalar $cfg->val( 'paths', 'templates', './templates/' ) );
-    $wire->set('ui',
-               $wire->create_service(
-                   'ui',
-                   class => 'LedgerSMB::Template::UI',
-                   lifecycle => 'eager',
-                   method => 'new_UI',
-                   args => {
-                       cache => scalar $cfg->val( 'paths', 'templates_cache',
-                                                  'lsmb_templates/' )
-                   }) );
+    $wire_config{paths} = {
+        '$class' => 'Beam::Wire',
+        config => {
+            locale => scalar $cfg->val( 'paths', 'localepath', './locale/po/' ),
+            templates => scalar $cfg->val( 'paths', 'templates', './templates/' ),
+        }
+    };
 
-    $wire->set(
-        'db' => $wire->create_service(
-            'db',
-            class => 'LedgerSMB::Database::Factory',
-            args => {
-                connect_data => {
-                    host => scalar $cfg->val( 'database', 'host', 'localhost'),
-                    port => scalar $cfg->val( 'database', 'port', 5432),
-                    sslmode => scalar $cfg->val( 'database', 'sslmode', 'prefer'),
-                },
-                schema => scalar $cfg->val( 'database', 'db_namespace', 'public' )
-            }));
+    $wire_config{ui} = {
+        class => 'LedgerSMB::Template::UI',
+        lifecycle => 'eager',
+        method => 'new_UI',
+        args => {
+            cache => scalar $cfg->val(
+                'paths', 'templates_cache', 'lsmb_templates/' ),
+        }
+    };
 
-    $wire->set(
-        'login_settings' => {
-            default_db => scalar $cfg->val( 'database', 'default_db' )
-        });
+    $wire_config{db} = {
+        class => 'LedgerSMB::Database::Factory',
+        args => {
+            connect_data => {
+                host => scalar $cfg->val( 'database', 'host', 'localhost'),
+                port => scalar $cfg->val( 'database', 'port', 5432),
+                sslmode => scalar $cfg->val( 'database', 'sslmode', 'prefer'),
+            },
+            schema => scalar $cfg->val( 'database', 'db_namespace', 'public' )
+        }
+    };
 
-    $wire->set(
-        'setup_settings' => {
-            auth_db  => scalar $cfg->val( 'database', 'auth_db', 'postgres' ),
-            admin_db => scalar $cfg->val( 'database', 'admin_db', 'template1' ),
-        });
+    $wire_config{login_settings} = {
+        default_db => scalar $cfg->val( 'database', 'default_db' )
+    };
 
-    $wire->set(
-        'workflows' => $wire->create_service(
-            workflows => (
-                class => 'LedgerSMB::Workflow::Loader',
-                lifecycle => 'eager',
-                method => 'load',
-                args => {
-                    lifecycle => 'eager',
-                    directories => [
-                        scalar $cfg->val( 'paths', 'workflows', 'workflows'),
-                        scalar $cfg->val( 'paths', 'custom_workflows', 'custom_workflows'),
-                        ],
-                },
-            )));
+    $wire_config{setup_settings} = {
+        auth_db  => scalar $cfg->val( 'database', 'auth_db', 'postgres' ),
+        admin_db => scalar $cfg->val( 'database', 'admin_db', 'template1' ),
+    };
+
+    $wire_config{workflows} = {
+        class => 'LedgerSMB::Workflow::Loader',
+        lifecycle => 'eager',
+        method => 'load',
+        args => {
+            lifecycle => 'eager',
+            directories => [
+                scalar $cfg->val( 'paths', 'workflows', 'workflows'),
+                scalar $cfg->val( 'paths', 'custom_workflows', 'custom_workflows'),
+                ],
+        },
+    };
+
+    return \%wire_config;
 }
 
 =head1 LICENSE AND COPYRIGHT

--- a/lib/LedgerSMB/Template/UI.pm
+++ b/lib/LedgerSMB/Template/UI.pm
@@ -18,7 +18,6 @@ use strict;
 use warnings;
 
 use LedgerSMB::Locale;
-use LedgerSMB::Sysconfig;
 use LedgerSMB::Template;
 
 use Carp;

--- a/old/lib/LedgerSMB/oldHandler.pm
+++ b/old/lib/LedgerSMB/oldHandler.pm
@@ -53,7 +53,6 @@ use LedgerSMB::App_State;
 use LedgerSMB::Middleware::SessionStorage;
 use LedgerSMB::Middleware::RequestID;
 use LedgerSMB::PSGI::Util;
-use LedgerSMB::Sysconfig;
 
 use HTML::Escape;
 use Log::Any;

--- a/t/06-blacklist.t
+++ b/t/06-blacklist.t
@@ -1,7 +1,5 @@
 #!/usr/bin/perl
 
-use LedgerSMB::Sysconfig;
-
 use Test2::V0;
 use Test2::Plugin::BailOnFail;
 use Digest::SHA 'sha512_base64'; #already a dependency

--- a/t/12-sysconfig.t
+++ b/t/12-sysconfig.t
@@ -10,10 +10,6 @@ Log::Log4perl->easy_init($OFF);
 use LedgerSMB::Sysconfig;
 use LedgerSMB::Magic qw( SCRIPT_NEWSCRIPTS SCRIPT_OLDSCRIPTS );
 
-LedgerSMB::Sysconfig->initialize( 't/data/ledgersmb.conf' );
-
-like $ENV{PATH}, qr/foo$/, 'appends config path correctly';
-
 for my $script (SCRIPT_OLDSCRIPTS->@*) {
     ok(-f 'old/bin/' . $script, "Whitelisted oldcode script $script exists");
 }

--- a/xt/lib/Pherkin/Extension/LedgerSMB.pm
+++ b/xt/lib/Pherkin/Extension/LedgerSMB.pm
@@ -19,13 +19,16 @@ use LedgerSMB::Database;
 use LedgerSMB::PGDate;
 use LedgerSMB::Entity::Person::Employee;
 use LedgerSMB::Entity::User;
-use Test::BDD::Cucumber::Extension;
+
+use Beam::Wire;
 use List::Util qw(any);
 use Log::Log4perl qw(:easy);
+use Test::BDD::Cucumber::Extension;
 
 use LedgerSMB::Sysconfig;
-my $wire = Beam::Wire->new;
-LedgerSMB::Sysconfig::ini2wire( $wire, LedgerSMB::Sysconfig->initialize );
+
+my $wire = Beam::Wire->new(
+    config => LedgerSMB::Sysconfig::ini2wire( LedgerSMB::Sysconfig->initialize ));
 
 use Moose;
 use namespace::autoclean;

--- a/xt/lib/Pherkin/Extension/LedgerSMB.pm
+++ b/xt/lib/Pherkin/Extension/LedgerSMB.pm
@@ -27,8 +27,7 @@ use Test::BDD::Cucumber::Extension;
 
 use LedgerSMB::Sysconfig;
 
-my $wire = Beam::Wire->new(
-    config => LedgerSMB::Sysconfig::ini2wire( LedgerSMB::Sysconfig->initialize ));
+my $wire = Beam::Wire->new( config => LedgerSMB::Sysconfig->ini2wire );
 
 use Moose;
 use namespace::autoclean;


### PR DESCRIPTION
Instead of configuring a Beam::Wire object, generate the argument
required for the constructor to do that itself. The reason for this
change is that it opens up a possibility to store the result as YAML
to help users migrate.