### PR TITLE
Fix incorrect template delimiters

### DIFF
--- a/templates/demo/PNL.html
+++ b/templates/demo/PNL.html
@@ -13,7 +13,7 @@ releases. No explicit versioning was applied before 2021-01-04.
 <html>
 <head>
   <meta name="generator" content="HTML Tidy for HTML5 for Linux version 5.6.0">
-  <title>[% title %]</title>
+  <title><?lsmb title ?></title>
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
   <style type="text/css">
   table.c1 {border-collapse: collapse}

--- a/templates/demo/balance_sheet.html
+++ b/templates/demo/balance_sheet.html
@@ -13,7 +13,7 @@ releases. No explicit versioning was applied before 2021-01-04.
 <html>
 <head>
   <meta name="generator" content="HTML Tidy for HTML5 for Linux version 5.6.0">
-  <title>[% title %]</title>
+  <title><?lsmb title ?></title>
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
   <style type="text/css">
   table.c1 {border-collapse: collapse}


### PR DESCRIPTION
The delimiters for UI templates are different from the ones for
document templates. When converting these from UI to document
templates, apparently, these were forgotten.
