### PR TITLE
Remove bold face from INPUT tags

### DIFF
--- a/UI/css/ledgersmb-common.css
+++ b/UI/css/ledgersmb-common.css
@@ -334,7 +334,6 @@ input {
     /*  font-family: var(--input-font-family); */
     border: var(--input-border);
     font-size: var(--input-font-size);
-    font-weight: bold;
 }
 
 select {


### PR DESCRIPTION
Nothing in LedgerSMB has bold inputs these days, but it turns
the inputs in our configuration table Vue components into bold
face because they don't use the 'dijitReset' class.

Instead of adding that class, lets just remove the bold face
css instruction in the first place.
