### PR TITLE
Proxy via `nginx` instead of directly to `plackup`

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -498,10 +498,10 @@ if (TARGET !== "readme") {
             port: 9000,
             proxy: {
                 "/*.pl": {
-                    target: "http://localhost:5762"
+                    target: "http://proxy"
                 },
                 "/erp/api": {
-                    target: "http://localhost:5762"
+                    target: "http://proxy"
                 }
             },
             static: {


### PR DESCRIPTION
Proxying via nginx results in a stable proxy setup, whereas
via plackup, the proxy engine gets stuck -- presumably on the
fact that plackup only handles a single connection.
