### PR TITLE
Rename D-I key 'output_plugins' to 'output_formatter'

### DIFF
--- a/bin/ledgersmb-server.psgi
+++ b/bin/ledgersmb-server.psgi
@@ -179,8 +179,8 @@ miscellaneous:
     backup_email_from: ''
     max_upload_size: 4194304
     proxy_ip: 127.0.0.1/8 ::1/128 ::ffff:127.0.0.1/108
-output_plugins:
-  $class: LedgerSMB::Template::Plugins
+output_formatter:
+  $class: LedgerSMB::Template::Formatter
   plugins:
   - $class: LedgerSMB::Template::Plugin::LaTeX
     format: PDF

--- a/doc/conf/ledgersmb.yaml
+++ b/doc/conf/ledgersmb.yaml
@@ -55,8 +55,8 @@ miscellaneous:
     max_upload_size: 4194304
     proxy_ip: 127.0.0.1/8 ::1/128 ::ffff:127.0.0.1/108
 
-output_plugins:
-  $class: LedgerSMB::Template::Plugins
+output_formatter:
+  $class: LedgerSMB::Template::Formatter
   plugins:
     - $class: LedgerSMB::Template::Plugin::LaTeX
       format: PDF

--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -592,7 +592,7 @@ sub report_renderer_doc {
                 filename => $report->output_name($request),
             },
             format_plugin   =>
-               $request->{_wire}->get( 'output_plugins' )->get( uc($request->{format} || 'HTML' ) ),
+               $request->{_wire}->get( 'output_formatter' )->get( uc($request->{format} || 'HTML' ) ),
             );
 
         $template->render($vars, $cvars);

--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -518,7 +518,7 @@ sub print {
                filename => 'printed-checks',
             },
             format_plugin   =>
-                 $request->{_wire}->get( 'output_plugins' )->get( uc $payment->{format} ),
+                 $request->{_wire}->get( 'output_formatter' )->get( uc $payment->{format} ),
             );
         $template->render(
             {
@@ -694,7 +694,7 @@ sub display_payments {
 
     $payment->{format_options} = [
         map { { text => $_, value => lc $_ } }
-        $request->{_wire}->get( 'output_plugins' )->get_formats
+        $request->{_wire}->get( 'output_formatter' )->get_formats
         ];
     $payment->{can_print} = scalar @{$payment->{format_options}};
 
@@ -1468,7 +1468,7 @@ sub print_payment {
       path     => 'DB',
       template => 'printPayment',
       format_plugin   =>
-         $request->{_wire}->get( 'output_plugins' )->get( 'HTML' ),
+         $request->{_wire}->get( 'output_formatter' )->get( 'HTML' ),
     );
     $template->render(
         {

--- a/lib/LedgerSMB/Scripts/report_aging.pm
+++ b/lib/LedgerSMB/Scripts/report_aging.pm
@@ -358,7 +358,7 @@ sub generate_statement {
                      language => $statement->{language},
                      method   => $request->{media},
                      format_plugin   =>
-                         $request->{_wire}->get( 'output_plugins' )->get( $request->{format}),
+                         $request->{_wire}->get( 'output_formatter' )->get( $request->{format}),
                 );
 
         $template->render(

--- a/lib/LedgerSMB/Scripts/taxform.pm
+++ b/lib/LedgerSMB/Scripts/taxform.pm
@@ -189,7 +189,7 @@ sub print {
         path     => 'DB',
         template => $request->{taxform_name},
         format_plugin   =>
-           $request->{_wire}->get( 'output_plugins' )->get( $request->{format}),
+           $request->{_wire}->get( 'output_formatter' )->get( $request->{format}),
     );
     $template->render($request);
 

--- a/lib/LedgerSMB/Scripts/timecard.pm
+++ b/lib/LedgerSMB/Scripts/timecard.pm
@@ -206,7 +206,7 @@ sub print {
         path     => 'DB',
         template => 'timecard',
         format_plugin   =>
-              $request->{_wire}->get( 'output_plugins' )->get( $request->{format} || 'HTML'),
+              $request->{_wire}->get( 'output_formatter' )->get( $request->{format} || 'HTML'),
     );
 
     if (lc($request->{media}) eq 'screen') {

--- a/lib/LedgerSMB/Template/Formatter.pm
+++ b/lib/LedgerSMB/Template/Formatter.pm
@@ -1,8 +1,8 @@
-package LedgerSMB::Template::Plugins;
+package LedgerSMB::Template::Formatter;
 
 =head1 NAME
 
-LedgerSMB::Template::Plugins - Module to manage template output format plugins
+LedgerSMB::Template::Formatter - Module to manage template output format plugins
 
 =head1 DESCRIPTION
 
@@ -11,7 +11,7 @@ This module manages the collection available output formats.
 =head1 SYNOPSIS
 
   output_formats:
-    $class: LedgerSMB::Template::Plugins
+    $class: LedgerSMB::Template::Formatter
     plugins:
       - $class: LedgerSMB::Template::Plugin::LaTeX
         format: "PDF"           # Supports Postscript too, but suppress that

--- a/lib/LedgerSMB/Template/UI.pm
+++ b/lib/LedgerSMB/Template/UI.pm
@@ -129,7 +129,7 @@ sub render_string {
               $request->{_company_config}->{dojo_theme} || 'claro'
           ),
           LIST_FORMATS => sub {
-              return $request->{_wire}->get( 'output_plugins' )->get_formats;
+              return $request->{_wire}->get( 'output_formatter' )->get_formats;
           },
           PRINTERS => [
               ( $request->{_wire}->get( 'printers' )->as_options,

--- a/old/bin/am.pl
+++ b/old/bin/am.pl
@@ -506,7 +506,7 @@ sub edit_recurring {
              map {
                  my $val = lc $_;
                  qq|<option value="$val">$_|
-             } $form->{_wire}->get( 'output_plugins' )->get_formats
+             } $form->{_wire}->get( 'output_formatter' )->get_formats
         );
 
     &schedule;

--- a/old/bin/arapprn.pl
+++ b/old/bin/arapprn.pl
@@ -259,7 +259,7 @@ sub print_transaction {
         locale => $locale,
         output_options => \%output_options,
         format_plugin   =>
-           $form->{_wire}->get( 'output_plugins' )->get( uc($form->{format} || 'HTML') ),
+           $form->{_wire}->get( 'output_formatter' )->get( uc($form->{format} || 'HTML') ),
         );
     $template->render($form);
     LedgerSMB::Legacy_Util::output_template($template, $form);

--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -1410,7 +1410,7 @@ sub print_form {
                 output_options => \%output_options,
                 filename => $form->{formname} . "-" . $form->{"${inv}number"},
                 format_plugin   =>
-                   $form->{_wire}->get( 'output_plugins' )->get( uc($form->{format} ) ),
+                   $form->{_wire}->get( 'output_formatter' )->get( uc($form->{format} ) ),
             );
         $template->render($form);
 
@@ -1524,7 +1524,7 @@ sub print_form {
         output_options => \%output_options,
         filename => $form->{formname} . "-" . $form->{"${inv}number"},
         format_plugin   =>
-            $form->{_wire}->get( 'output_plugins' )->get( uc($form->{format} ) ),
+            $form->{_wire}->get( 'output_formatter' )->get( uc($form->{format} ) ),
         );
     $template->render($form);
     LedgerSMB::Legacy_Util::output_template($template, $form,

--- a/old/bin/printer.pl
+++ b/old/bin/printer.pl
@@ -138,7 +138,7 @@ sub print_options {
         default_values => $form->{selectformat},
         options => [
             map { { text => $_, value => lc $_ } }
-            $form->{_wire}->get( 'output_plugins' )->get_formats ],
+            $form->{_wire}->get( 'output_formatter' )->get_formats ],
     };
     if ($form->{type} && $form->{type} eq 'invoice'){
        push @{$options{format}{options}}, {

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -1173,7 +1173,7 @@ sub generate_selects {
              map {
                  my $val = lc $_;
                  qq|<option value="$val">$_|
-             } $form->{_wire}->get( 'output_plugins' )->get_formats
+             } $form->{_wire}->get( 'output_formatter' )->get_formats
         );
 
     # warehouse

--- a/old/lib/LedgerSMB/Sysconfig.pm
+++ b/old/lib/LedgerSMB/Sysconfig.pm
@@ -79,8 +79,8 @@ sub ini2wire {
         }
     } @optionals;
 
-    $wire_config{output_plugins} = {
-        class => 'LedgerSMB::Template::Plugins',
+    $wire_config{output_formatter} = {
+        class => 'LedgerSMB::Template::Formatter',
         args => { plugins => \@formats }
     };
 

--- a/t/01-load.t
+++ b/t/01-load.t
@@ -49,7 +49,7 @@ my @modules =
     (
      'LedgerSMB::Sysconfig',
      'LedgerSMB::X12', 'LedgerSMB::X12::EDI850', 'LedgerSMB::X12::EDI894',
-     'LedgerSMB::Template::Plugins',
+     'LedgerSMB::Template::Formatter',
      'LedgerSMB::Template::Plugin::XLSX',
      'LedgerSMB::Template::Plugin::ODS',
      'LedgerSMB::Template::Plugin::LaTeX',


### PR DESCRIPTION
The concept of 'output_formatter' is much more user-friendly
than the concept of 'output_plugins' which is why this rename
was agreed on.
